### PR TITLE
Fix macaroon revocation

### DIFF
--- a/internal/interface/grpc/macaroons.go
+++ b/internal/interface/grpc/macaroons.go
@@ -55,7 +55,7 @@ func genMacaroons(
 
 	// Create the macaroon files.
 	for macFilename, macPermissions := range macaroonsToGenerate {
-		mktMacBytes, err := svc.BakeMacaroon(ctx, macPermissions)
+		mktMacBytes, err := svc.BakeMacaroon(ctx, macPermissions, macFilename)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
If a macaroon is deleted and generated once again, using the old one won't allow the user to access any resource.