### PR TITLE
chore: remove leftover Println

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -682,12 +682,6 @@ func (s *service) SubmitOffchainTx(
 	// verify the ark tx integrity
 	rebuiltTxid := rebuiltArkTx.UnsignedTx.TxID()
 	if rebuiltTxid != txid {
-		fmt.Println("REBUILT ARK TX")
-		fmt.Println(rebuiltArkTx.B64Encode())
-		fmt.Println("REBUILT CP TXS")
-		for _, cp := range rebuiltCheckpointTxs {
-			fmt.Println(cp.B64Encode())
-		}
 		return nil, "", "", fmt.Errorf(
 			"invalid ark tx: expected txid %s got %s", rebuiltTxid, txid,
 		)


### PR DESCRIPTION
@Kukks @tiero please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed verbose debug printouts during offchain transaction submission integrity checks, resulting in cleaner logs and reduced exposure of encoded transaction data. No changes to behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->