### PR TITLE
FinalizeTx fix: verify ark signer signature in checkpoints

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -719,7 +719,8 @@ func (s *service) SubmitOffchainTx(
 	}
 
 	// verify the tapscript signatures
-	if valid, _, err := s.builder.VerifyTapscriptPartialSigs(signedArkTx); err != nil || !valid {
+	if valid, _, err := s.builder.VerifyTapscriptPartialSigs(signedArkTx, false); err != nil ||
+		!valid {
 		return nil, "", "", fmt.Errorf("invalid ark tx signature(s): %s", err)
 	}
 
@@ -793,7 +794,7 @@ func (s *service) FinalizeOffchainTx(
 	finalCheckpointTxsMap := make(map[string]string)
 	for _, checkpoint := range finalCheckpointTxs {
 		// verify the tapscript signatures
-		valid, checkpointTxid, err := s.builder.VerifyTapscriptPartialSigs(checkpoint)
+		valid, checkpointTxid, err := s.builder.VerifyTapscriptPartialSigs(checkpoint, true)
 		if err != nil || !valid {
 			return fmt.Errorf("invalid tx signature: %s", err)
 		}
@@ -2461,7 +2462,7 @@ func (s *service) verifyForfeitTxsSigs(txs []string) error {
 			defer wg.Done()
 
 			for tx := range jobs {
-				valid, txid, err := s.builder.VerifyTapscriptPartialSigs(tx)
+				valid, txid, err := s.builder.VerifyTapscriptPartialSigs(tx, false)
 				if err != nil {
 					errChan <- fmt.Errorf("failed to validate forfeit tx %s: %s", txid, err)
 					return

--- a/internal/core/ports/tx_builder.go
+++ b/internal/core/ports/tx_builder.go
@@ -55,7 +55,7 @@ type TxBuilder interface {
 		vtxoTreeExpiry *arklib.RelativeLocktime, batchOutputs SweepableBatchOutput, err error,
 	)
 	FinalizeAndExtract(tx string) (txhex string, err error)
-	VerifyTapscriptPartialSigs(tx string) (valid bool, txid string, err error)
+	VerifyTapscriptPartialSigs(tx string, checkSignerSig bool) (valid bool, txid string, err error)
 	VerifyAndCombinePartialTx(dest string, src string) (string, error)
 	CountSignedTaprootInputs(tx string) (int, error)
 }

--- a/internal/core/ports/tx_builder.go
+++ b/internal/core/ports/tx_builder.go
@@ -55,7 +55,7 @@ type TxBuilder interface {
 		vtxoTreeExpiry *arklib.RelativeLocktime, batchOutputs SweepableBatchOutput, err error,
 	)
 	FinalizeAndExtract(tx string) (txhex string, err error)
-	VerifyTapscriptPartialSigs(tx string, checkSignerSig bool) (valid bool, txid string, err error)
+	VerifyTapscriptPartialSigs(tx string, mustIncludeSignerSig bool) (valid bool, txid string, err error)
 	VerifyAndCombinePartialTx(dest string, src string) (string, error)
 	CountSignedTaprootInputs(tx string) (int, error)
 }

--- a/internal/core/ports/tx_builder.go
+++ b/internal/core/ports/tx_builder.go
@@ -55,7 +55,9 @@ type TxBuilder interface {
 		vtxoTreeExpiry *arklib.RelativeLocktime, batchOutputs SweepableBatchOutput, err error,
 	)
 	FinalizeAndExtract(tx string) (txhex string, err error)
-	VerifyTapscriptPartialSigs(tx string, mustIncludeSignerSig bool) (valid bool, txid string, err error)
+	VerifyTapscriptPartialSigs(
+		tx string, mustIncludeSignerSig bool,
+	) (valid bool, txid string, err error)
 	VerifyAndCombinePartialTx(dest string, src string) (string, error)
 	CountSignedTaprootInputs(tx string) (int, error)
 }

--- a/internal/infrastructure/live-store/live_store_test.go
+++ b/internal/infrastructure/live-store/live_store_test.go
@@ -468,8 +468,9 @@ func (m *mockedTxBuilder) FinalizeAndExtract(tx string) (txhex string, err error
 
 func (m *mockedTxBuilder) VerifyTapscriptPartialSigs(
 	tx string,
+	checkSignerSig bool,
 ) (valid bool, txid string, err error) {
-	args := m.Called(tx)
+	args := m.Called(tx, checkSignerSig)
 	res0 := args.Get(0).(bool)
 	res1 := args.Get(1).(string)
 	return res0, res1, args.Error(2)

--- a/internal/infrastructure/live-store/live_store_test.go
+++ b/internal/infrastructure/live-store/live_store_test.go
@@ -467,10 +467,9 @@ func (m *mockedTxBuilder) FinalizeAndExtract(tx string) (txhex string, err error
 }
 
 func (m *mockedTxBuilder) VerifyTapscriptPartialSigs(
-	tx string,
-	checkSignerSig bool,
+	tx string, mustIncludeSignerSig bool,
 ) (valid bool, txid string, err error) {
-	args := m.Called(tx, checkSignerSig)
+	args := m.Called(tx, mustIncludeSignerSig)
 	res0 := args.Get(0).(bool)
 	res1 := args.Get(1).(string)
 	return res0, res1, args.Error(2)

--- a/internal/infrastructure/tx-builder/covenantless/builder.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder.go
@@ -49,16 +49,22 @@ func (b *txBuilder) GetTxid(tx string) (string, error) {
 	return ptx.UnsignedTx.TxID(), nil
 }
 
-func (b *txBuilder) VerifyTapscriptPartialSigs(tx string) (bool, string, error) {
+func (b *txBuilder) VerifyTapscriptPartialSigs(
+	tx string,
+	checkSignerSig bool,
+) (bool, string, error) {
 	ptx, err := psbt.NewFromRawBytes(strings.NewReader(tx), true)
 	if err != nil {
 		return false, "", err
 	}
 
-	return b.verifyTapscriptPartialSigs(ptx)
+	return b.verifyTapscriptPartialSigs(ptx, checkSignerSig)
 }
 
-func (b *txBuilder) verifyTapscriptPartialSigs(ptx *psbt.Packet) (bool, string, error) {
+func (b *txBuilder) verifyTapscriptPartialSigs(
+	ptx *psbt.Packet,
+	checkSignerSig bool,
+) (bool, string, error) {
 	txid := ptx.UnsignedTx.TxID()
 
 	signerPubkey, err := b.signer.GetPubkey(context.Background())
@@ -126,8 +132,10 @@ func (b *txBuilder) verifyTapscriptPartialSigs(ptx *psbt.Packet) (bool, string, 
 			}
 		}
 
-		// we don't need to check if operator signed
-		keys[signerPubkeyHex] = true
+		if !checkSignerSig {
+			// we don't need to check if operator signed, so we set valid = true
+			keys[signerPubkeyHex] = true
+		}
 
 		if len(tapLeaf.ControlBlock) == 0 {
 			return false, txid, fmt.Errorf("missing control block for input %d", index)


### PR DESCRIPTION
by default `TxBuilder.VerifyTapscriptPartialSigs` is excluding the verification of the ark signer signature because most of the time, the signer doesn't sign transactions he is verifying. However, that's not the case for checkpoint tx submitted in `FinalizeTx` RPC leading to a potential attack where the user is removing the operator's signature from the checkpoint psbt. 

the new argument `checkSignerSig` in VerifyTapscriptPartialSigs fixes this.

it closes #700 

@altafan @Kukks  please review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an optional operator-signature flag to make signature verification stage-aware, allowing select stages to skip or require the operator's signature.

* **Bug Fixes**
  * Reduced false verification failures during off‑chain submission, finalization checkpoints, and forfeit processing.

* **Tests**
  * Updated mocks and tests to cover the new verification behavior.

* **Chores**
  * Internal API and implementation updates to propagate the new flag; no user-facing workflow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->