### PR TITLE
pop intent: check boarding input spent status

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1576,7 +1576,53 @@ func (s *service) startConfirmation(roundTiming roundTiming) {
 	}
 
 	// TODO take into account available liquidity
-	intents := s.cache.Intents().Pop(num)
+	intentsPopped := s.cache.Intents().Pop(num)
+	intents := make([]ports.TimedIntent, 0, len(intentsPopped))
+
+	// for each intent, check if all boarding inputs are unspent
+	// exclude any intent with at least one spent boarding input
+	for _, intent := range intentsPopped {
+		includeIntent := true
+
+		for _, input := range intent.BoardingInputs {
+			spent, err := s.wallet.GetOutpointStatus(ctx, input.Outpoint)
+			if err != nil {
+				log.WithError(err).
+					Warnf("failed to get outpoint status for boarding input %s", input.Outpoint)
+				continue
+			}
+
+			if spent {
+				log.WithField("intent_id", intent.Id).
+					Debugf("boarding input %s is spent", input.Outpoint)
+				includeIntent = false
+				break
+			}
+		}
+
+		if includeIntent {
+			intents = append(intents, intent)
+		}
+	}
+
+	if len(intents) < int(s.roundMinParticipantsCount) {
+		// repush valid intents back to the queue
+		for _, intent := range intents {
+			if err := s.cache.Intents().Push(intent.Intent, intent.BoardingInputs, intent.CosignersPublicKeys); err != nil {
+				log.WithError(err).Warn("failed to re-push intents to the queue")
+				continue
+			}
+		}
+
+		roundAborted = true
+		err := fmt.Errorf(
+			"not enough intents registered %d/%d",
+			len(intents),
+			s.roundMinParticipantsCount,
+		)
+		log.WithError(err).Debugf("round %s aborted", roundId)
+		return
+	}
 
 	s.roundReportSvc.SetIntentsNum(len(intents))
 


### PR DESCRIPTION
After pop intents, the server checks if any boarding inputs are spent or not. It aims to prevent the boarding input to be included in the commitment tx, making the batch session to fail at the very end of the process.

it closes #699 

@altafan @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents progressing with intents that have already-spent inputs, reducing failed or invalid rounds.
  - Ensures participant counts reflect only valid intents, improving round stability.
  - Automatically re-queues valid intents and aborts rounds when below the minimum participant threshold to avoid stuck sessions.
  - Improved error handling and logging for input status checks to aid diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->