### PR TITLE
envs: remove redundant ARKD_LIVE_STORE_TYPE variable

### DIFF
--- a/envs/arkd.dev.env
+++ b/envs/arkd.dev.env
@@ -6,7 +6,6 @@ ARKD_BOARDING_EXIT_DELAY=1024
 ARKD_DATADIR=./data/regtest
 ARKD_ESPLORA_URL=http://localhost:3000
 ARKD_WALLET_ADDR=localhost:6060
-ARKD_LIVE_STORE_TYPE=redis
 ARKD_PG_DB_URL=postgresql://root:secret@127.0.0.1:5432/projection?sslmode=disable
 ARKD_PG_EVENT_DB_URL=postgresql://root:secret@127.0.0.1:5432/event?sslmode=disable
 ARKD_REDIS_URL=redis://localhost:6379/0


### PR DESCRIPTION
The ARKD_LIVE_STORE_TYPE variable was set to redis, but since redis is already the default store type and the Redis URL is explicitly configured via ARKD_REDIS_URL, this variable is unnecessary.

Simplify the https://github.com/arkade-os/rust-sdk/pull/101 to allow not include redis during the e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration by removing a specific variable. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->