### PR TITLE
Flexible checkpoint output script

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -6,8 +6,13 @@ import (
 )
 
 type VtxoInput struct {
-	Outpoint           *wire.OutPoint
-	Amount             int64
-	Tapscript          *waddrmgr.Tapscript
-	RevealedTapscripts []string
+	Outpoint *wire.OutPoint
+	Amount   int64
+	// Tapscript is the path used to spend the vtxo
+	Tapscript *waddrmgr.Tapscript
+	// CheckpointTapscript is the path used to craft checkpoint output script
+	// it is combined with the server's unroll script to creaft a new "checkpoint" output script
+	// it can be nil, defaulting to Tapscript if not set
+	CheckpointTapscript *waddrmgr.Tapscript
+	RevealedTapscripts  []string
 }


### PR DESCRIPTION
This PR adds an optional `CheckpointTapscript` field to `common.VtxoInput` allowing to specify a custom collaborative tapscript used to build the checkpoint output script.

@altafan @Kukks please review