### PR TITLE
allow to send sub-dust amounts in offchain transactions

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -9,3 +9,13 @@ import (
 func P2TRScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
 	return txscript.NewScriptBuilder().AddOp(txscript.OP_1).AddData(schnorr.SerializePubKey(taprootKey)).Script()
 }
+
+func DustReturnScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
+	return txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(schnorr.SerializePubKey(taprootKey)).Script()
+}
+
+func IsDustReturnScript(script []byte) bool {
+	return len(script) == 32+1+1 &&
+		script[0] == txscript.OP_RETURN &&
+		script[1] == 0x20
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -10,11 +10,11 @@ func P2TRScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
 	return txscript.NewScriptBuilder().AddOp(txscript.OP_1).AddData(schnorr.SerializePubKey(taprootKey)).Script()
 }
 
-func DustReturnScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
+func SubDustScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
 	return txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(schnorr.SerializePubKey(taprootKey)).Script()
 }
 
-func IsDustReturnScript(script []byte) bool {
+func IsSubDustScript(script []byte) bool {
 	return len(script) == 32+1+1 &&
 		script[0] == txscript.OP_RETURN &&
 		script[1] == 0x20

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -35,7 +35,7 @@ services:
       - ARK_DATADIR=./data/regtest
       - ARK_WALLET_ADDR=arkd-wallet:6060
       - ARK_ESPLORA_URL=http://chopsticks:3000
-      - ARK_MIN_VTXO_AMOUNT=1
+      - ARK_VTXO_MIN_AMOUNT=1
     volumes:
       - type: tmpfs
         target: /app/data

--- a/docker-compose.regtest.yml
+++ b/docker-compose.regtest.yml
@@ -35,6 +35,7 @@ services:
       - ARK_DATADIR=./data/regtest
       - ARK_WALLET_ADDR=arkd-wallet:6060
       - ARK_ESPLORA_URL=http://chopsticks:3000
+      - ARK_MIN_VTXO_AMOUNT=1
     volumes:
       - type: tmpfs
         target: /app/data

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -56,6 +56,9 @@ type SettleOptions struct {
 	EventsCh chan<- client.RoundEvent
 }
 
+// name alias, sub-dust vtxos are recoverable vtxos
+var WithSubDustVtxos = WithRecoverableVtxos
+
 func WithRecoverableVtxos(o interface{}) error {
 	opts, ok := o.(*SettleOptions)
 	if !ok {
@@ -549,10 +552,6 @@ func (a *covenantlessArkClient) SendOffChain(
 			return "", fmt.Errorf("invalid receiver address '%s': expected server %s, got %s", receiver.To(), hex.EncodeToString(expectedServerPubkey), hex.EncodeToString(rcvServerPubkey))
 		}
 
-		if receiver.Amount() < a.Dust {
-			return "", fmt.Errorf("invalid amount (%d), must be greater than dust %d", receiver.Amount(), a.Dust)
-		}
-
 		sumOfReceivers += receiver.Amount()
 	}
 
@@ -623,7 +622,7 @@ func (a *covenantlessArkClient) SendOffChain(
 		},
 	}
 
-	virtualTx, checkpointsTxs, err := buildOffchainTx(inputs, receivers, checkpointExitScript)
+	virtualTx, checkpointsTxs, err := buildOffchainTx(inputs, receivers, checkpointExitScript, a.Dust)
 	if err != nil {
 		return "", err
 	}
@@ -3456,6 +3455,7 @@ func buildOffchainTx(
 	vtxos []redeemTxInput,
 	receivers []Receiver,
 	serverUnrollScript *tree.CSVMultisigClosure,
+	dustLimit uint64,
 ) (string, []string, error) {
 	if len(vtxos) <= 0 {
 		return "", nil, fmt.Errorf("missing vtxos")
@@ -3523,7 +3523,13 @@ func buildOffchainTx(
 			return "", nil, err
 		}
 
-		newVtxoScript, err := common.P2TRScript(addr.VtxoTapKey)
+		var newVtxoScript []byte
+
+		if receiver.Amount() < dustLimit {
+			newVtxoScript, err = common.DustReturnScript(addr.VtxoTapKey)
+		} else {
+			newVtxoScript, err = common.P2TRScript(addr.VtxoTapKey)
+		}
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -3526,7 +3526,7 @@ func buildOffchainTx(
 		var newVtxoScript []byte
 
 		if receiver.Amount() < dustLimit {
-			newVtxoScript, err = common.DustReturnScript(addr.VtxoTapKey)
+			newVtxoScript, err = common.SubDustScript(addr.VtxoTapKey)
 		} else {
 			newVtxoScript, err = common.P2TRScript(addr.VtxoTapKey)
 		}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -314,6 +314,14 @@ func (c *Config) Validate() error {
 		)
 	}
 
+	if c.VtxoMinAmount == 0 {
+		return fmt.Errorf("vtxo min amount must be greater than 0")
+	}
+
+	if c.UtxoMinAmount == 0 {
+		return fmt.Errorf("utxo min amount must be greater than 0")
+	}
+
 	if err := c.repoManager(); err != nil {
 		return err
 	}

--- a/server/internal/core/application/service.go
+++ b/server/internal/core/application/service.go
@@ -584,7 +584,7 @@ func (s *covenantlessService) SubmitOffchainTx(
 
 		if out.Value < int64(dust) {
 			// if the output is below dust limit, it must be using OP_RETURN-style vtxo pkscript
-			if !common.IsDustReturnScript(out.PkScript) {
+			if !common.IsSubDustScript(out.PkScript) {
 				return nil, "", "", fmt.Errorf("output #%d amount is less than dust limit but is not using OP_RETURN output script", outIndex)
 			}
 		}
@@ -2445,7 +2445,7 @@ func (s *covenantlessService) extractVtxosScripts(vtxos []domain.Vtxo) ([]string
 		var script []byte
 
 		if vtxo.Amount < dustLimit {
-			script, err = common.DustReturnScript(vtxoTapKey)
+			script, err = common.SubDustScript(vtxoTapKey)
 		} else {
 			script, err = common.P2TRScript(vtxoTapKey)
 		}

--- a/server/internal/core/application/service.go
+++ b/server/internal/core/application/service.go
@@ -120,6 +120,9 @@ func NewService(
 	if vtxoMinSettlementAmount < int64(dustAmount) {
 		vtxoMinSettlementAmount = int64(dustAmount)
 	}
+	if vtxoMinOffchainTxAmount == -1 {
+		vtxoMinOffchainTxAmount = int64(dustAmount)
+	}
 	if utxoMinAmount < int64(dustAmount) {
 		utxoMinAmount = int64(dustAmount)
 	}
@@ -576,10 +579,8 @@ func (s *covenantlessService) SubmitOffchainTx(
 				return nil, "", "", fmt.Errorf("output #%d amount is higher than max vtxo amount: %d", outIndex, s.vtxoMaxAmount)
 			}
 		}
-		if s.vtxoMinOffchainTxAmount >= 0 {
-			if out.Value < s.vtxoMinOffchainTxAmount {
-				return nil, "", "", fmt.Errorf("output #%d amount is lower than min vtxo amount: %d", outIndex, s.vtxoMinOffchainTxAmount)
-			}
+		if out.Value < s.vtxoMinOffchainTxAmount {
+			return nil, "", "", fmt.Errorf("output #%d amount is lower than min vtxo amount: %d", outIndex, s.vtxoMinOffchainTxAmount)
 		}
 
 		if out.Value < int64(dust) {
@@ -854,10 +855,8 @@ func (s *covenantlessService) RegisterIntent(ctx context.Context, bip322signatur
 						return "", fmt.Errorf("boarding input amount is higher than max utxo amount:%d", s.utxoMaxAmount)
 					}
 				}
-				if s.utxoMinAmount >= 0 {
-					if tx.TxOut[outpoint.Index].Value < s.utxoMinAmount {
-						return "", fmt.Errorf("boarding input amount is lower than min utxo amount:%d", s.utxoMinAmount)
-					}
+				if tx.TxOut[outpoint.Index].Value < s.utxoMinAmount {
+					return "", fmt.Errorf("boarding input amount is lower than min utxo amount:%d", s.utxoMinAmount)
 				}
 
 				boardingTxs[vtxoKey.Txid] = tx
@@ -985,10 +984,8 @@ func (s *covenantlessService) RegisterIntent(ctx context.Context, bip322signatur
 						return "", fmt.Errorf("receiver amount is higher than max utxo amount: %d", s.utxoMaxAmount)
 					}
 				}
-				if s.utxoMinAmount >= 0 {
-					if amount < uint64(s.utxoMinAmount) {
-						return "", fmt.Errorf("receiver amount is lower than min utxo amount: %d", s.utxoMinAmount)
-					}
+				if amount < uint64(s.utxoMinAmount) {
+					return "", fmt.Errorf("receiver amount is lower than min utxo amount: %d", s.utxoMinAmount)
 				}
 
 				_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.PkScript, s.chainParams())
@@ -1007,10 +1004,8 @@ func (s *covenantlessService) RegisterIntent(ctx context.Context, bip322signatur
 						return "", fmt.Errorf("receiver amount is higher than max vtxo amount: %d", s.vtxoMaxAmount)
 					}
 				}
-				if s.vtxoMinSettlementAmount >= 0 {
-					if amount < uint64(s.vtxoMinSettlementAmount) {
-						return "", fmt.Errorf("receiver amount is lower than min vtxo amount: %d", s.vtxoMinSettlementAmount)
-					}
+				if amount < uint64(s.vtxoMinSettlementAmount) {
+					return "", fmt.Errorf("receiver amount is lower than min vtxo amount: %d", s.vtxoMinSettlementAmount)
 				}
 
 				hasOffChainReceiver = true
@@ -1116,10 +1111,8 @@ func (s *covenantlessService) SpendVtxos(ctx context.Context, inputs []ports.Inp
 						return "", fmt.Errorf("boarding input amount is higher than max utxo amount:%d", s.utxoMaxAmount)
 					}
 				}
-				if s.utxoMinAmount >= 0 {
-					if tx.TxOut[input.VOut].Value < s.utxoMinAmount {
-						return "", fmt.Errorf("boarding input amount is lower than min utxo amount:%d", s.utxoMinAmount)
-					}
+				if tx.TxOut[input.VOut].Value < s.utxoMinAmount {
+					return "", fmt.Errorf("boarding input amount is lower than min utxo amount:%d", s.utxoMinAmount)
 				}
 
 				boardingTxs[input.Txid] = tx

--- a/server/internal/infrastructure/db/service.go
+++ b/server/internal/infrastructure/db/service.go
@@ -317,7 +317,7 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 				continue
 			}
 
-			isDust := common.IsDustReturnScript(out.PkScript)
+			isDust := common.IsSubDustScript(out.PkScript)
 
 			newVtxos = append(newVtxos, domain.Vtxo{
 				VtxoKey: domain.VtxoKey{

--- a/server/internal/infrastructure/db/service.go
+++ b/server/internal/infrastructure/db/service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ark-network/ark/common"
 	"github.com/ark-network/ark/common/tree"
 	"github.com/ark-network/ark/server/internal/core/domain"
 	"github.com/ark-network/ark/server/internal/core/ports"
@@ -316,6 +317,8 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 				continue
 			}
 
+			isDust := common.IsDustReturnScript(out.PkScript)
+
 			newVtxos = append(newVtxos, domain.Vtxo{
 				VtxoKey: domain.VtxoKey{
 					Txid: txid,
@@ -327,6 +330,10 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 				RoundTxid: offchainTx.RootCommitmentTxid(),
 				RedeemTx:  offchainTx.VirtualTx,
 				CreatedAt: offchainTx.EndingTimestamp,
+				// mark the vtxo as "swept" if it is below dust limit to prevent it from being spent again in a future offchain tx
+				// the only way to spend a swept vtxo is by collecting enough dust to cover the minSettlementVtxoAmount and then settle.
+				// because sub-dust vtxos are using OP_RETURN output script, they can't be unilaterally exited.
+				Swept: isDust,
 			})
 		}
 

--- a/server/test/e2e/e2e_test.go
+++ b/server/test/e2e/e2e_test.go
@@ -819,7 +819,7 @@ func TestChainOffchainTransactions(t *testing.T) {
 	require.NotZero(t, balance.Offchain.Total)
 }
 
-func TestSubdustVtxoTransaction(t *testing.T) {
+func TestSubDustVtxoTransaction(t *testing.T) {
 	ctx := context.Background()
 	bob, grpcBob := setupArkSDK(t)
 	defer bob.Stop()
@@ -870,7 +870,7 @@ func TestSubdustVtxoTransaction(t *testing.T) {
 	require.Error(t, err)
 
 	// bob should fail to settle the subdust
-	_, err = bob.Settle(ctx)
+	_, err = bob.Settle(ctx, arksdk.WithSubDustVtxos)
 	require.Error(t, err)
 
 	// resend some funds to bob so he can settle

--- a/server/test/e2e/e2e_test.go
+++ b/server/test/e2e/e2e_test.go
@@ -722,9 +722,6 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 			finalCheckpoints = append(finalCheckpoints, finalCheckpoint)
 		}
 
-		err = grpcTransportClient.FinalizeOffchainTx(ctx, bobTxid, finalCheckpoints)
-		require.NoError(t, err)
-
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -732,6 +729,9 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, vtxos)
 		}()
+
+		err = grpcTransportClient.FinalizeOffchainTx(ctx, bobTxid, finalCheckpoints)
+		require.NoError(t, err)
 
 		wg.Wait()
 
@@ -779,7 +779,7 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 	})
 }
 
-func TestChainOutOfRoundTransactions(t *testing.T) {
+func TestChainOffchainTransactions(t *testing.T) {
 	var receive utils.ArkReceive
 	receiveStr, err := runArkCommand("receive")
 	require.NoError(t, err)
@@ -817,6 +817,69 @@ func TestChainOutOfRoundTransactions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal([]byte(balanceStr), &balance))
 	require.NotZero(t, balance.Offchain.Total)
+}
+
+func TestSubdustVtxoTransaction(t *testing.T) {
+	ctx := context.Background()
+	bob, grpcBob := setupArkSDK(t)
+	defer bob.Stop()
+	defer grpcBob.Close()
+
+	var receive utils.ArkReceive
+	receiveStr, err := runArkCommand("receive")
+	require.NoError(t, err)
+
+	err = json.Unmarshal([]byte(receiveStr), &receive)
+	require.NoError(t, err)
+
+	_, err = utils.RunCommand("nigiri", "faucet", receive.Boarding)
+	require.NoError(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	_, err = runArkCommand("settle", "--password", utils.Password)
+	require.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
+
+	_, bobAddr, _, err := bob.Receive(ctx)
+	require.NoError(t, err)
+
+	subdustAmount := uint64(1)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		vtxos, err := bob.NotifyIncomingFunds(ctx, bobAddr)
+		require.NoError(t, err)
+		require.NotNil(t, vtxos)
+		require.Len(t, vtxos, 1)
+		require.Equal(t, vtxos[0].Amount, subdustAmount)
+	}()
+
+	// send 1 satoshi
+	_, err = runArkCommand("send", "--amount", fmt.Sprintf("%d", subdustAmount), "--to", bobAddr, "--password", utils.Password)
+	require.NoError(t, err)
+
+	// wait for bob to receive the vtxo
+	wg.Wait()
+
+	// bob should fail to send the satoshi via offchain tx
+	_, err = bob.SendOffChain(ctx, false, []arksdk.Receiver{arksdk.NewBitcoinReceiver(bobAddr, subdustAmount)}, false)
+	require.Error(t, err)
+
+	// bob should fail to settle the subdust
+	_, err = bob.Settle(ctx)
+	require.Error(t, err)
+
+	// resend some funds to bob so he can settle
+	_, err = runArkCommand("send", "--amount", "1000", "--to", bobAddr, "--password", utils.Password)
+	require.NoError(t, err)
+
+	// now that bob has enough funds (greater than dust), he should be able to settle
+	_, err = bob.Settle(ctx, arksdk.WithSubDustVtxos)
+	require.NoError(t, err)
 }
 
 // TestCollisionBetweenInRoundAndRedeemVtxo tests for a potential collision between VTXOs that could occur


### PR DESCRIPTION
This PR is handling sub-dust vtxo so that the server can treat them as expired VTXOs.

Sub-dust output are OP_RETURN output. These output types can be added to any offchain transactions. 

**sub-dust offchain tx output pkscript**
```
// unspendable "burn" output
OP_RETURN <x_only_tapkey>
```

Because they are OP_RETURN, they can't be spent again in another offchain tx. However, they can be registered in a settlement via BIP322 intent. To make the intent signature "standard" the `OP_RETURN` is replaced by `OP_1` : 

**sub-dust intent input pkscript**
```
// taproot output script
OP_1 <x_only_tapkey>
```

Thus, signing a subdust vtxo = signing a non-dust vtxo. 
The sub-dust VTXOs can't be exited unilaterally, so they do not require forfeit transactions.

it closes #479 

@altafan @Kukks please review
