### PR TITLE
fix collaborative exit

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -968,7 +968,11 @@ func (s *service) RegisterIntent(
 					)
 				}
 
-				_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.PkScript, s.chainParams())
+				chainParams := s.chainParams()
+				if chainParams == nil {
+					return "", fmt.Errorf("unsupported network: %s", s.network.Name)
+				}
+				_, addrs, _, err := txscript.ExtractPkScriptAddrs(output.PkScript, chainParams)
 				if err != nil {
 					return "", fmt.Errorf("failed to extract pkscript addrs: %s", err)
 				}
@@ -2191,10 +2195,16 @@ func (s *service) chainParams() *chaincfg.Params {
 		return &chaincfg.MainNetParams
 	case arklib.BitcoinTestNet.Name:
 		return &chaincfg.TestNet3Params
+	//case arklib.BitcoinTestNet4.Name: //TODO uncomment once supported
+	//	return &chaincfg.TestNet4Params
+	case arklib.BitcoinSigNet.Name:
+		return &chaincfg.SigNetParams
+	case arklib.BitcoinMutinyNet.Name:
+		return &arklib.MutinyNetSigNetParams
 	case arklib.BitcoinRegTest.Name:
 		return &chaincfg.RegressionNetParams
 	default:
-		return nil
+		return &chaincfg.MainNetParams
 	}
 }
 


### PR DESCRIPTION
In RegisterIntent RPC, when parsing the onchain address, add a check on supported network to prevent panics.
Also add support mutinynet addresses.

@tiero @bordalix @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when registering intents on unsupported or misconfigured networks by validating network parameters first.
  * Standardized default network to MainNet for more consistent behavior across environments.
  * Clearer error messaging when an unsupported network is encountered.
  * Improved stability across supported networks during address handling.
  * Reduced edge-case failures during address parsing and registration flows.
  * No user action required; behavior is now more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->