### PR TITLE
broker.go: safer synchronization

### DIFF
--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -356,7 +356,8 @@ func (h *indexerService) GetSubscription(
 
 	h.scriptSubsHandler.stopTimeout(subscriptionId)
 	defer func() {
-		if len(h.scriptSubsHandler.getTopics(subscriptionId)) > 0 {
+		topics := h.scriptSubsHandler.getTopics(subscriptionId)
+		if len(topics) > 0 {
 			h.scriptSubsHandler.startTimeout(subscriptionId, h.subscriptionTimeoutDuration)
 			return
 		}
@@ -435,7 +436,7 @@ func (h *indexerService) SubscribeForScripts(
 
 func (h *indexerService) listenToTxEvents() {
 	for event := range h.eventsCh {
-		if len(h.scriptSubsHandler.listeners) <= 0 {
+		if !h.scriptSubsHandler.hasListeners() {
 			continue
 		}
 
@@ -462,7 +463,9 @@ func (h *indexerService) listenToTxEvents() {
 				}
 			}
 		}
-		for _, l := range h.scriptSubsHandler.listeners {
+
+		listenersCopy := h.scriptSubsHandler.getListenersCopy()
+		for _, l := range listenersCopy {
 			spendableVtxos := make([]*arkv1.IndexerVtxo, 0)
 			spentVtxos := make([]*arkv1.IndexerVtxo, 0)
 			involvedScripts := make([]string, 0)
@@ -478,16 +481,22 @@ func (h *indexerService) listenToTxEvents() {
 			}
 
 			if len(spendableVtxos) > 0 || len(spentVtxos) > 0 {
-				go func() {
-					l.ch <- &arkv1.GetSubscriptionResponse{
+				go func(listener *listener[*arkv1.GetSubscriptionResponse]) {
+					select {
+					case listener.ch <- &arkv1.GetSubscriptionResponse{
 						Txid:          event.Txid,
 						Scripts:       involvedScripts,
 						NewVtxos:      spendableVtxos,
 						SpentVtxos:    spentVtxos,
 						Tx:            event.Tx,
 						CheckpointTxs: checkpointTxs,
+					}:
+						// Message sent successfully
+					default:
+						// Channel is full, skip this message to prevent blocking
+						// This prevents the goroutine from hanging indefinitely
 					}
-				}()
+				}(l)
 			}
 		}
 	}


### PR DESCRIPTION
This PR improves the `broker` utility struct used to implement pub/sub endpoints. 
* reduce the buffered channel capacity from 1000 to 100 to reduce memory usage. anyway this channel should be always red by the client, no need to keep 1000 messages in memory.
* do not block writes to channels : if a listener is "acting bad" or have an issue preventing him to read the channel, message are skipped. It prevents forever living routines.
* use mutex before accessing listeners map (`getListenersCopy` and `hasListeners` methods).

@tiero please review