### PR TITLE
Remove warnings from nbxplorer chain info response

### DIFF
--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/types.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/types.go
@@ -171,19 +171,18 @@ type trackedSource struct {
 }
 
 type blockchainInfoResponse struct {
-	Bestblockhash        string   `json:"bestblockhash"`
-	Bits                 string   `json:"bits"`
-	Blocks               uint32   `json:"blocks"`
-	Chain                string   `json:"chain"`
-	Chainwork            string   `json:"chainwork"`
-	Difficulty           float64  `json:"difficulty"`
-	Headers              uint32   `json:"headers"`
-	Initialblockdownload bool     `json:"initialblockdownload"`
-	Mediantime           int64    `json:"mediantime"`
-	Pruned               bool     `json:"pruned"`
-	SizeOnDisk           uint64   `json:"size_on_disk"`
-	Target               string   `json:"target"`
-	Time                 int64    `json:"time"`
-	Verificationprogress float64  `json:"verificationprogress"`
-	Warnings             []string `json:"warnings"`
+	Bestblockhash        string  `json:"bestblockhash"`
+	Bits                 string  `json:"bits"`
+	Blocks               uint32  `json:"blocks"`
+	Chain                string  `json:"chain"`
+	Chainwork            string  `json:"chainwork"`
+	Difficulty           float64 `json:"difficulty"`
+	Headers              uint32  `json:"headers"`
+	Initialblockdownload bool    `json:"initialblockdownload"`
+	Mediantime           int64   `json:"mediantime"`
+	Pruned               bool    `json:"pruned"`
+	SizeOnDisk           uint64  `json:"size_on_disk"`
+	Target               string  `json:"target"`
+	Time                 int64   `json:"time"`
+	Verificationprogress float64 `json:"verificationprogress"`
 }


### PR DESCRIPTION
Broken with Core >=v28:

`error while initializing services: failed to connect to nbxplorer: failed to unmarshal blockchain info: json: cannot unmarshal string into Go struct field blockchainInfoResponse.warnings of type []string`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined backend response data by removing unused warning metadata, reducing payload surface.
  - No changes to user-facing features or behaviors.
  - Improves maintainability without affecting existing workflows or compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->