### PR TITLE
arkd-wallet: unit tests outpointLocker

### DIFF
--- a/pkg/arkd-wallet/core/application/wallet/key_manager.go
+++ b/pkg/arkd-wallet/core/application/wallet/key_manager.go
@@ -67,7 +67,7 @@ func newKeyManager(seed []byte, network *chaincfg.Params) (*keyManager, error) {
 		return nil, err
 	}
 
-	forfeitPrvkey, err := deriveForfeitPrvkey(mainAccount, network)
+	forfeitPrvkey, err := deriveForfeitPrvkey(mainAccount)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func computeTaprootDerivationScheme(accountKey *hdkeychain.ExtendedKey) (string,
 	return neutered.String() + "-[taproot]", nil
 }
 
-func deriveForfeitPrvkey(xpub *hdkeychain.ExtendedKey, network *chaincfg.Params) (*btcec.PrivateKey, error) {
+func deriveForfeitPrvkey(xpub *hdkeychain.ExtendedKey) (*btcec.PrivateKey, error) {
 	key, err := xpub.Derive(0)
 	if err != nil {
 		return nil, err

--- a/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
+++ b/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
@@ -38,7 +38,9 @@ func (l *outpointLocker) lock(_ context.Context, outpoints ...wire.OutPoint) err
 		if _, ok := l.lockedOutpoints[outpoint]; ok {
 			return fmt.Errorf("outpoint %s is already locked", outpoint)
 		}
+	}
 
+	for _, outpoint := range outpoints {
 		l.lockedOutpoints[outpoint] = lockedUntil
 	}
 

--- a/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
+++ b/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
@@ -22,7 +22,11 @@ func newOutpointLocker(lockFor time.Duration) *outpointLocker {
 	}
 }
 
-func (l *outpointLocker) lock(ctx context.Context, outpoints ...wire.OutPoint) error {
+func (l *outpointLocker) lock(_ context.Context, outpoints ...wire.OutPoint) error {
+	if len(outpoints) == 0 {
+		return nil
+	}
+
 	l.locker.Lock()
 	defer l.locker.Unlock()
 
@@ -36,7 +40,7 @@ func (l *outpointLocker) lock(ctx context.Context, outpoints ...wire.OutPoint) e
 	return nil
 }
 
-func (l *outpointLocker) get(ctx context.Context) (map[wire.OutPoint]struct{}, error) {
+func (l *outpointLocker) get(_ context.Context) (map[wire.OutPoint]struct{}, error) {
 	l.locker.Lock()
 	defer l.locker.Unlock()
 

--- a/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
+++ b/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -34,6 +35,10 @@ func (l *outpointLocker) lock(_ context.Context, outpoints ...wire.OutPoint) err
 	lockedUntil := now.Add(l.lockExpiry)
 
 	for _, outpoint := range outpoints {
+		if _, ok := l.lockedOutpoints[outpoint]; ok {
+			return fmt.Errorf("outpoint %s is already locked", outpoint)
+		}
+
 		l.lockedOutpoints[outpoint] = lockedUntil
 	}
 

--- a/pkg/arkd-wallet/core/application/wallet/outpoint_locker_test.go
+++ b/pkg/arkd-wallet/core/application/wallet/outpoint_locker_test.go
@@ -1,0 +1,140 @@
+package wallet
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOutpointLocker(t *testing.T) {
+	lockDuration := 5 * time.Minute
+	locker := newOutpointLocker(lockDuration)
+
+	require.NotNil(t, locker)
+	require.Equal(t, lockDuration, locker.lockExpiry)
+	require.NotNil(t, locker.lockedOutpoints)
+	require.Empty(t, locker.lockedOutpoints)
+}
+
+func TestOutpointLocker_Lock(t *testing.T) {
+	lockDuration := 1 * time.Hour
+	locker := newOutpointLocker(lockDuration)
+
+	hash0 := random32Bytes()
+	hash1 := random32Bytes()
+	outpoint1 := wire.OutPoint{Hash: hash0, Index: 0}
+	outpoint2 := wire.OutPoint{Hash: hash1, Index: 1}
+
+	// test locking single outpoint
+	err := locker.lock(context.Background(), outpoint1)
+	require.NoError(t, err)
+
+	// verify outpoint is locked
+	lockedOutpoints, err := locker.get(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lockedOutpoints, 1)
+	require.Contains(t, lockedOutpoints, outpoint1)
+
+	// test locking multiple outpoints
+	err = locker.lock(context.Background(), outpoint2)
+	require.NoError(t, err)
+
+	// verify both outpoints are locked
+	lockedOutpoints, err = locker.get(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lockedOutpoints, 2)
+	require.Contains(t, lockedOutpoints, outpoint1)
+	require.Contains(t, lockedOutpoints, outpoint2)
+
+	// test locking same outpoint again (should update expiry)
+	time.Sleep(10 * time.Millisecond) // Small delay to ensure different timestamps
+	err = locker.lock(context.Background(), outpoint1)
+	require.NoError(t, err)
+
+	// verify outpoint is still locked with updated expiry
+	lockedOutpoints, err = locker.get(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lockedOutpoints, 2)
+	require.Contains(t, lockedOutpoints, outpoint1)
+	require.Contains(t, lockedOutpoints, outpoint2)
+}
+
+func TestOutpointLocker_Get(t *testing.T) {
+	lockDuration := 100 * time.Millisecond
+	locker := newOutpointLocker(lockDuration)
+
+	hash0 := random32Bytes()
+	hash1 := random32Bytes()
+	outpoint1 := wire.OutPoint{Hash: hash0, Index: 0}
+	outpoint2 := wire.OutPoint{Hash: hash1, Index: 1}
+
+	// lock outpoints
+	err := locker.lock(context.Background(), outpoint1, outpoint2)
+	require.NoError(t, err)
+
+	lockedOutpoints, err := locker.get(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lockedOutpoints, 2)
+	require.Contains(t, lockedOutpoints, outpoint1)
+	require.Contains(t, lockedOutpoints, outpoint2)
+
+	// wait for locks to expire
+	time.Sleep(lockDuration + 50*time.Millisecond)
+
+	lockedOutpoints, err = locker.get(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, lockedOutpoints)
+}
+
+func TestOutpointLocker_ConcurrentGetAndLock(t *testing.T) {
+	// half lock, half get
+	numberOfRoutines := 100
+	lockDuration := 100 * time.Millisecond
+	locker := newOutpointLocker(lockDuration)
+
+	outpoints := make([]wire.OutPoint, 0, 10)
+	for index := range numberOfRoutines / 2 {
+		outpoints = append(outpoints, wire.OutPoint{Hash: random32Bytes(), Index: uint32(index)})
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(numberOfRoutines)
+
+	// start 10 goroutines that lock the outpoint
+	for _, outpoint := range outpoints {
+		go func() {
+			err := locker.lock(context.Background(), outpoint)
+			require.NoError(t, err)
+			wg.Done()
+		}()
+	}
+
+	// start 10 goroutines that get locked outpoints
+	for range numberOfRoutines / 2 {
+		go func() {
+			_, err := locker.get(context.Background())
+			require.NoError(t, err)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	lockedOutpoints, err := locker.get(context.Background())
+	require.NoError(t, err)
+	require.Len(t, lockedOutpoints, len(outpoints))
+	for _, outpoint := range outpoints {
+		require.Contains(t, lockedOutpoints, outpoint)
+	}
+}
+
+func random32Bytes() [32]byte {
+	var b [32]byte
+	rand.Read(b[:])
+	return b
+}


### PR DESCRIPTION
This PR adds unit tests to our `outpointLocker` struct. 

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified key-derivation interface and streamlined key-management flow to reduce internal complexity.

- Tests
  - Added comprehensive unit tests for outpoint locking covering expiry, re-locking, and concurrent access.

- Bug Fixes
  - Skip lock processing for empty inputs to improve performance.
  - Detect and surface duplicate-lock attempts to prevent conflicting locks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->