### PR TITLE
Hardcode 1 week unil exit delay on mainnet

### DIFF
--- a/pkg/client-lib/init.go
+++ b/pkg/client-lib/init.go
@@ -85,6 +85,12 @@ func (a *service) init(
 		return fmt.Errorf("failed to parse forfeit pubkey: %s", err)
 	}
 
+	// TODO: Drop me once go-sdk handles arkd config changes properly
+	unilateralExitDelay := uint32(info.UnilateralExitDelay)
+	if network.Name == arklib.Bitcoin.Name {
+		unilateralExitDelay = 605184
+	}
+
 	unilateralExitDelayType := arklib.LocktimeTypeBlock
 	if info.UnilateralExitDelay >= 512 {
 		unilateralExitDelayType = arklib.LocktimeTypeSecond
@@ -103,7 +109,7 @@ func (a *service) init(
 		Network:         network,
 		SessionDuration: info.SessionDuration,
 		UnilateralExitDelay: arklib.RelativeLocktime{
-			Type: unilateralExitDelayType, Value: uint32(info.UnilateralExitDelay),
+			Type: unilateralExitDelayType, Value: unilateralExitDelay,
 		},
 		Dust: info.Dust,
 		BoardingExitDelay: arklib.RelativeLocktime{


### PR DESCRIPTION
Closes #1016.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated exit delay configuration for Bitcoin network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->