### PR TITLE
Verify exit closures & Verify CSV in RegisterIntent

### DIFF
--- a/common/tree/psbt.go
+++ b/common/tree/psbt.go
@@ -106,7 +106,7 @@ func AddVtxoTreeExpiry(inIndex int, ptx *psbt.Packet, vtxoTreeExpiry common.Rela
 func GetVtxoTreeExpiry(in psbt.PInput) (*common.RelativeLocktime, error) {
 	for _, u := range in.Unknowns {
 		if bytes.Contains(u.Key, VTXO_TREE_EXPIRY_PSBT_KEY) {
-			return common.BIP68DecodeSequence(u.Value)
+			return common.BIP68DecodeSequenceFromBytes(u.Value)
 		}
 	}
 

--- a/common/tree/script.go
+++ b/common/tree/script.go
@@ -411,7 +411,7 @@ func (d *CSVMultisigClosure) Decode(script []byte) (bool, error) {
 
 	}
 
-	locktime, err := common.BIP68DecodeSequence(sequence)
+	locktime, err := common.BIP68DecodeSequenceFromBytes(sequence)
 	if err != nil {
 		return false, err
 	}

--- a/common/vtxo.go
+++ b/common/vtxo.go
@@ -24,7 +24,7 @@ type TaprootTree interface {
 //
 // TODO: gather common and tree package to prevent circular dependency and move C generic
 type VtxoScript[T TaprootTree, C interface{}] interface {
-	Validate(server *secp256k1.PublicKey, minLocktime RelativeLocktime) error
+	Validate(server *secp256k1.PublicKey, minLocktime RelativeLocktime, blockTypeAllowed bool) error
 	TapTree() (taprootKey *secp256k1.PublicKey, taprootScriptTree T, err error)
 	Encode() ([]string, error)
 	Decode(scripts []string) error

--- a/server/envs/dev.env
+++ b/server/envs/dev.env
@@ -7,3 +7,4 @@ ARK_DATADIR=./data/regtest
 ARK_WALLET_ADDR=localhost:6060
 ARK_DB_URL=postgresql://root:secret@127.0.0.1:5432/projection?sslmode=disable
 ARK_EVENT_DB_URL=postgresql://root:secret@127.0.0.1:5432/event?sslmode=disable
+ARK_ALLOW_CSV_BLOCK_TYPE=true

--- a/server/internal/core/application/utils.go
+++ b/server/internal/core/application/utils.go
@@ -595,6 +595,7 @@ func newBoardingInput(
 	input ports.Input,
 	serverPubKey *secp256k1.PublicKey,
 	boardingExitDelay common.RelativeLocktime,
+	blockTypeCSVAllowed bool,
 ) (*ports.BoardingInput, error) {
 	if len(tx.TxOut) <= int(input.VOut) {
 		return nil, fmt.Errorf("output not found")
@@ -624,7 +625,7 @@ func newBoardingInput(
 		)
 	}
 
-	if err := boardingScript.Validate(serverPubKey, boardingExitDelay); err != nil {
+	if err := boardingScript.Validate(serverPubKey, boardingExitDelay, blockTypeCSVAllowed); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This adds verification of the exit closures when spending a VTXO and also adds loigc to RegisterIntent to validate the CSV delay of the exit path used  to prove ownership of the funds.

Please @louisinger @Kukks review.