### PR TITLE
Hotfix encoding of ark psbt fields

### DIFF
--- a/pkg/ark-lib/txutils/psbt_fields.go
+++ b/pkg/ark-lib/txutils/psbt_fields.go
@@ -11,7 +11,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
-const ArkPsbtFieldKeyType = 255
+const ArkPsbtFieldKeyType = 222
 
 var (
 	// ArkPsbtFieldTaprootTree reveals the taproot tree associated with an input


### PR DESCRIPTION
The choosen id (255) causes clients using bitcoin sdks of other languages to not be able to parse psbts that include some ark unknown fields.

The new one (222) is the reuslt of the sum of the ascii chars for "a" "r" "k"

Please @louisinger @Kukks review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the PSBT key prefix used for custom fields in transaction processing.

- Bug Fixes
  - Improved consistency when reading and writing PSBT data using the app.

- Notes
  - No UI changes. This update may affect compatibility of PSBT data exchanged with other versions; re-generating or re-sharing affected PSBTs might be necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->