### PR TITLE
indexer GetVtxos: fix recoverableOnly filter

### DIFF
--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -184,7 +184,7 @@ func (i *indexerService) GetVtxos(
 	if recoverableOnly {
 		recoverableVtxos := make([]domain.Vtxo, 0, len(allVtxos))
 		for _, vtxo := range allVtxos {
-			if !vtxo.RequiresForfeit() {
+			if !vtxo.RequiresForfeit() && !vtxo.Spent {
 				recoverableVtxos = append(recoverableVtxos, vtxo)
 			}
 		}


### PR DESCRIPTION
A vtxo is not any more "recoverable" if already spent (it means it has been "recovered"). This PR ensures `GetVtxos` RPC with recoverableOnly = true excludes the spent coins.

@tiero @altafan @Kukks  please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recoverable outputs now exclude spent items, ensuring only unspent, non-forfeit outputs are shown as recoverable.
  * Improves accuracy of recoverable balances and counts across the app.
  * Reduces confusion during recovery workflows by preventing already-spent outputs from appearing as recoverable.
  * No other user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->