### PR TITLE
VerifyTapscriptSigs options

### DIFF
--- a/internal/infrastructure/tx-builder/covenantless/builder.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder.go
@@ -1065,6 +1065,7 @@ func (b *txBuilder) VerifyBoardingTapscriptSigs(
 		ptx,
 		prevoutFetcher,
 		script.WithSkipPublicKeys(signerPubkey),
+		script.WithSkipUnsignedInputs(),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/infrastructure/tx-builder/covenantless/builder.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder.go
@@ -1064,7 +1064,7 @@ func (b *txBuilder) VerifyBoardingTapscriptSigs(
 	ins, err := script.VerifyTapscriptSigs(
 		ptx,
 		prevoutFetcher,
-		[]*btcec.PublicKey{signerPubkey},
+		script.WithSkipPublicKeys(signerPubkey),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ark-lib/intent/proof.go
+++ b/pkg/ark-lib/intent/proof.go
@@ -103,7 +103,6 @@ func Verify(proofB64, message string, skip []*btcec.PublicKey) error {
 	if _, err := script.VerifyTapscriptSigs(
 		ptx, prevoutFetcher,
 		script.WithSkipPublicKeys(skip...),
-		script.WithoutSkipUnsignedInput(),
 	); err != nil {
 		return fmt.Errorf("invalid intent proof: %w", err)
 	}

--- a/pkg/ark-lib/intent/proof.go
+++ b/pkg/ark-lib/intent/proof.go
@@ -3,7 +3,6 @@ package intent
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -101,42 +100,27 @@ func Verify(proofB64, message string, skip []*btcec.PublicKey) error {
 		return ErrInvalidTxWrongOutputIndex
 	}
 
-	signedInputs, err := script.VerifyTapscriptSigs(ptx, prevoutFetcher, skip)
-	if err != nil {
+	if _, err := script.VerifyTapscriptSigs(
+		ptx, prevoutFetcher,
+		script.WithSkipPublicKeys(skip...),
+		script.WithoutSkipUnsignedInput(),
+	); err != nil {
 		return fmt.Errorf("invalid intent proof: %w", err)
 	}
 
-	// Ensure every ownership input (index 1+) was actually validated.
-	// VerifyTapscriptSigs silently skips unsigned inputs, so we must check
-	// that no applicable input slipped through without a signature.
-	signedSet := make(map[int]struct{}, len(signedInputs))
-	for _, idx := range signedInputs {
-		signedSet[idx] = struct{}{}
-	}
+	// Note closures use hash-locks, not signatures — VerifyTapscriptSigs
+	// skips them entirely, so we must verify the preimage here.
 	for i := 1; i < len(ptx.Inputs); i++ {
-		if _, ok := signedSet[i]; ok {
+		in := ptx.Inputs[i]
+		if len(in.TaprootLeafScript) != 1 {
 			continue
 		}
-
-		in := ptx.Inputs[i]
-		if len(in.TaprootLeafScript) == 1 {
-			// Note closures use hash-locks, not signatures — verify the
-			// preimage and control block instead.
-			if script.IsNoteClosureScript(in.TaprootLeafScript[0].Script) {
-				if err := verifyNoteInput(ptx, i, prevoutFetcher); err != nil {
-					return fmt.Errorf("invalid intent proof: %w", err)
-				}
-				continue
-			}
-
-			// For unsigned condition closures, the input is valid only if
-			// every expected signer is in the skip list.
-			if allSignersSkipped(in.TaprootLeafScript[0].Script, skip) {
-				continue
-			}
+		if !script.IsNoteClosureScript(in.TaprootLeafScript[0].Script) {
+			continue
 		}
-
-		return fmt.Errorf("missing signature for input %d", i)
+		if err := verifyNoteInput(ptx, i, prevoutFetcher); err != nil {
+			return fmt.Errorf("invalid intent proof: %w", err)
+		}
 	}
 
 	return nil
@@ -458,33 +442,3 @@ func verifyNoteInput(
 	return nil
 }
 
-// allSignersSkipped returns true if every public key in the closure
-// is present in the skip list.
-func allSignersSkipped(closureScript []byte, skip []*btcec.PublicKey) bool {
-	closure, err := script.DecodeClosure(closureScript)
-	if err != nil {
-		return false
-	}
-
-	var pubKeys []*btcec.PublicKey
-	switch c := closure.(type) {
-	case *script.ConditionMultisigClosure:
-		pubKeys = c.PubKeys
-	case *script.ConditionCSVMultisigClosure:
-		pubKeys = c.PubKeys
-	default:
-		return false
-	}
-
-	skipSet := make(map[string]struct{}, len(skip))
-	for _, k := range skip {
-		skipSet[hex.EncodeToString(schnorr.SerializePubKey(k))] = struct{}{}
-	}
-
-	for _, k := range pubKeys {
-		if _, ok := skipSet[hex.EncodeToString(schnorr.SerializePubKey(k))]; !ok {
-			return false
-		}
-	}
-	return len(pubKeys) > 0
-}

--- a/pkg/ark-lib/intent/proof.go
+++ b/pkg/ark-lib/intent/proof.go
@@ -113,8 +113,9 @@ func Verify(proofB64, message string, skip []*btcec.PublicKey) error {
 	for i := 1; i < len(ptx.Inputs); i++ {
 		in := ptx.Inputs[i]
 		if len(in.TaprootLeafScript) != 1 {
-			continue
+			return fmt.Errorf("malformed input %d: missing TaprootLeafScript", i)
 		}
+		
 		if !script.IsNoteClosureScript(in.TaprootLeafScript[0].Script) {
 			continue
 		}

--- a/pkg/ark-lib/script/verify.go
+++ b/pkg/ark-lib/script/verify.go
@@ -14,8 +14,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
-
-
 type VerifyTapscriptOption func(*verifyTapscriptOptions)
 
 type verifyTapscriptOptions struct {
@@ -41,10 +39,11 @@ func WithSkipPublicKeys(keys ...*btcec.PublicKey) VerifyTapscriptOption {
 	}
 }
 
-// WithoutSkipUnsignedInput makes the func returns an error if any input is unsigned
-func WithoutSkipUnsignedInput() VerifyTapscriptOption {
+// WithSkipUnsignedInputs makes the func ignore unsigned inputs instead of
+// returning an error.
+func WithSkipUnsignedInputs() VerifyTapscriptOption {
 	return func(o *verifyTapscriptOptions) {
-		o.skipUnsignedInputs = false
+		o.skipUnsignedInputs = true
 	}
 }
 
@@ -53,8 +52,7 @@ func VerifyTapscriptSigs(
 	tx *psbt.Packet, prevoutFetcher txscript.PrevOutputFetcher,
 	opts ...VerifyTapscriptOption,
 ) (signedInputs []int, err error) {
-	// skip unsigned input by default
-	options := &verifyTapscriptOptions{skipUnsignedInputs: true}
+	options := &verifyTapscriptOptions{}
 	for _, opt := range opts {
 		opt(options)
 	}

--- a/pkg/ark-lib/script/verify.go
+++ b/pkg/ark-lib/script/verify.go
@@ -12,12 +12,52 @@ import (
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
-// VerifyTapscriptSigs verifies the tapscript signatures of the given tx
-// it skips inputs that are not signed or do not specify a taproot leaf script
-func VerifyTapscriptSigs(tx *psbt.Packet, prevoutFetcher txscript.PrevOutputFetcher, skip []*secp256k1.PublicKey) (signedInputs []int, err error) {
+
+
+type VerifyTapscriptOption func(*verifyTapscriptOptions)
+
+type verifyTapscriptOptions struct {
+	skipPublicKeys     []string // x-only hex encoded
+	skipUnsignedInputs bool
+}
+
+// WithSkipPublicKeys sets the key to ignore in signature validation
+func WithSkipPublicKeys(keys ...*btcec.PublicKey) VerifyTapscriptOption {
+	return func(o *verifyTapscriptOptions) {
+		encoded := make([]string, 0, len(keys))
+		for _, pubkey := range keys {
+			xonly := hex.EncodeToString(schnorr.SerializePubKey(pubkey))
+
+			if slices.Contains(encoded, xonly) {
+				continue // avoid duplication
+			}
+
+			encoded = append(encoded, xonly)
+		}
+
+		o.skipPublicKeys = encoded
+	}
+}
+
+// WithoutSkipUnsignedInput makes the func returns an error if any input is unsigned
+func WithoutSkipUnsignedInput() VerifyTapscriptOption {
+	return func(o *verifyTapscriptOptions) {
+		o.skipUnsignedInputs = false
+	}
+}
+
+// VerifyTapscriptSigs verifies the tapscript signatures of the given tx.
+func VerifyTapscriptSigs(
+	tx *psbt.Packet, prevoutFetcher txscript.PrevOutputFetcher,
+	opts ...VerifyTapscriptOption,
+) (signedInputs []int, err error) {
+	// skip unsigned input by default
+	options := &verifyTapscriptOptions{skipUnsignedInputs: true}
+	for _, opt := range opts {
+		opt(options)
+	}
 	if len(tx.Inputs) != len(tx.UnsignedTx.TxIn) {
 		return nil, fmt.Errorf(
 			"malformed tx: number of psbt inputs (%d) does not match number of tx inputs (%d)",
@@ -145,9 +185,21 @@ func VerifyTapscriptSigs(tx *psbt.Packet, prevoutFetcher txscript.PrevOutputFetc
 			)
 		}
 
-		// skip if not signed
 		if len(input.TaprootScriptSpendSig) == 0 {
-			continue
+			if options.skipUnsignedInputs {
+				continue
+			}
+
+			// if options.skipUnsignedInputs = false, return an error 
+			// only if one of the expected signer is not in skipPublicKeys
+			// otherwise it means we skip all signers
+			for key := range expectedSigners {
+				if !slices.Contains(options.skipPublicKeys, key) {
+					return nil, fmt.Errorf(
+						"input %d has no tapscript signatures", inputIndex,
+					)
+				}
+			}
 		}
 
 		leaf := txscript.NewBaseTapLeaf(tapscriptLeaf.Script)
@@ -208,13 +260,8 @@ func VerifyTapscriptSigs(tx *psbt.Packet, prevoutFetcher txscript.PrevOutputFetc
 
 		signedInputs = append(signedInputs, inputIndex)
 
-		ignore := make([]string, 0, len(skip))
-		for _, pubkey := range skip {
-			ignore = append(ignore, hex.EncodeToString(schnorr.SerializePubKey(pubkey)))
-		}
-
 		for key, hasSig := range expectedSigners {
-			if slices.Contains(ignore, key) {
+			if slices.Contains(options.skipPublicKeys, key) {
 				continue
 			}
 

--- a/pkg/ark-lib/script/verify.go
+++ b/pkg/ark-lib/script/verify.go
@@ -190,7 +190,7 @@ func VerifyTapscriptSigs(
 				continue
 			}
 
-			// if options.skipUnsignedInputs = false, return an error 
+			// if options.skipUnsignedInputs = false, return an error
 			// only if one of the expected signer is not in skipPublicKeys
 			// otherwise it means we skip all signers
 			for key := range expectedSigners {
@@ -200,6 +200,8 @@ func VerifyTapscriptSigs(
 					)
 				}
 			}
+			// all signers are skipped, treat input as not signed
+			continue
 		}
 
 		leaf := txscript.NewBaseTapLeaf(tapscriptLeaf.Script)

--- a/pkg/ark-lib/script/verify_test.go
+++ b/pkg/ark-lib/script/verify_test.go
@@ -33,7 +33,9 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			packet, prevoutFetcher := buildTx(t, setup)
 			// No signatures added.
 
-			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
+			signedInputs, err := script.VerifyTapscriptSigs(
+				packet, prevoutFetcher, script.WithSkipUnsignedInputs(),
+			)
 			require.NoError(t, err)
 			require.Empty(t, signedInputs)
 		})
@@ -161,14 +163,12 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			require.Error(t, err)
 		})
 
-		t.Run("WithoutSkipUnsignedInput errors on unsigned input", func(t *testing.T) {
+		t.Run("unsigned input errors by default", func(t *testing.T) {
 			setup := newSingleKeySetup(t)
 			packet, prevoutFetcher := buildTx(t, setup)
 			// No signatures added.
 
-			_, err := script.VerifyTapscriptSigs(
-				packet, prevoutFetcher, script.WithoutSkipUnsignedInput(),
-			)
+			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.Error(t, err)
 		})
 

--- a/pkg/ark-lib/script/verify_test.go
+++ b/pkg/ark-lib/script/verify_test.go
@@ -23,7 +23,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			sig := makeSignature(t, setup.privKey, packet, 0, setup.leaf, prevoutFetcher)
 			packet.Inputs[0].TaprootScriptSpendSig = []*psbt.TaprootScriptSpendSig{sig}
 
-			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.NoError(t, err)
 			require.Equal(t, []int{0}, signedInputs)
 		})
@@ -33,7 +33,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			packet, prevoutFetcher := buildTx(t, setup)
 			// No signatures added.
 
-			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.NoError(t, err)
 			require.Empty(t, signedInputs)
 		})
@@ -47,7 +47,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			packet.Inputs[0].TaprootScriptSpendSig = []*psbt.TaprootScriptSpendSig{sig1}
 
 			signedInputs, err := script.VerifyTapscriptSigs(
-				packet, prevoutFetcher, []*btcec.PublicKey{privKey2.PubKey()},
+				packet, prevoutFetcher, script.WithSkipPublicKeys(privKey2.PubKey()),
 			)
 			require.NoError(t, err)
 			require.Equal(t, []int{0}, signedInputs)
@@ -68,7 +68,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			prevoutFetcher, err := txutils.GetPrevOutputFetcher(packet)
 			require.NoError(t, err)
 
-			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.NoError(t, err)
 			require.Empty(t, signedInputs)
 		})
@@ -87,7 +87,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 
 			packet.Inputs[0].TaprootLeafScript[0].Script = noteScript
 
-			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.NoError(t, err)
 			require.Empty(t, signedInputs)
 		})
@@ -98,7 +98,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 
 			packet.Inputs[0].TaprootLeafScript = nil
 
-			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			signedInputs, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.NoError(t, err)
 			require.Empty(t, signedInputs)
 		})
@@ -115,7 +115,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			corrupted[0] ^= 0x01
 			packet.Inputs[0].TaprootLeafScript[0].ControlBlock = corrupted
 
-			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.Error(t, err)
 		})
 
@@ -132,7 +132,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			corrupted := append(append([]byte{}, setup.controlBlockBytes...), fakeNode...)
 			packet.Inputs[0].TaprootLeafScript[0].ControlBlock = corrupted
 
-			_, err = script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			_, err = script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.Error(t, err)
 		})
 
@@ -145,7 +145,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			sig.Signature[0] ^= 0xff
 			packet.Inputs[0].TaprootScriptSpendSig = []*psbt.TaprootScriptSpendSig{sig}
 
-			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.Error(t, err)
 		})
 
@@ -157,7 +157,18 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			sig1 := makeSignature(t, setup.privKey, packet, 0, setup.leaf, prevoutFetcher)
 			packet.Inputs[0].TaprootScriptSpendSig = []*psbt.TaprootScriptSpendSig{sig1}
 
-			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			_, err := script.VerifyTapscriptSigs(packet, prevoutFetcher)
+			require.Error(t, err)
+		})
+
+		t.Run("WithoutSkipUnsignedInput errors on unsigned input", func(t *testing.T) {
+			setup := newSingleKeySetup(t)
+			packet, prevoutFetcher := buildTx(t, setup)
+			// No signatures added.
+
+			_, err := script.VerifyTapscriptSigs(
+				packet, prevoutFetcher, script.WithoutSkipUnsignedInput(),
+			)
 			require.Error(t, err)
 		})
 
@@ -171,7 +182,7 @@ func TestVerifyTapscriptSigs(t *testing.T) {
 			require.NoError(t, err)
 			packet.Inputs[0].TaprootScriptSpendSig = []*psbt.TaprootScriptSpendSig{sig}
 
-			_, err = script.VerifyTapscriptSigs(packet, prevoutFetcher, nil)
+			_, err = script.VerifyTapscriptSigs(packet, prevoutFetcher)
 			require.Error(t, err)
 		})
 	})


### PR DESCRIPTION
add `WithSkipPublicKeys` and `WithoutSkipUnsignedInput` options to VerifyTapscriptSigs. It also simplify `intent.Verify`.

it closes #1013 

@altafan please review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Signature verification now uses an options-based configuration for more flexible control over which signers or unsigned inputs are skipped.
  * Verification routines reworked to rely on the new configuration model.

* **Bug Fixes**
  * Validation tightened for certain input types; unsigned inputs are treated as error by default unless explicitly skipped.

* **Tests**
  * Updated and expanded tests to cover the new options behavior and unsigned-input error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->