### PR TITLE
Hotfix: finalize batch with no waiting time if no forfeit txs or boarding ins needed to be signed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/arkade-os/arkd/pkg/arkd-wallet-btcwallet v0.0.0-00010101000000-000000000000
 	github.com/arkade-os/arkd/pkg/kvdb v0.0.0-20250606113434-241d3e1ec7cb
 	github.com/arkade-os/arkd/pkg/macaroons v0.0.0-00010101000000-000000000000
-	github.com/arkade-os/go-sdk v0.7.1
+	github.com/arkade-os/go-sdk v0.7.2-0.20250920044614-7ad704f4846f
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btcwallet/walletdb v1.4.2
 	github.com/dgraph-io/badger/v4 v4.8.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSi
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/arkade-os/go-sdk v0.7.1 h1:oSdN1ErdFejZB993zlh/q++YhziMfKiHFvCNTKfatwc=
-github.com/arkade-os/go-sdk v0.7.1/go.mod h1:cGMYagvFj57pBUSJPL+wVQ67eVrNk0R6MPtEOLKyRlQ=
+github.com/arkade-os/go-sdk v0.7.2-0.20250920044614-7ad704f4846f h1:BAtzSK6JbVBMRcXsJguNImms/IiAJPNHhS7uwYuStmE=
+github.com/arkade-os/go-sdk v0.7.2-0.20250920044614-7ad704f4846f/go.mod h1:cGMYagvFj57pBUSJPL+wVQ67eVrNk0R6MPtEOLKyRlQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1850,20 +1850,9 @@ func (s *service) finalizeRound(roundTiming roundTiming) {
 		log.WithError(err).Warn("failed to parse commitment tx")
 		return
 	}
+
 	commitmentTxid := commitmentTx.UnsignedTx.TxID()
-
-	includesBoardingInputs := false
-	for _, in := range commitmentTx.Inputs {
-		// TODO: this is ok as long as the signer doesn't use taproot address too!
-		// We need to find a better way to understand if an in input is ours or if
-		// it's a boarding one.
-		scriptType := txscript.GetScriptClass(in.WitnessUtxo.PkScript)
-		if scriptType == txscript.WitnessV1TaprootTy {
-			includesBoardingInputs = true
-			break
-		}
-	}
-
+	includesBoardingInputs := s.cache.BoardingInputs().Get() > 0
 	txToSign := s.cache.CurrentRound().Get().CommitmentTx
 	forfeitTxs := make([]domain.ForfeitTx, 0)
 

--- a/pkg/ark-cli/go.mod
+++ b/pkg/ark-cli/go.mod
@@ -7,8 +7,8 @@ replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v
 replace github.com/arkade-os/arkd/pkg/ark-lib => ../ark-lib
 
 require (
-	github.com/arkade-os/arkd/pkg/ark-lib v0.7.1-0.20250828160539-46c64760fbe0
-	github.com/arkade-os/go-sdk v0.6.3-0.20250829091740-3927041311a7
+	github.com/arkade-os/arkd/pkg/ark-lib v0.7.1
+	github.com/arkade-os/go-sdk v0.7.2-0.20250920032633-589935f9a8b5
 	github.com/urfave/cli/v2 v2.27.4
 	golang.org/x/term v0.30.0
 )
@@ -59,6 +59,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/flatbuffers v24.3.25+incompatible // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/pkg/ark-cli/go.mod
+++ b/pkg/ark-cli/go.mod
@@ -8,7 +8,7 @@ replace github.com/arkade-os/arkd/pkg/ark-lib => ../ark-lib
 
 require (
 	github.com/arkade-os/arkd/pkg/ark-lib v0.7.1
-	github.com/arkade-os/go-sdk v0.7.2-0.20250920032633-589935f9a8b5
+	github.com/arkade-os/go-sdk v0.7.2-0.20250920044614-7ad704f4846f
 	github.com/urfave/cli/v2 v2.27.4
 	golang.org/x/term v0.30.0
 )

--- a/pkg/ark-cli/go.sum
+++ b/pkg/ark-cli/go.sum
@@ -16,8 +16,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/arkade-os/go-sdk v0.7.2-0.20250920032633-589935f9a8b5 h1:a3xMEytpqU3trip5FVPn6+uv1CQv/enm/CqDsB6PgOE=
-github.com/arkade-os/go-sdk v0.7.2-0.20250920032633-589935f9a8b5/go.mod h1:cGMYagvFj57pBUSJPL+wVQ67eVrNk0R6MPtEOLKyRlQ=
+github.com/arkade-os/go-sdk v0.7.2-0.20250920044614-7ad704f4846f h1:BAtzSK6JbVBMRcXsJguNImms/IiAJPNHhS7uwYuStmE=
+github.com/arkade-os/go-sdk v0.7.2-0.20250920044614-7ad704f4846f/go.mod h1:cGMYagvFj57pBUSJPL+wVQ67eVrNk0R6MPtEOLKyRlQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/pkg/ark-cli/go.sum
+++ b/pkg/ark-cli/go.sum
@@ -16,8 +16,8 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmH
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/arkade-os/go-sdk v0.6.3-0.20250829091740-3927041311a7 h1:wAbjiRa76POTUAMr3M165ToivzcriVMkx/1+ZDi/pzA=
-github.com/arkade-os/go-sdk v0.6.3-0.20250829091740-3927041311a7/go.mod h1:gN+fRzES7Deu4nMWUgVuiDSgdlIsj/4ylsiaSzCtUtY=
+github.com/arkade-os/go-sdk v0.7.2-0.20250920032633-589935f9a8b5 h1:a3xMEytpqU3trip5FVPn6+uv1CQv/enm/CqDsB6PgOE=
+github.com/arkade-os/go-sdk v0.7.2-0.20250920032633-589935f9a8b5/go.mod h1:cGMYagvFj57pBUSJPL+wVQ67eVrNk0R6MPtEOLKyRlQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=

--- a/pkg/ark-cli/main.go
+++ b/pkg/ark-cli/main.go
@@ -44,10 +44,7 @@ func main() {
 		&notesCommand,
 		&recoverCommand,
 	)
-	app.Flags = []cli.Flag{
-		datadirFlag,
-		networkFlag,
-	}
+	app.Flags = []cli.Flag{datadirFlag, verboseFlag}
 	app.Before = func(ctx *cli.Context) error {
 		sdk, err := getArkSdkClient(ctx)
 		if err != nil {
@@ -72,11 +69,6 @@ var (
 		Required: false,
 		Value:    arklib.AppDataDir("ark-cli", false),
 		EnvVars:  []string{DatadirEnvVar},
-	}
-	networkFlag = &cli.StringFlag{
-		Name:  "network",
-		Usage: "network to use mainnet, testnet, regtest, signet, mutinynet for bitcoin)",
-		Value: "mainnet",
 	}
 	explorerFlag = &cli.StringFlag{
 		Name:  "explorer",
@@ -165,9 +157,7 @@ var (
 		Action: func(ctx *cli.Context) error {
 			return initArkSdk(ctx)
 		},
-		Flags: []cli.Flag{
-			networkFlag, passwordFlag, privateKeyFlag, urlFlag, explorerFlag, restFlag, verboseFlag,
-		},
+		Flags: []cli.Flag{passwordFlag, privateKeyFlag, urlFlag, explorerFlag, restFlag},
 	}
 	configCommand = cli.Command{
 		Name:  "config",
@@ -261,7 +251,6 @@ func initArkSdk(ctx *cli.Context) error {
 			Seed:        ctx.String(privateKeyFlag.Name),
 			Password:    string(password),
 			ExplorerURL: ctx.String(explorerFlag.Name),
-			Verbose:     ctx.Bool(verboseFlag.Name),
 		},
 	)
 }
@@ -288,7 +277,6 @@ func config(ctx *cli.Context) error {
 		"utxo_max_amount":       cfgData.UtxoMaxAmount,
 		"vtxo_min_amount":       cfgData.VtxoMinAmount,
 		"vtxo_max_amount":       cfgData.VtxoMaxAmount,
-		"verbose":               cfgData.Verbose,
 	}
 
 	return printJSON(cfg)
@@ -488,19 +476,24 @@ func getArkSdkClient(ctx *cli.Context) (arksdk.ArkClient, error) {
 		return nil, fmt.Errorf("CLI not initialized, run 'init' cmd to initialize")
 	}
 
+	opts := make([]arksdk.ClientOption, 0)
+	if ctx.Bool(verboseFlag.Name) {
+		opts = append(opts, arksdk.WithVerbose())
+	}
+
 	return loadOrCreateClient(
-		arksdk.LoadArkClient, arksdk.NewArkClient, sdkRepository,
+		arksdk.LoadArkClient, arksdk.NewArkClient, sdkRepository, opts,
 	)
 }
 
 func loadOrCreateClient(
-	loadFunc, newFunc func(types.Store) (arksdk.ArkClient, error),
-	sdkRepository types.Store,
+	loadFunc, newFunc func(types.Store, ...arksdk.ClientOption) (arksdk.ArkClient, error),
+	sdkRepository types.Store, opts []arksdk.ClientOption,
 ) (arksdk.ArkClient, error) {
-	client, err := loadFunc(sdkRepository)
+	client, err := loadFunc(sdkRepository, opts...)
 	if err != nil {
 		if errors.Is(err, arksdk.ErrNotInitialized) {
-			return newFunc(sdkRepository)
+			return newFunc(sdkRepository, opts...)
 		}
 		return nil, err
 	}

--- a/pkg/ark-cli/main.go
+++ b/pkg/ark-cli/main.go
@@ -150,6 +150,12 @@ var (
 		Value:       false,
 		DefaultText: "false",
 	}
+	verboseFlag = &cli.BoolFlag{
+		Name:        "verbose",
+		Usage:       "enable debug logs",
+		Value:       false,
+		DefaultText: "false",
+	}
 )
 
 var (
@@ -159,7 +165,9 @@ var (
 		Action: func(ctx *cli.Context) error {
 			return initArkSdk(ctx)
 		},
-		Flags: []cli.Flag{networkFlag, passwordFlag, privateKeyFlag, urlFlag, explorerFlag, restFlag},
+		Flags: []cli.Flag{
+			networkFlag, passwordFlag, privateKeyFlag, urlFlag, explorerFlag, restFlag, verboseFlag,
+		},
 	}
 	configCommand = cli.Command{
 		Name:  "config",
@@ -253,6 +261,7 @@ func initArkSdk(ctx *cli.Context) error {
 			Seed:        ctx.String(privateKeyFlag.Name),
 			Password:    string(password),
 			ExplorerURL: ctx.String(explorerFlag.Name),
+			Verbose:     ctx.Bool(verboseFlag.Name),
 		},
 	)
 }
@@ -279,6 +288,7 @@ func config(ctx *cli.Context) error {
 		"utxo_max_amount":       cfgData.UtxoMaxAmount,
 		"vtxo_min_amount":       cfgData.VtxoMinAmount,
 		"vtxo_max_amount":       cfgData.VtxoMaxAmount,
+		"verbose":               cfgData.Verbose,
 	}
 
 	return printJSON(cfg)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2214,7 +2214,7 @@ func setupServerWalletAndCLI() error {
 
 	if _, err := runArkCommand(
 		"init", "--server-url", "localhost:7070", "--password", password,
-		"--network", "regtest", "--explorer", "http://chopsticks:3000",
+		"--explorer", "http://chopsticks:3000",
 	); err != nil {
 		return fmt.Errorf("error initializing ark config: %s", err)
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -454,7 +454,9 @@ func TestReactToRedemptionOfRefreshedVtxos(t *testing.T) {
 		}
 	}
 
-	expl, err := explorer.NewExplorer("http://localhost:3000", arklib.BitcoinRegTest)
+	expl, err := explorer.NewExplorer(
+		"http://localhost:3000", arklib.BitcoinRegTest, explorer.WithTracker(false),
+	)
 	require.NoError(t, err)
 
 	branch, err := redemption.NewRedeemBranch(ctx, expl, indexerSvc, vtxo)
@@ -550,7 +552,9 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 		}
 		require.NotEmpty(t, vtxo)
 
-		expl, err := explorer.NewExplorer("http://localhost:3000", arklib.BitcoinRegTest)
+		expl, err := explorer.NewExplorer(
+			"http://localhost:3000", arklib.BitcoinRegTest, explorer.WithTracker(false),
+		)
 		require.NoError(t, err)
 
 		branch, err := redemption.NewRedeemBranch(ctx, expl, indexerSvc, vtxo)
@@ -784,7 +788,9 @@ func TestReactToRedemptionOfVtxosSpentAsync(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		explorer, err := explorer.NewExplorer("http://localhost:3000", arklib.BitcoinRegTest)
+		explorer, err := explorer.NewExplorer(
+			"http://localhost:3000", arklib.BitcoinRegTest, explorer.WithTracker(false),
+		)
 		require.NoError(t, err)
 
 		encodedArkTx, err := ptx.B64Encode()
@@ -1430,7 +1436,9 @@ func TestSendToCLTVMultisigClosure(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	explorer, err := explorer.NewExplorer("http://localhost:3000", arklib.BitcoinRegTest)
+	explorer, err := explorer.NewExplorer(
+		"http://localhost:3000", arklib.BitcoinRegTest, explorer.WithTracker(false),
+	)
 	require.NoError(t, err)
 
 	encodedVirtualTx, err := ptx.B64Encode()
@@ -1708,7 +1716,9 @@ func TestSendToConditionMultisigClosure(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	explorer, err := explorer.NewExplorer("http://localhost:3000", arklib.BitcoinRegTest)
+	explorer, err := explorer.NewExplorer(
+		"http://localhost:3000", arklib.BitcoinRegTest, explorer.WithTracker(false),
+	)
 	require.NoError(t, err)
 
 	encodedVirtualTx, err := ptx.B64Encode()


### PR DESCRIPTION
Before this, when redeeming a note in a 1-client batch, arkd would have waited for clients to submit forfeit txs or boarding ins, but since the client has nothing to send, arkd waited until the timeout (ARKD_ROUND_INTERVAL) to move on to signing & broadcasting the commitment tx.

This addresses the issue described by getting the number of boarding inputs to sign from the cache instead of extracting them (erroneously) from the commitment tx.

This also update go-sdk to latest master and implements in the cli a --verbose flag. Tests are now free from sdk logs.

Please @Kukks @sekulicd review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster detection of specific transaction inputs by using a cached count instead of per-input inspection.

* **New Features**
  * Added a CLI --verbose option and surface of the verbose setting in configuration output.

* **Chores**
  * Updated several dependency versions and added an indirect websocket dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->