### PR TITLE
chore: log a warning if broadcast commitment tx fails

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1865,6 +1865,7 @@ func (s *service) finalizeRound(roundTiming roundTiming) {
 		changes = s.cache.CurrentRound().Fail(
 			fmt.Errorf("failed to broadcast commitment tx: %s", err),
 		)
+		log.WithError(err).Warn("failed to broadcast commitment tx")
 		return
 	}
 


### PR DESCRIPTION
Add missing Warn log on `BroadcastTransaction` error.

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging for broadcast failures during round finalization to aid in troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->