### PR TITLE
Redis Live-store: make Pop() and Delete() transactionnal

### DIFF
--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -159,6 +159,19 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 				return fmt.Errorf("failed to get intent ids: %v", err)
 			}
 
+			// Watch each intent body so a concurrent Update() on any of them
+			// aborts this tx and we re-read the fresh Inputs/BoardingInputs
+			// before writing to intentStoreVtxosToRemoveKey.
+			if len(ids) > 0 {
+				bodyKeys := make([]string, 0, len(ids))
+				for _, id := range ids {
+					bodyKeys = append(bodyKeys, s.intents.Key(id))
+				}
+				if err := tx.Watch(ctx, bodyKeys...).Err(); err != nil {
+					return fmt.Errorf("failed to watch intent bodies: %v", err)
+				}
+			}
+
 			// fetch intents
 			var intentsByTime []ports.TimedIntent
 			for _, id := range ids {
@@ -319,8 +332,10 @@ func (s *intentStore) Update(
 }
 
 func (s *intentStore) Delete(ctx context.Context, ids []string) error {
-	watchKeys := []string{intentStoreIdsKey, intentStoreVtxosKey}
 	for _, id := range ids {
+		// Watch the intent body so a concurrent Update() aborts this tx and
+		// we re-read the fresh Inputs/BoardingInputs before SREM-ing vtxos.
+		watchKeys := []string{intentStoreIdsKey, intentStoreVtxosKey, s.intents.Key(id)}
 		var err error
 		for range s.numOfRetries {
 			err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {

--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -3,6 +3,7 @@ package redislivestore
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -141,73 +142,91 @@ func (s *intentStore) Push(
 }
 
 func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, error) {
-	// clear selected intents list
-	if err := s.rdb.Del(ctx, selectedIntentsKey).Err(); err != nil {
-		return nil, fmt.Errorf("failed to clear selected intents: %v", err)
+	watchKeys := []string{
+		intentStoreIdsKey,
+		intentStoreVtxosToRemoveKey,
+		selectedIntentsKey,
 	}
 
-	ids, err := s.rdb.SMembers(ctx, intentStoreIdsKey).Result()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get intent ids: %v", err)
-	}
-
-	var intentsByTime []ports.TimedIntent
-	for _, id := range ids {
-		intent, err := s.intents.Get(ctx, id)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get intent %s: %v", id, err)
-		}
-
-		if intent == nil {
-			log.Warnf("got nil intent for id %s", id)
-			continue
-		}
-
-		if len(intent.Receivers) > 0 {
-			intentsByTime = append(intentsByTime, *intent)
-		}
-	}
-
-	sort.SliceStable(intentsByTime, func(i, j int) bool {
-		return intentsByTime[i].Timestamp.Before(intentsByTime[j].Timestamp)
-	})
-	if num < 0 || num > int64(len(intentsByTime)) {
-		num = int64(len(intentsByTime))
-	}
-
-	result := make([]ports.TimedIntent, 0, num)
-	var inputsToRemove []string
-	for _, intent := range intentsByTime[:num] {
-		result = append(result, intent)
-		for _, vtxo := range intent.Inputs {
-			inputsToRemove = append(inputsToRemove, vtxo.Outpoint.String())
-		}
-		for _, boardingInput := range intent.BoardingInputs {
-			inputsToRemove = append(inputsToRemove, boardingInput.String())
-		}
-
-		if err := s.intents.Delete(ctx, intent.Id); err != nil {
-			return nil, fmt.Errorf("failed to delete intent %s: %v", intent.Id, err)
-		}
-
-		s.rdb.SRem(ctx, intentStoreIdsKey, intent.Id)
-	}
-
-	if len(inputsToRemove) > 0 {
-		s.rdb.SAdd(ctx, intentStoreVtxosToRemoveKey, inputsToRemove)
-	}
-
-	if len(result) > 0 {
-		// push each selected intent to the list
-		for _, intent := range result {
-			if err := s.intents.ListPush(ctx, selectedIntentsKey, &intent); err != nil {
-				return nil, fmt.Errorf(
-					"failed to add intent to list of selected %s: %v", intent.Id, err,
-				)
+	var result []ports.TimedIntent
+	var err error
+	for range s.numOfRetries {
+		err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {
+			// list all ids
+			ids, err := s.rdb.SMembers(ctx, intentStoreIdsKey).Result()
+			if err != nil {
+				return fmt.Errorf("failed to get intent ids: %v", err)
 			}
+
+			// fetch intents
+			var intentsByTime []ports.TimedIntent
+			for _, id := range ids {
+				intent, err := s.intents.Get(ctx, id)
+				if err != nil {
+					return fmt.Errorf("failed to get intent %s: %v", id, err)
+				}
+				if intent == nil {
+					log.Warnf("got nil intent for id %s", id)
+					continue
+				}
+				if len(intent.Receivers) > 0 {
+					intentsByTime = append(intentsByTime, *intent)
+				}
+			}
+
+			// sort by time
+			sort.SliceStable(intentsByTime, func(i, j int) bool {
+				return intentsByTime[i].Timestamp.Before(intentsByTime[j].Timestamp)
+			})
+			n := num
+			if n < 0 || n > int64(len(intentsByTime)) {
+				n = int64(len(intentsByTime))
+			}
+			selected := intentsByTime[:n]
+
+			// list outpoints to remove
+			var inputsToRemove []interface{}
+			for _, intent := range selected {
+				for _, vtxo := range intent.Inputs {
+					inputsToRemove = append(inputsToRemove, vtxo.Outpoint.String())
+				}
+				for _, boardingInput := range intent.BoardingInputs {
+					inputsToRemove = append(inputsToRemove, boardingInput.String())
+				}
+			}
+
+			// delete intent, intent id and add outpoints to "vtxosToRemove" in the same transaction
+			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Del(ctx, selectedIntentsKey)
+				for i := range selected {
+					intent := selected[i]
+					pipe.Del(ctx, "intent:"+intent.Id)
+					pipe.SRem(ctx, intentStoreIdsKey, intent.Id)
+					if err := s.intents.ListPushPipe(
+						ctx, pipe, selectedIntentsKey, &intent,
+					); err != nil {
+						return err
+					}
+				}
+
+				if len(inputsToRemove) > 0 {
+					pipe.SAdd(ctx, intentStoreVtxosToRemoveKey, inputsToRemove...)
+				}
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+			// safe copy to result
+			result = slices.Clone(selected)
+			return nil
+		}, watchKeys...)
+		if err == nil {
+			return result, nil
 		}
+		time.Sleep(s.retryDelay)
 	}
-	return result, nil
+	return nil, fmt.Errorf("failed to pop intents after max number of retries: %v", err)
 }
 
 func (s *intentStore) GetSelectedIntents(ctx context.Context) ([]ports.TimedIntent, error) {
@@ -295,27 +314,42 @@ func (s *intentStore) Update(
 }
 
 func (s *intentStore) Delete(ctx context.Context, ids []string) error {
+	watchKeys := []string{intentStoreIdsKey, intentStoreVtxosKey}
 	for _, id := range ids {
-		intent, err := s.intents.Get(ctx, id)
+		var err error
+		for range s.numOfRetries {
+			err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {
+				// get intent by id
+				intent, err := s.intents.Get(ctx, id)
+				if err != nil {
+					return fmt.Errorf("failed to get intent %s: %v", id, err)
+				}
+				if intent == nil {
+					// ignore nil intent as defensive check to avoid dereference panic
+					return nil 
+				}
+				// delete intent id + outpoints in the same tx pipeline
+				_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+					for _, vtxo := range intent.Inputs {
+						pipe.SRem(ctx, intentStoreVtxosKey, vtxo.Outpoint.String())
+					}
+					for _, boardingInput := range intent.BoardingInputs {
+						pipe.SRem(ctx, intentStoreVtxosKey, boardingInput.String())
+					}
+					pipe.Del(ctx, "intent:"+id)
+					pipe.SRem(ctx, intentStoreIdsKey, id)
+					return nil
+				})
+				return err
+			}, watchKeys...)
+			if err == nil {
+				break
+			}
+			time.Sleep(s.retryDelay)
+		}
 		if err != nil {
-			return fmt.Errorf("failed to get intent %s: %v", id, err)
+			log.Warnf("delete: failed to delete intent %s: %v", id, err)
 		}
-		if intent == nil {
-			continue
-		}
-
-		for _, vtxo := range intent.Inputs {
-			s.rdb.SRem(ctx, intentStoreVtxosKey, vtxo.Outpoint.String())
-		}
-		for _, boardingInput := range intent.BoardingInputs {
-			s.rdb.SRem(ctx, intentStoreVtxosKey, boardingInput.String())
-		}
-
-		if err := s.intents.Delete(ctx, id); err != nil {
-			log.Warnf("delete:failed to delete intent %s: %v", id, err)
-		}
-
-		s.rdb.SRem(ctx, intentStoreIdsKey, id)
 	}
 	return nil
 }

--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -326,7 +326,7 @@ func (s *intentStore) Delete(ctx context.Context, ids []string) error {
 				}
 				if intent == nil {
 					// ignore nil intent as defensive check to avoid dereference panic
-					return nil 
+					return nil
 				}
 				// delete intent id + outpoints in the same tx pipeline
 				_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {

--- a/internal/infrastructure/live-store/redis/intents.go
+++ b/internal/infrastructure/live-store/redis/intents.go
@@ -2,6 +2,7 @@ package redislivestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -153,7 +154,7 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 	for range s.numOfRetries {
 		err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {
 			// list all ids
-			ids, err := s.rdb.SMembers(ctx, intentStoreIdsKey).Result()
+			ids, err := tx.SMembers(ctx, intentStoreIdsKey).Result()
 			if err != nil {
 				return fmt.Errorf("failed to get intent ids: %v", err)
 			}
@@ -161,7 +162,7 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 			// fetch intents
 			var intentsByTime []ports.TimedIntent
 			for _, id := range ids {
-				intent, err := s.intents.Get(ctx, id)
+				intent, err := s.intents.GetWith(ctx, tx, id)
 				if err != nil {
 					return fmt.Errorf("failed to get intent %s: %v", id, err)
 				}
@@ -200,7 +201,7 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 				pipe.Del(ctx, selectedIntentsKey)
 				for i := range selected {
 					intent := selected[i]
-					pipe.Del(ctx, "intent:"+intent.Id)
+					s.intents.DeletePipe(ctx, pipe, intent.Id)
 					pipe.SRem(ctx, intentStoreIdsKey, intent.Id)
 					if err := s.intents.ListPushPipe(
 						ctx, pipe, selectedIntentsKey, &intent,
@@ -223,6 +224,10 @@ func (s *intentStore) Pop(ctx context.Context, num int64) ([]ports.TimedIntent, 
 		}, watchKeys...)
 		if err == nil {
 			return result, nil
+		}
+		// only retry on transient WATCH conflicts; propagate any other error.
+		if !errors.Is(err, redis.TxFailedErr) {
+			return nil, fmt.Errorf("failed to pop intents: %v", err)
 		}
 		time.Sleep(s.retryDelay)
 	}
@@ -320,7 +325,7 @@ func (s *intentStore) Delete(ctx context.Context, ids []string) error {
 		for range s.numOfRetries {
 			err = s.rdb.Watch(ctx, func(tx *redis.Tx) error {
 				// get intent by id
-				intent, err := s.intents.Get(ctx, id)
+				intent, err := s.intents.GetWith(ctx, tx, id)
 				if err != nil {
 					return fmt.Errorf("failed to get intent %s: %v", id, err)
 				}
@@ -336,7 +341,7 @@ func (s *intentStore) Delete(ctx context.Context, ids []string) error {
 					for _, boardingInput := range intent.BoardingInputs {
 						pipe.SRem(ctx, intentStoreVtxosKey, boardingInput.String())
 					}
-					pipe.Del(ctx, "intent:"+id)
+					s.intents.DeletePipe(ctx, pipe, id)
 					pipe.SRem(ctx, intentStoreIdsKey, id)
 					return nil
 				})
@@ -345,10 +350,14 @@ func (s *intentStore) Delete(ctx context.Context, ids []string) error {
 			if err == nil {
 				break
 			}
+			// only retry on transient WATCH conflicts; stop on terminal errors.
+			if !errors.Is(err, redis.TxFailedErr) {
+				break
+			}
 			time.Sleep(s.retryDelay)
 		}
 		if err != nil {
-			log.Warnf("delete: failed to delete intent %s: %v", id, err)
+			return fmt.Errorf("failed to delete intent %s: %v", id, err)
 		}
 	}
 	return nil

--- a/internal/infrastructure/live-store/redis/intents_test.go
+++ b/internal/infrastructure/live-store/redis/intents_test.go
@@ -1,8 +1,16 @@
 package redislivestore
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/arkade-os/arkd/internal/core/domain"
+	"github.com/arkade-os/arkd/internal/core/ports"
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
@@ -36,4 +44,136 @@ func TestPopNilIntent(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, popped)
 	})
+}
+
+// TestPopAndDeleteWatchIntentBody verifies that Pop() and Delete() add the
+// per-intent body key (`intent:<id>`) to their WATCH set, so a concurrent
+// Update() on the same intent aborts the transaction with TxFailedErr rather
+// than committing stale outpoints to intent:vtxos / intent:vtxosToRemove.
+func TestPopAndDeleteWatchIntentBody(t *testing.T) {
+	ctx := t.Context()
+
+	redisOpts, err := redis.ParseURL("redis://localhost:6379/2")
+	require.NoError(t, err)
+	rdb := redis.NewClient(redisOpts)
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	hook := &watchHook{}
+	rdb.AddHook(hook)
+
+	s, ok := NewIntentStore(rdb, 3).(*intentStore)
+	require.True(t, ok)
+	t.Cleanup(func() { _ = s.DeleteAll(ctx) })
+	require.NoError(t, s.DeleteAll(ctx))
+
+	// seed a minimal intent body without going through Push (which would
+	// pollute the hook with its own WATCH calls)
+	id := "raceintent-" + uuid.New().String()
+	body, err := json.Marshal(ports.TimedIntent{
+		Intent: domain.Intent{
+			Id: id,
+			Inputs: []domain.Vtxo{
+				{Outpoint: domain.Outpoint{Txid: "aa", VOut: 0}},
+			},
+			Receivers: []domain.Receiver{{Amount: 1, PubKey: "pk"}},
+		},
+		Timestamp: time.Now(),
+	})
+	require.NoError(t, err)
+	bodyKey := s.intents.Key(id)
+	require.NoError(t, rdb.Set(ctx, bodyKey, body, 0).Err())
+	require.NoError(t, rdb.SAdd(ctx, intentStoreIdsKey, id).Err())
+
+	t.Run("pop watches intent body", func(t *testing.T) {
+		hook.mu.Lock()
+		hook.sets = nil
+		hook.mu.Unlock()
+
+		_, err := s.Pop(ctx, 1)
+		require.NoError(t, err)
+
+		watched := hook.watchedKeys()
+		require.Contains(t, watched, bodyKey)
+	})
+
+	// re-seed for the Delete subtest (Pop consumes the intent)
+	require.NoError(t, rdb.Set(ctx, bodyKey, body, 0).Err())
+	require.NoError(t, rdb.SAdd(ctx, intentStoreIdsKey, id).Err())
+
+	t.Run("delete watches intent body", func(t *testing.T) {
+		hook.mu.Lock()
+		hook.sets = nil
+		hook.mu.Unlock()
+
+		require.NoError(t, s.Delete(ctx, []string{id}))
+
+		watched := hook.watchedKeys()
+		require.Contains(t, watched, bodyKey)
+	})
+
+	// And: end-to-end — a concurrent body overwrite between WATCH and EXEC
+	// must abort the transaction with TxFailedErr, proving WATCH is active.
+	t.Run("watch detects concurrent body update", func(t *testing.T) {
+		require.NoError(t, rdb.Set(ctx, bodyKey, body, 0).Err())
+		require.NoError(t, rdb.SAdd(ctx, intentStoreIdsKey, id).Err())
+
+		err := rdb.Watch(ctx, func(tx *redis.Tx) error {
+			// overwrite the body from an unrelated connection
+			require.NoError(t, rdb.Set(ctx, bodyKey, body, 0).Err())
+			_, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.SRem(ctx, intentStoreIdsKey, id)
+				return nil
+			})
+			return err
+		}, intentStoreIdsKey, bodyKey)
+
+		require.True(t, errors.Is(err, redis.TxFailedErr))
+	})
+}
+
+// watchHook records the key sets passed to every WATCH command issued on the
+// connection it is attached to, so tests can assert what a caller watched.
+type watchHook struct {
+	mu   sync.Mutex
+	sets [][]string
+}
+
+func (h *watchHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+
+func (h *watchHook) ProcessPipelineHook(
+	next redis.ProcessPipelineHook,
+) redis.ProcessPipelineHook {
+	return next
+}
+
+func (h *watchHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		args := cmd.Args()
+		if len(args) > 0 {
+			if name, ok := args[0].(string); ok && strings.EqualFold(name, "watch") {
+				keys := make([]string, 0, len(args)-1)
+				for _, a := range args[1:] {
+					if s, ok := a.(string); ok {
+						keys = append(keys, s)
+					}
+				}
+				h.mu.Lock()
+				h.sets = append(h.sets, keys)
+				h.mu.Unlock()
+			}
+		}
+		return next(ctx, cmd)
+	}
+}
+
+func (h *watchHook) watchedKeys() map[string]struct{} {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := map[string]struct{}{}
+	for _, set := range h.sets {
+		for _, k := range set {
+			out[k] = struct{}{}
+		}
+	}
+	return out
 }

--- a/internal/infrastructure/live-store/redis/intents_test.go
+++ b/internal/infrastructure/live-store/redis/intents_test.go
@@ -12,7 +12,9 @@ import (
 func TestPopNilIntent(t *testing.T) {
 	ctx := t.Context()
 	
-	redisOpts, err := redis.ParseURL("redis://localhost:6379/0")
+	// use /1 to isolate from TestLiveStoreImplementations which uses /0
+	// it avoids race condition where DeleteAll clean the intent list before the end of the test
+	redisOpts, err := redis.ParseURL("redis://localhost:6379/1")
 	require.NoError(t, err)
 	rdb := redis.NewClient(redisOpts)
 

--- a/internal/infrastructure/live-store/redis/intents_test.go
+++ b/internal/infrastructure/live-store/redis/intents_test.go
@@ -11,7 +11,7 @@ import (
 // TestPopNilIntent ensures Pop doesn't panic when intent:ids contains an id whose intent:<id> body is "nil"
 func TestPopNilIntent(t *testing.T) {
 	ctx := t.Context()
-	
+
 	// use /1 to isolate from TestLiveStoreImplementations which uses /0
 	// it avoids race condition where DeleteAll clean the intent list before the end of the test
 	redisOpts, err := redis.ParseURL("redis://localhost:6379/1")

--- a/internal/infrastructure/live-store/redis/kv.go
+++ b/internal/infrastructure/live-store/redis/kv.go
@@ -22,6 +22,12 @@ func (s *KVStore[T]) key(id string) string {
 	return s.prefix + id
 }
 
+// Key returns the fully-prefixed Redis key for id, so callers can WATCH a
+// specific entry without leaking the KVStore prefix.
+func (s *KVStore[T]) Key(id string) string {
+	return s.key(id)
+}
+
 func (s *KVStore[T]) Get(ctx context.Context, id string) (*T, error) {
 	return s.getWith(ctx, s.rdb, id)
 }

--- a/internal/infrastructure/live-store/redis/kv.go
+++ b/internal/infrastructure/live-store/redis/kv.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/arkade-os/arkd/internal/core/ports"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -17,11 +16,6 @@ type KVStore[T any] struct {
 
 func NewRedisKVStore[T any](rdb *redis.Client, prefix string) *KVStore[T] {
 	return &KVStore[T]{rdb: rdb, prefix: prefix}
-}
-
-// NewIntentKVStore returns a KVStore for TimedIntent with the proper prefix.
-func NewIntentKVStore(rdb *redis.Client) *KVStore[ports.TimedIntent] {
-	return &KVStore[ports.TimedIntent]{rdb: rdb, prefix: "intent:"}
 }
 
 func (s *KVStore[T]) key(id string) string {
@@ -97,13 +91,16 @@ func (s *KVStore[T]) SetPipe(
 	return nil
 }
 
-// ListPush pushes a value to the front of a Redis list
-func (s *KVStore[T]) ListPush(ctx context.Context, key string, value *T) error {
+// ListPushPipe pushes a value to the front of a Redis list (in pipeline)
+func (s *KVStore[T]) ListPushPipe(
+	ctx context.Context, pipe redis.Pipeliner, key string, value *T,
+) error {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
-	return s.rdb.LPush(ctx, key, data).Err()
+	pipe.LPush(ctx, key, data)
+	return nil
 }
 
 // ListRange gets all items from a Redis list

--- a/internal/infrastructure/live-store/redis/kv.go
+++ b/internal/infrastructure/live-store/redis/kv.go
@@ -23,7 +23,17 @@ func (s *KVStore[T]) key(id string) string {
 }
 
 func (s *KVStore[T]) Get(ctx context.Context, id string) (*T, error) {
-	val, err := s.rdb.Get(ctx, s.key(id)).Result()
+	return s.getWith(ctx, s.rdb, id)
+}
+
+// GetWith reads through an arbitrary redis.Cmdable (e.g. a *redis.Tx inside a
+// Watch callback) so reads share the same connection as the transaction.
+func (s *KVStore[T]) GetWith(ctx context.Context, c redis.Cmdable, id string) (*T, error) {
+	return s.getWith(ctx, c, id)
+}
+
+func (s *KVStore[T]) getWith(ctx context.Context, c redis.Cmdable, id string) (*T, error) {
+	val, err := c.Get(ctx, s.key(id)).Result()
 	if errors.Is(err, redis.Nil) {
 		return nil, nil
 	}
@@ -47,6 +57,12 @@ func (s *KVStore[T]) Set(ctx context.Context, id string, value *T) error {
 
 func (s *KVStore[T]) Delete(ctx context.Context, id string) error {
 	return s.rdb.Del(ctx, s.key(id)).Err()
+}
+
+// DeletePipe queues a DEL for the given id on the pipeline, keeping the key
+// prefix encapsulated in the KVStore.
+func (s *KVStore[T]) DeletePipe(ctx context.Context, pipe redis.Pipeliner, id string) {
+	pipe.Del(ctx, s.key(id))
 }
 
 func (s *KVStore[T]) GetMulti(ctx context.Context, ids []string) ([]*T, error) {


### PR DESCRIPTION
This PR uses the `DeleteVtxos` pattern (Watch with retry + Pipeline) to make `Pop` and `Delete` methods transactionnal. 

@altafan @sekulicd please review



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability and atomicity of storage operations to reduce intermittent failures and ensure consistent data under concurrent access.
* **Tests**
  * Adjusted test environment configuration and added coverage to validate transactional behavior and concurrent-change handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->