### PR TITLE
Move to vtxo output script & Change address encoding

### DIFF
--- a/common/encoding.go
+++ b/common/encoding.go
@@ -11,8 +11,8 @@ import (
 // Address represents an Ark address with HRP, server public key, and VTXO Taproot public key
 type Address struct {
 	HRP        string
+	VtxoScript []byte
 	Server     *secp256k1.PublicKey
-	VtxoTapKey *secp256k1.PublicKey
 }
 
 // Encode converts the address to its bech32m string representation
@@ -20,13 +20,15 @@ func (a *Address) Encode() (string, error) {
 	if a.Server == nil {
 		return "", fmt.Errorf("missing server public key")
 	}
-	if a.VtxoTapKey == nil {
-		return "", fmt.Errorf("missing vtxo tap public key")
+	if len(a.VtxoScript) <= 0 {
+		return "", fmt.Errorf("missing vtxo script")
 	}
 
-	combinedKey := append(
-		schnorr.SerializePubKey(a.Server), schnorr.SerializePubKey(a.VtxoTapKey)...,
-	)
+	if !IsP2TRScript(a.VtxoScript) {
+		return "", fmt.Errorf("invalid vtxo script, must be P2TR")
+	}
+
+	combinedKey := append(a.VtxoScript, schnorr.SerializePubKey(a.Server)...)
 	grp, err := bech32.ConvertBits(combinedKey, 8, 5, true)
 	if err != nil {
 		return "", err
@@ -37,7 +39,7 @@ func (a *Address) Encode() (string, error) {
 // DecodeAddress parses a bech32m encoded address string and returns an Address object
 func DecodeAddress(addr string) (*Address, error) {
 	if len(addr) == 0 {
-		return nil, fmt.Errorf("address is empty")
+		return nil, fmt.Errorf("missing address")
 	}
 
 	prefix, buf, err := bech32.DecodeNoLimit(addr)
@@ -45,26 +47,25 @@ func DecodeAddress(addr string) (*Address, error) {
 		return nil, err
 	}
 	if prefix != Bitcoin.Addr && prefix != BitcoinTestNet.Addr && prefix != BitcoinRegTest.Addr {
-		return nil, fmt.Errorf("invalid prefix")
+		return nil, fmt.Errorf("unknown prefix")
 	}
 	grp, err := bech32.ConvertBits(buf, 5, 8, false)
 	if err != nil {
 		return nil, err
 	}
 
-	serverKey, err := schnorr.ParsePubKey(grp[:32])
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %s", err)
+	vtxoScript := grp[:34]
+	if !IsP2TRScript(vtxoScript) {
+		return nil, fmt.Errorf("failed to parse vtxo script, must be P2TR")
 	}
-
-	vtxoKey, err := schnorr.ParsePubKey(grp[32:])
+	serverKey, err := schnorr.ParsePubKey(grp[34:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse server public key: %s", err)
 	}
 
 	return &Address{
 		HRP:        prefix,
+		VtxoScript: vtxoScript,
 		Server:     serverKey,
-		VtxoTapKey: vtxoKey,
 	}, nil
 }

--- a/common/encoding_test.go
+++ b/common/encoding_test.go
@@ -25,9 +25,9 @@ func TestAddressEncoding(t *testing.T) {
 	fixtures := struct {
 		Address struct {
 			Valid []struct {
-				Addr              string `json:"addr"`
-				ExpectedUserKey   string `json:"expectedUserKey"`
-				ExpectedServerKey string `json:"expectedServerKey"`
+				Addr               string `json:"addr"`
+				ExpectedVtxoScript string `json:"expectedVtxoScript"`
+				ExpectedServerKey  string `json:"expectedServerKey"`
 			} `json:"valid"`
 			Invalid []struct {
 				Addr          string `json:"addr"`
@@ -44,10 +44,10 @@ func TestAddressEncoding(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, addr.HRP)
 			require.NotNil(t, addr.Server)
-			require.NotNil(t, addr.VtxoTapKey)
+			require.NotNil(t, addr.VtxoScript)
 
 			require.NoError(t, err)
-			require.Equal(t, f.ExpectedUserKey, hex.EncodeToString(addr.VtxoTapKey.SerializeCompressed()))
+			require.Equal(t, f.ExpectedVtxoScript, hex.EncodeToString(addr.VtxoScript))
 
 			require.NoError(t, err)
 			require.Equal(t, f.ExpectedServerKey, hex.EncodeToString(addr.Server.SerializeCompressed()))
@@ -60,9 +60,12 @@ func TestAddressEncoding(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		for _, f := range fixtures.Address.Invalid {
-			addr, err := common.DecodeAddress(f.Addr)
-			require.EqualError(t, err, f.ExpectedError)
-			require.Nil(t, addr)
+			t.Run(f.ExpectedError, func(t *testing.T) {
+				addr, err := common.DecodeAddress(f.Addr)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), f.ExpectedError)
+				require.Nil(t, addr)
+			})
 		}
 	})
 }

--- a/common/fixtures/encoding.json
+++ b/common/fixtures/encoding.json
@@ -2,15 +2,23 @@
   "address": {
     "valid": [
       {
-        "addr": "tark1x0lm8hhr2wc6n6lyemtyh9rz8rg2ftpkfun46aca56kjg3ws0tsztfpuanaquxc6faedvjk3tax0575y6perapg3e95654pk8r4fjecs5fyd2",
-        "expectedUserKey": "0225a43cecfa0e1b1a4f72d64ad15f4cfa7a84d0723e8511c969aa543638ea9967",
+        "addr": "tark12ysztfpuanaquxc6faedvjk3tax0575y6perapg3e95654pk8r4fjeenl7eaac6nkx57hexw6e9egc3c6zj2cdj0yawhw8dx45jyt5r6uqxg7ess",
+        "expectedVtxoScript": "512025a43cecfa0e1b1a4f72d64ad15f4cfa7a84d0723e8511c969aa543638ea9967",
         "expectedServerKey": "0233ffb3dee353b1a9ebe4ced64b946238d0a4ac364f275d771da6ad2445d07ae0"
       }
     ],
     "invalid": [
       {
         "addr": "wrongprefix1qt9tfh7c09hlsstzq5y9tzuwyaesrwr8gpy8cn29cxv0flp64958s0n0yd0",
-        "expectedError": "invalid prefix"
+        "expectedError": "unknown prefix"
+      },
+      {
+        "addr": "tark1x0lm8hhr2wc6n6lyemtyh9rz8rg2ftpkfun46aca56kjg3ws0tsztfpuanaquxc6faedvjk3tax0575y6perapg3e95654pk8r4fjecs5fyd2",
+        "expectedError": "failed to parse vtxo script, must be P2TR"
+      },
+      {
+        "addr": "tark12ysztfpuanaquxc6faedvjk3tax0575y6perapg3e95654pk8r4fjeczx0lm8hhr2wc6n6lyemtyh9rz8rg2ftpkfun46aca56kjg3ws0tsqu50gr8",
+        "expectedError": "failed to parse server public key"
       }
     ]
   }

--- a/common/utils.go
+++ b/common/utils.go
@@ -7,15 +7,19 @@ import (
 )
 
 func P2TRScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
-	return txscript.NewScriptBuilder().AddOp(txscript.OP_1).AddData(schnorr.SerializePubKey(taprootKey)).Script()
+	key := schnorr.SerializePubKey(taprootKey)
+	return txscript.NewScriptBuilder().AddOp(txscript.OP_1).AddData(key).Script()
+}
+
+func IsP2TRScript(script []byte) bool {
+	return len(script) == 32+1+1 && script[0] == txscript.OP_1 && script[1] == 0x20
 }
 
 func SubDustScript(taprootKey *secp256k1.PublicKey) ([]byte, error) {
-	return txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(schnorr.SerializePubKey(taprootKey)).Script()
+	key := schnorr.SerializePubKey(taprootKey)
+	return txscript.NewScriptBuilder().AddOp(txscript.OP_RETURN).AddData(key).Script()
 }
 
 func IsSubDustScript(script []byte) bool {
-	return len(script) == 32+1+1 &&
-		script[0] == txscript.OP_RETURN &&
-		script[1] == 0x20
+	return len(script) == 32+1+1 && script[0] == txscript.OP_RETURN && script[1] == 0x20
 }

--- a/pkg/client-sdk/base_client.go
+++ b/pkg/client-sdk/base_client.go
@@ -18,7 +18,6 @@ import (
 	walletstore "github.com/ark-network/ark/pkg/client-sdk/wallet/singlekey/store"
 	filestore "github.com/ark-network/ark/pkg/client-sdk/wallet/singlekey/store/file"
 	inmemorystore "github.com/ark-network/ark/pkg/client-sdk/wallet/singlekey/store/inmemory"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
@@ -203,10 +202,12 @@ func (a *arkClient) NotifyIncomingFunds(
 	if err != nil {
 		return nil, err
 	}
-
-	scripts := []string{
-		hex.EncodeToString(schnorr.SerializePubKey(decoded.VtxoTapKey)),
+	script, err := common.P2TRScript(decoded.VtxoTapKey)
+	if err != nil {
+		return nil, err
 	}
+
+	scripts := []string{hex.EncodeToString(script)}
 	subId, err := a.indexer.SubscribeForScripts(ctx, "", scripts)
 	if err != nil {
 		return nil, err

--- a/pkg/client-sdk/base_client.go
+++ b/pkg/client-sdk/base_client.go
@@ -202,12 +202,8 @@ func (a *arkClient) NotifyIncomingFunds(
 	if err != nil {
 		return nil, err
 	}
-	script, err := common.P2TRScript(decoded.VtxoTapKey)
-	if err != nil {
-		return nil, err
-	}
 
-	scripts := []string{hex.EncodeToString(script)}
+	scripts := []string{hex.EncodeToString(decoded.VtxoScript)}
 	subId, err := a.indexer.SubscribeForScripts(ctx, "", scripts)
 	if err != nil {
 		return nil, err

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -1098,8 +1098,7 @@ func (a *covenantlessArkClient) listenForArkTxs(ctx context.Context) {
 				// nolint
 				decoded, _ := common.DecodeAddress(addr.Address)
 				// nolint
-				script, _ := common.P2TRScript(decoded.VtxoTapKey)
-				myScripts[hex.EncodeToString(script)] = struct{}{}
+				myScripts[hex.EncodeToString(decoded.VtxoScript)] = struct{}{}
 			}
 
 			if event.CommitmentTx != nil {
@@ -2551,8 +2550,6 @@ func (a *covenantlessArkClient) validateOffchainReceiver(
 		return err
 	}
 
-	vtxoTapKey := schnorr.SerializePubKey(rcvAddr.VtxoTapKey)
-
 	leaves := vtxoGraph.Leaves()
 	for _, leaf := range leaves {
 		for _, output := range leaf.UnsignedTx.TxOut {
@@ -2560,7 +2557,7 @@ func (a *covenantlessArkClient) validateOffchainReceiver(
 				continue
 			}
 
-			if bytes.Equal(output.PkScript[2:], vtxoTapKey) {
+			if bytes.Equal(output.PkScript, rcvAddr.VtxoScript) {
 				if output.Value != int64(receiver.Amount) {
 					continue
 				}

--- a/pkg/client-sdk/client.go
+++ b/pkg/client-sdk/client.go
@@ -1093,23 +1093,24 @@ func (a *covenantlessArkClient) listenForArkTxs(ctx context.Context) {
 				continue
 			}
 
-			myPubkeys := make(map[string]struct{})
+			myScripts := make(map[string]struct{})
 			for _, addr := range offchainAddrs {
-				// nolint:all
+				// nolint
 				decoded, _ := common.DecodeAddress(addr.Address)
-				pubkey := hex.EncodeToString(decoded.VtxoTapKey.SerializeCompressed()[1:])
-				myPubkeys[pubkey] = struct{}{}
+				// nolint
+				script, _ := common.P2TRScript(decoded.VtxoTapKey)
+				myScripts[hex.EncodeToString(script)] = struct{}{}
 			}
 
 			if event.CommitmentTx != nil {
-				if err := a.handleCommitmentTx(ctxBg, myPubkeys, event.CommitmentTx); err != nil {
+				if err := a.handleCommitmentTx(ctxBg, myScripts, event.CommitmentTx); err != nil {
 					log.WithError(err).Error("failed to process commitment tx")
 					continue
 				}
 			}
 
 			if event.ArkTx != nil {
-				if err := a.handleArkTx(ctxBg, myPubkeys, event.ArkTx); err != nil {
+				if err := a.handleArkTx(ctxBg, myScripts, event.ArkTx); err != nil {
 					log.WithError(err).Error("failed to process ark tx")
 					continue
 				}

--- a/pkg/client-sdk/types/types.go
+++ b/pkg/client-sdk/types/types.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/ark-network/ark/common"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -73,21 +72,15 @@ func (v Vtxo) IsRecoverable() bool {
 }
 
 func (v Vtxo) Address(server *secp256k1.PublicKey, net common.Network) (string, error) {
-	buf, err := hex.DecodeString(v.Script)
-	if err != nil {
-		return "", err
-	}
-	pubkeyBytes := buf[2:]
-
-	pubkey, err := schnorr.ParsePubKey(pubkeyBytes)
+	vtxoScript, err := hex.DecodeString(v.Script)
 	if err != nil {
 		return "", err
 	}
 
 	a := &common.Address{
 		HRP:        net.Addr,
+		VtxoScript: vtxoScript,
 		Server:     server,
-		VtxoTapKey: pubkey,
 	}
 
 	return a.Encode()
@@ -214,14 +207,7 @@ func (o Receiver) ToTxOut() (*wire.TxOut, bool, error) {
 
 		isOnchain = true
 	} else {
-		pkScript, err = common.P2TRScript(arkAddress.VtxoTapKey)
-		if err != nil {
-			return nil, false, err
-		}
-	}
-
-	if len(pkScript) == 0 {
-		return nil, false, fmt.Errorf("invalid address")
+		pkScript = arkAddress.VtxoScript
 	}
 
 	return &wire.TxOut{

--- a/pkg/client-sdk/types/types.go
+++ b/pkg/client-sdk/types/types.go
@@ -73,10 +73,11 @@ func (v Vtxo) IsRecoverable() bool {
 }
 
 func (v Vtxo) Address(server *secp256k1.PublicKey, net common.Network) (string, error) {
-	pubkeyBytes, err := hex.DecodeString(v.Script)
+	buf, err := hex.DecodeString(v.Script)
 	if err != nil {
 		return "", err
 	}
+	pubkeyBytes := buf[2:]
 
 	pubkey, err := schnorr.ParsePubKey(pubkeyBytes)
 	if err != nil {

--- a/pkg/client-sdk/utils.go
+++ b/pkg/client-sdk/utils.go
@@ -283,15 +283,16 @@ func buildOffchainTx(
 			return "", nil, err
 		}
 
-		var newVtxoScript []byte
-
+		newVtxoScript := addr.VtxoScript
 		if receiver.Amount < dustLimit {
-			newVtxoScript, err = common.SubDustScript(addr.VtxoTapKey)
-		} else {
-			newVtxoScript, err = common.P2TRScript(addr.VtxoTapKey)
-		}
-		if err != nil {
-			return "", nil, err
+			vtxoTapKey, err := schnorr.ParsePubKey(addr.VtxoScript[2:])
+			if err != nil {
+				return "", nil, err
+			}
+			newVtxoScript, err = common.SubDustScript(vtxoTapKey)
+			if err != nil {
+				return "", nil, err
+			}
 		}
 
 		outs = append(outs, &wire.TxOut{

--- a/pkg/client-sdk/wallet/singlekey/bitcoin_wallet.go
+++ b/pkg/client-sdk/wallet/singlekey/bitcoin_wallet.go
@@ -62,10 +62,13 @@ func (w *bitcoinWallet) GetAddresses(
 	}
 
 	netParams := utils.ToBitcoinNetwork(data.Network)
+	vtxoTapKey, err := schnorr.ParsePubKey(offchainAddr.Address.VtxoScript[2:])
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 
 	redemptionAddr, err := btcutil.NewAddressTaproot(
-		schnorr.SerializePubKey(offchainAddr.Address.VtxoTapKey),
-		&netParams,
+		schnorr.SerializePubKey(vtxoTapKey), &netParams,
 	)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -501,11 +504,15 @@ func (w *bitcoinWallet) getArkAddresses(
 	if err != nil {
 		return nil, nil, err
 	}
+	vtxoScript, err := common.P2TRScript(vtxoTapKey)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	offchainAddress := &common.Address{
 		HRP:        data.Network.Addr,
 		Server:     data.ServerPubKey,
-		VtxoTapKey: vtxoTapKey,
+		VtxoScript: vtxoScript,
 	}
 
 	boardingVtxoScript := tree.NewDefaultVtxoScript(

--- a/server/internal/core/application/service.go
+++ b/server/internal/core/application/service.go
@@ -1243,7 +1243,7 @@ func (s *covenantlessService) ListVtxos(ctx context.Context, address string) ([]
 		return nil, nil, fmt.Errorf("address does not match server pubkey")
 	}
 
-	pubkey := hex.EncodeToString(schnorr.SerializePubKey(decodedAddress.VtxoTapKey))
+	pubkey := hex.EncodeToString(decodedAddress.VtxoScript[2:])
 
 	return s.repoManager.Vtxos().GetAllNonRedeemedVtxos(ctx, pubkey)
 }
@@ -1359,11 +1359,15 @@ func (s *covenantlessService) GetTxRequestQueue(
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse pubkey: %s", err)
 			}
+			vtxoScript, err := common.P2TRScript(vtxoTapKey)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get vtxo script: %s", err)
+			}
 
 			address := common.Address{
 				HRP:        s.network.Addr,
 				Server:     s.pubkey,
-				VtxoTapKey: vtxoTapKey,
+				VtxoScript: vtxoScript,
 			}
 
 			addressStr, err := address.Encode()

--- a/server/internal/interface/grpc/handlers/indexer.go
+++ b/server/internal/interface/grpc/handlers/indexer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	arkv1 "github.com/ark-network/ark/api-spec/protobuf/gen/ark/v1"
+	"github.com/ark-network/ark/common"
 	"github.com/ark-network/ark/server/internal/core/application"
 	"github.com/ark-network/ark/server/internal/core/domain"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -648,6 +649,17 @@ func parseArkAddresses(addresses []string) ([]string, error) {
 		pubkeys = append(pubkeys, pubkey)
 	}
 	return pubkeys, nil
+}
+
+func parseArkAddress(addr string) (string, error) {
+	if len(addr) <= 0 {
+		return "", fmt.Errorf("missing address")
+	}
+	decoded, err := common.DecodeAddress(addr)
+	if err != nil {
+		return "", fmt.Errorf("invalid address: %s", err)
+	}
+	return hex.EncodeToString(decoded.VtxoScript[2:]), nil
 }
 
 func parseScripts(scripts []string) ([]string, error) {

--- a/server/internal/interface/grpc/handlers/indexer.go
+++ b/server/internal/interface/grpc/handlers/indexer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ark-network/ark/server/internal/core/application"
 	"github.com/ark-network/ark/server/internal/core/domain"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -253,9 +254,9 @@ func (e *indexerService) GetVtxos(ctx context.Context, request *arkv1.GetVtxosRe
 		return nil, status.Errorf(codes.Internal, "failed to get vtxos: %v", err)
 	}
 
-	vtxos := make([]*arkv1.IndexerVtxo, len(resp.Vtxos))
-	for i, vtxo := range resp.Vtxos {
-		vtxos[i] = newIndexerVtxo(vtxo)
+	vtxos := make([]*arkv1.IndexerVtxo, 0, len(resp.Vtxos))
+	for _, vtxo := range resp.Vtxos {
+		vtxos = append(vtxos, newIndexerVtxo(vtxo))
 	}
 
 	return &arkv1.GetVtxosResponse{
@@ -502,10 +503,12 @@ func (h *indexerService) listenToTxEvents() {
 		allSpentVtxos := make(map[string][]*arkv1.IndexerVtxo)
 
 		for _, vtxo := range event.SpendableVtxos {
-			allSpendableVtxos[vtxo.PubKey] = append(allSpendableVtxos[vtxo.PubKey], newIndexerVtxo(vtxo))
+			vtxoScript := toP2TR(vtxo.PubKey)
+			allSpendableVtxos[vtxoScript] = append(allSpendableVtxos[vtxoScript], newIndexerVtxo(vtxo))
 		}
 		for _, vtxo := range event.SpentVtxos {
-			allSpentVtxos[vtxo.PubKey] = append(allSpentVtxos[vtxo.PubKey], newIndexerVtxo(vtxo))
+			vtxoScript := toP2TR(vtxo.PubKey)
+			allSpentVtxos[vtxoScript] = append(allSpentVtxos[vtxoScript], newIndexerVtxo(vtxo))
 		}
 
 		for _, l := range h.scriptSubsHandler.listeners {
@@ -653,28 +656,28 @@ func parseScripts(scripts []string) ([]string, error) {
 	}
 
 	for _, script := range scripts {
-		if _, err := parsePubkey(script); err != nil {
+		if _, err := parseScript(script); err != nil {
 			return nil, err
 		}
 	}
 	return scripts, nil
 }
 
-func parsePubkey(pubkey string) (string, error) {
-	if len(pubkey) <= 0 {
-		return "", fmt.Errorf("missing pubkey")
+func parseScript(script string) (string, error) {
+	if len(script) <= 0 {
+		return "", fmt.Errorf("missing script")
 	}
-	buf, err := hex.DecodeString(pubkey)
+	buf, err := hex.DecodeString(script)
 	if err != nil {
-		return "", fmt.Errorf("invalid pubkey format: %s", err)
+		return "", fmt.Errorf("invalid script format, must be hex")
 	}
-	if len(buf) != 32 {
-		return "", fmt.Errorf("invalid pubkey length: got %d, expeted 32", len(buf))
+	if !txscript.IsPayToTaproot(buf) {
+		return "", fmt.Errorf("invalid script, must be P2TR")
 	}
-	if _, err := schnorr.ParsePubKey(buf); err != nil {
-		return "", fmt.Errorf("invalid schnorr pubkey: %s", err)
+	if _, err := schnorr.ParsePubKey(buf[2:]); err != nil {
+		return "", fmt.Errorf("invalid script, failed to extract tapkey: %s", err)
 	}
-	return pubkey, nil
+	return script, nil
 }
 
 func newIndexerVtxo(vtxo domain.Vtxo) *arkv1.IndexerVtxo {
@@ -686,7 +689,7 @@ func newIndexerVtxo(vtxo domain.Vtxo) *arkv1.IndexerVtxo {
 		CreatedAt:      vtxo.CreatedAt,
 		ExpiresAt:      vtxo.ExpireAt,
 		Amount:         vtxo.Amount,
-		Script:         vtxo.PubKey,
+		Script:         toP2TR(vtxo.PubKey),
 		IsPreconfirmed: vtxo.RedeemTx != "",
 		IsSwept:        vtxo.Swept,
 		IsRedeemed:     vtxo.Redeemed,

--- a/server/internal/interface/grpc/handlers/parser.go
+++ b/server/internal/interface/grpc/handlers/parser.go
@@ -52,7 +52,7 @@ func (v vtxoList) toProto() []*arkv1.Vtxo {
 			Swept:          vv.Swept,
 			Preconfirmed:   len(vv.RedeemTx) > 0,
 			Redeemed:       vv.Redeemed,
-			Script:         vv.PubKey,
+			Script:         toP2TR(vv.PubKey),
 			CreatedAt:      vv.CreatedAt,
 		})
 	}
@@ -131,4 +131,14 @@ func (i intentsInfo) toProto() []*arkv1.IntentInfo {
 func convertSatsToBTCStr(sats uint64) string {
 	btc := float64(sats) * 1e-8
 	return fmt.Sprintf("%.8f", btc)
+}
+
+func toP2TR(pubkey string) string {
+	// nolint
+	buf, _ := hex.DecodeString(pubkey)
+	// nolint
+	key, _ := schnorr.ParsePubKey(buf)
+	// nolint
+	script, _ := common.P2TRScript(key)
+	return hex.EncodeToString(script)
 }

--- a/server/internal/interface/grpc/handlers/parser.go
+++ b/server/internal/interface/grpc/handlers/parser.go
@@ -9,28 +9,7 @@ import (
 	"github.com/ark-network/ark/server/internal/core/application"
 	"github.com/ark-network/ark/server/internal/core/domain"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
-	"github.com/btcsuite/btcd/btcutil"
 )
-
-// From interface type to app type
-
-func parseAddress(addr string) (*common.Address, error) {
-	if len(addr) <= 0 {
-		return nil, fmt.Errorf("missing address")
-	}
-	return common.DecodeAddress(addr)
-}
-
-func parseArkAddress(addr string) (string, error) {
-	a, err := parseAddress(addr)
-	if err != nil {
-		return "", err
-	}
-	if _, err := btcutil.DecodeAddress(addr, nil); err == nil {
-		return "", fmt.Errorf("must be an ark address")
-	}
-	return hex.EncodeToString(schnorr.SerializePubKey(a.VtxoTapKey)), nil
-}
 
 // From app type to interface type
 

--- a/server/test/e2e/e2e_test.go
+++ b/server/test/e2e/e2e_test.go
@@ -30,7 +30,6 @@ import (
 	singlekeywallet "github.com/ark-network/ark/pkg/client-sdk/wallet/singlekey"
 	inmemorystore "github.com/ark-network/ark/pkg/client-sdk/wallet/singlekey/store/inmemory"
 	utils "github.com/ark-network/ark/server/test/e2e"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -619,12 +618,14 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 
 		vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
 		require.NoError(t, err)
+		outputScript, err := common.P2TRScript(vtxoTapKey)
+		require.NoError(t, err)
 
 		closure := vtxoScript.ForfeitClosures()[0]
 
 		bobAddr := common.Address{
 			HRP:        "tark",
-			VtxoTapKey: vtxoTapKey,
+			VtxoScript: outputScript,
 			Server:     aliceAddr.Server,
 		}
 
@@ -684,16 +685,13 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 		var bobOutput *wire.TxOut
 		var bobOutputIndex uint32
 		for i, out := range virtualPtx.UnsignedTx.TxOut {
-			if bytes.Equal(out.PkScript[2:], schnorr.SerializePubKey(bobAddr.VtxoTapKey)) {
+			if bytes.Equal(out.PkScript, bobAddr.VtxoScript) {
 				bobOutput = out
 				bobOutputIndex = uint32(i)
 				break
 			}
 		}
 		require.NotNil(t, bobOutput)
-
-		alicePkScript, err := common.P2TRScript(aliceAddr.VtxoTapKey)
-		require.NoError(t, err)
 
 		tapscripts := make([]string, 0, len(vtxoScript.Closures))
 		for _, closure := range vtxoScript.Closures {
@@ -726,7 +724,7 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 			[]*wire.TxOut{
 				{
 					Value:    bobOutput.Value,
-					PkScript: alicePkScript,
+					PkScript: aliceAddr.VtxoScript,
 				},
 			},
 			&tree.CSVMultisigClosure{
@@ -1232,12 +1230,14 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 
 	vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
 	require.NoError(t, err)
+	outputScript, err := common.P2TRScript(vtxoTapKey)
+	require.NoError(t, err)
 
 	closure := vtxoScript.ForfeitClosures()[0]
 
 	bobAddr := common.Address{
 		HRP:        "tark",
-		VtxoTapKey: vtxoTapKey,
+		VtxoScript: outputScript,
 		Server:     aliceAddr.Server,
 	}
 
@@ -1295,16 +1295,13 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 	var bobOutput *wire.TxOut
 	var bobOutputIndex uint32
 	for i, out := range virtualPtx.UnsignedTx.TxOut {
-		if bytes.Equal(out.PkScript[2:], schnorr.SerializePubKey(bobAddr.VtxoTapKey)) {
+		if bytes.Equal(out.PkScript, bobAddr.VtxoScript) {
 			bobOutput = out
 			bobOutputIndex = uint32(i)
 			break
 		}
 	}
 	require.NotNil(t, bobOutput)
-
-	alicePkScript, err := common.P2TRScript(aliceAddr.VtxoTapKey)
-	require.NoError(t, err)
 
 	tapscripts := make([]string, 0, len(vtxoScript.Closures))
 	for _, closure := range vtxoScript.Closures {
@@ -1337,7 +1334,7 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 		[]*wire.TxOut{
 			{
 				Value:    bobOutput.Value,
-				PkScript: alicePkScript,
+				PkScript: aliceAddr.VtxoScript,
 			},
 		},
 		&tree.CSVMultisigClosure{
@@ -1481,12 +1478,14 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 
 	vtxoTapKey, vtxoTapTree, err := vtxoScript.TapTree()
 	require.NoError(t, err)
+	outputScript, err := common.P2TRScript(vtxoTapKey)
+	require.NoError(t, err)
 
 	closure := vtxoScript.ForfeitClosures()[0]
 
 	bobAddr := common.Address{
 		HRP:        "tark",
-		VtxoTapKey: vtxoTapKey,
+		VtxoScript: outputScript,
 		Server:     aliceAddr.Server,
 	}
 
@@ -1545,16 +1544,13 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 	var bobOutput *wire.TxOut
 	var bobOutputIndex uint32
 	for i, out := range virtualPtx.UnsignedTx.TxOut {
-		if bytes.Equal(out.PkScript[2:], schnorr.SerializePubKey(bobAddr.VtxoTapKey)) {
+		if bytes.Equal(out.PkScript, bobAddr.VtxoScript) {
 			bobOutput = out
 			bobOutputIndex = uint32(i)
 			break
 		}
 	}
 	require.NotNil(t, bobOutput)
-
-	alicePkScript, err := common.P2TRScript(aliceAddr.VtxoTapKey)
-	require.NoError(t, err)
 
 	tapscripts := make([]string, 0, len(vtxoScript.Closures))
 	for _, closure := range vtxoScript.Closures {
@@ -1587,7 +1583,7 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 		[]*wire.TxOut{
 			{
 				Value:    bobOutput.Value,
-				PkScript: alicePkScript,
+				PkScript: aliceAddr.VtxoScript,
 			},
 		},
 		&tree.CSVMultisigClosure{


### PR DESCRIPTION
This makes the server return and accept vtxo output scripts instead of pubkeys.

This also changes the address encoding format from <hrp serverKey vtxoKey> to <hrp vtxoScript serverKey>.

Closes #623
Closes #624 

Please @louisinger @Kukks review