### PR TITLE
docs: add missing breaking changes documentation

### DIFF
--- a/api-spec/BREAKING_CHANGES.md
+++ b/api-spec/BREAKING_CHANGES.md
@@ -1,0 +1,49 @@
+# API Breaking Changes and Best Practices
+
+This document outlines the policies and best practices for evolving the Ark API (Protobuf and OpenAPI) to ensure stability and backward compatibility for clients.
+
+## ⚠️ Important Note on Stability
+
+`arkd` is currently in **Alpha**. While we strive for stability, the API may undergo breaking changes as the protocol matures. This document serves as the guide for how we manage those changes.
+
+## What Constitutes a Breaking Change?
+
+We use [`buf`](https://buf.build/) to automatically detect breaking changes in our Protobuf definitions. The following are considered breaking:
+
+- **Deleting a field**: Removing a field from a message.
+- **Changing a field tag number**: Changing the assigned number (e.g., `string name = 1;` to `string name = 2;`).
+- **Changing a field type**: For example, changing `int32` to `string`.
+- **Changing a field name**: While binary-compatible, this breaks generated code in most languages.
+- **Changing field labels**: For example, changing a field from optional to `repeated`.
+- **Deleting or renaming** a message, enum, service, or method.
+
+## How to Resolve Breaking Changes
+
+If breaking changes are detected by the automated check (`./scripts/check-proto-breaking`), use the following framework to resolve them:
+
+1. **Revert the breaking changes**: If the change was accidental or can be avoided, revert it to maintain compatibility.
+2. **Add new fields**: Instead of modifying existing fields, add new ones with a **new tag number** (the number after the `=`). Use the `[deprecated = true]` option for the old field. This is the preferred way to evolve the API without breaking existing clients.
+   ```proto
+   // Bad: Changing type or name on the same tag number (1)
+   // int32 amount = 1;
+
+   // Good: Keep tag 1 as is, and add tag 2 for the new field
+   int32 amount = 1 [deprecated = true];
+   string amount_v2 = 2;
+   ```
+3. **Use field reservations**: If you must delete a field, reserve its tag number and name in the message to prevent future reuse. Note that deleting a field is still a breaking change and should only be done when a break is acceptable.
+   ```proto
+   message MyMessage {
+     reserved 4, 5 to 10;
+     reserved "old_field";
+   }
+   ```
+4. **Document intentional changes**: If a breaking change is strictly necessary (e.g., for security or fundamental protocol fixes), clearly document the rationale in your Pull Request and coordinate with known client maintainers.
+
+## Verification Tooling
+
+### Automated Check
+We use a script to check for breaking changes against the `master` branch. This script is integrated into our GitHub Actions:
+```sh
+./scripts/check-proto-breaking master
+```

--- a/api-spec/BREAKING_CHANGES.md
+++ b/api-spec/BREAKING_CHANGES.md
@@ -4,7 +4,7 @@ This document outlines the policies and best practices for evolving the Ark API 
 
 ## ⚠️ Important Note on Stability
 
-`arkd` is currently in **Alpha**. While we strive for stability, the API may undergo breaking changes as the protocol matures. This document serves as the guide for how we manage those changes.
+`arkd` is currently in **Alpha**. While we strive for stability, the API may undergo breaking changes as the protocol matures. As the OpenAPI specification is auto-generated from Protobuf definitions (via `buf.gen.yaml`), breaking Protobuf changes will also break the OpenAPI spec.
 
 ## What Constitutes a Breaking Change?
 
@@ -19,7 +19,7 @@ We use [`buf`](https://buf.build/) to automatically detect breaking changes in o
 
 ## How to Resolve Breaking Changes
 
-If breaking changes are detected by the automated check (`./scripts/check-proto-breaking`), use the following framework to resolve them:
+If breaking changes are detected by the automated checks, use the following framework to resolve them:
 
 1. **Revert the breaking changes**: If the change was accidental or can be avoided, revert it to maintain compatibility.
 2. **Add new fields**: Instead of modifying existing fields, add new ones with a **new tag number** (the number after the `=`). Use the `[deprecated = true]` option for the old field. This is the preferred way to evolve the API without breaking existing clients.
@@ -43,7 +43,8 @@ If breaking changes are detected by the automated check (`./scripts/check-proto-
 ## Verification Tooling
 
 ### Automated Check
-We use a script to check for breaking changes against the `master` branch. This script is integrated into our GitHub Actions:
+Local verification can be performed against the `master` branch using the provided script. A similar check runs automatically in GitHub Actions on all Pull Requests:
+
 ```sh
 ./scripts/check-proto-breaking master
 ```


### PR DESCRIPTION
This PR adds the missing `api-spec/BREAKING_CHANGES.md` documentation referenced in the README. It establishes a clear framework for developers to handle Protobuf API evolution while maintaining backward compatibility for clients.

fixes #1006

- Fixes the broken link in the README by adding the `api-spec/BREAKING_CHANGES.md` file.
- Provides a simple 4-step guide for developers on how to update the API without breaking existing users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API evolution and breaking-change policy describing what counts as a breaking change and recommended additive/deprecation practices.
  * Added a step-by-step workflow for resolving breaking-change alerts and guidance on verification tooling integrated into CI and local checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->