### PR TITLE
arkd command: add dropwtxmgr

### DIFF
--- a/cmd/arkd/commands.go
+++ b/cmd/arkd/commands.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,7 @@ var (
 		Subcommands: cli.Commands{
 			walletStatusCmd,
 			walletCreateOrRestoreCmd,
+			walletDropWtxmgrCmd,
 			walletUnlockCmd,
 			walletAddressCmd,
 			walletBalanceCmd,
@@ -37,6 +39,12 @@ var (
 		Usage:  "Create or restore the wallet",
 		Action: walletCreateOrRestoreAction,
 		Flags:  []cli.Flag{passwordFlag, mnemonicFlag, gapLimitFlag},
+	}
+	walletDropWtxmgrCmd = &cli.Command{
+		Name:   "dropwtxmgr",
+		Usage:  "Run the dropwtxmgr tool",
+		Action: walletDropWtxmgrAction,
+		Flags:  []cli.Flag{dbPathFlag},
 	}
 	walletUnlockCmd = &cli.Command{
 		Name:   "unlock",
@@ -176,6 +184,12 @@ func walletCreateOrRestoreAction(ctx *cli.Context) error {
 	}
 
 	fmt.Println(seed)
+	return nil
+}
+
+func walletDropWtxmgrAction(ctx *cli.Context) error {
+	dbPath := ctx.String(dbPathFlagName)
+	os.Exit(dropWtxmgr(dbPath))
 	return nil
 }
 

--- a/cmd/arkd/dropwtxmgr.go
+++ b/cmd/arkd/dropwtxmgr.go
@@ -1,0 +1,49 @@
+/*
+This is a copy of the dropwtxmgr tool from the btcwallet repo.
+(https://github.com/btcsuite/btcwallet/blob/master/cmd/dropwtxmgr/main.go)
+It is used to drop the wtxmgr database in case you want to force a rescan.
+
+You can run it with:
+	arkd wallet dropwtxmgr --datadir /path/to/arkd/data/wallet.db
+
+Once Tx history is deleted, the rescan will automatically start on the next unlock.
+
+See: https://github.com/btcsuite/btcwallet/blob/master/docs/force_rescans.md
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/btcsuite/btcwallet/wallet"
+	"github.com/btcsuite/btcwallet/walletdb"
+	_ "github.com/btcsuite/btcwallet/walletdb/bdb"
+)
+
+func dropWtxmgr(dbPath string) int {
+	fmt.Println("Database path:", dbPath)
+	_, err := os.Stat(dbPath)
+	if os.IsNotExist(err) {
+		fmt.Println("Database file does not exist")
+		return 1
+	}
+
+	db, err := walletdb.Open("bdb", dbPath, true, wallet.DefaultDBTimeout)
+	if err != nil {
+		fmt.Println("Failed to open database:", err)
+		return 1
+	}
+	defer db.Close()
+
+	fmt.Println("Dropping btcwallet transaction history")
+
+	err = wallet.DropTransactionHistory(db, true)
+	if err != nil {
+		fmt.Println("Failed to drop and re-create namespace:", err)
+		return 1
+	}
+
+	return 0
+}

--- a/cmd/arkd/dropwtxmgr.go
+++ b/cmd/arkd/dropwtxmgr.go
@@ -35,6 +35,7 @@ func dropWtxmgr(dbPath string) int {
 		fmt.Println("Failed to open database:", err)
 		return 1
 	}
+	// nolint:errcheck
 	defer db.Close()
 
 	fmt.Println("Dropping btcwallet transaction history")

--- a/cmd/arkd/flags.go
+++ b/cmd/arkd/flags.go
@@ -13,6 +13,7 @@ const (
 	urlFlagName                     = "url"
 	datadirFlagName                 = "datadir"
 	passwordFlagName                = "password"
+	dbPathFlagName                  = "datadir"
 	mnemonicFlagName                = "mnemonic"
 	gapLimitFlagName                = "addr-gap-limit"
 	amountFlagName                  = "amount"
@@ -42,7 +43,11 @@ var (
 		Usage: "arkd datadir from where to source TLS cert and macaroon if needed",
 		Value: arklib.AppDataDir("arkd", false),
 	}
-
+	dbPathFlag = &cli.StringFlag{
+		Name:     dbPathFlagName,
+		Usage:    "path to the wallet database",
+		Required: true,
+	}
 	passwordFlag = &cli.StringFlag{
 		Name:     passwordFlagName,
 		Usage:    "wallet password",

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/arkade-os/arkd/pkg/macaroons v0.0.0-00010101000000-000000000000
 	github.com/arkade-os/go-sdk v0.6.3-0.20250708135236-08d1624ee483
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/btcsuite/btcwallet/walletdb v1.4.2
 	github.com/dgraph-io/badger/v4 v4.3.0
 	github.com/go-co-op/gocron v1.37.0
 	github.com/golang-migrate/migrate/v4 v4.17.1
@@ -69,7 +70,6 @@ require (
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 // indirect
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 // indirect
 	github.com/btcsuite/btcwallet/wallet/txsizes v1.2.4 // indirect
-	github.com/btcsuite/btcwallet/walletdb v1.4.2 // indirect
 	github.com/btcsuite/btcwallet/wtxmgr v1.5.3 // indirect
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect


### PR DESCRIPTION
```
arkd wallet dropwtxmgr --datadir /path/to/wallet.db
```

The command only drops the transaction history, allowing to trigger a full rescan on next wallet unlock.
more about this: https://github.com/btcsuite/btcwallet/blob/master/docs/force_rescans.md

@tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to remove the wallet transaction history database, enabling users to force a rescan on the next wallet unlock.
  * Introduced a required flag for specifying the wallet database path when using the new command.

* **Chores**
  * Updated dependencies to explicitly include the wallet database library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->