### PR TITLE
build: embed commit hash into version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .github
 .run
 **/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,12 @@ WORKDIR /app
 COPY . .
 
 # ENV GOPROXY=https://goproxy.io,direct
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.Version=${VERSION}'" -o ./bin/arkd ./cmd/arkd
-RUN cd pkg/ark-cli && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.Version=${VERSION}'" -o ../../bin/ark main.go
+RUN set -eux; \
+    if [ -z "$VERSION" ]; then \
+        VERSION=$(git rev-parse --short HEAD); \
+    fi; \
+    CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.Version=${VERSION}'" -o ./bin/arkd ./cmd/arkd; \
+    cd pkg/ark-cli && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.Version=${VERSION}'" -o ../../bin/ark main.go
 
 # Second image, running the arkd executable
 FROM alpine:3.20


### PR DESCRIPTION
## Summary
- allow Docker builds to embed git commit hash when no version is provided
- include `.git` directory in Docker build context

## Testing
- `go test ./internal/core/domain -run TestRound -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_b_6892449a3618832cb0a3f1cef5e9631c