### PR TITLE
FinalizeOffchainTx: reject if any input is unrolled

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1179,7 +1179,14 @@ func (s *service) FinalizeOffchainTx(
 			).WithMetadata(errors.InvalidSignatureMetadata{Tx: checkpoint})
 		}
 
-		decodedCheckpointTxs[ptx.UnsignedTx.TxID()] = ptx
+		checkpointTxid := ptx.UnsignedTx.TxID()
+		if len(ptx.UnsignedTx.TxIn) < 1 {
+			return errors.INVALID_PSBT_MISSING_INPUT.New(
+				"invalid checkpoint tx %s", checkpointTxid,
+			).WithMetadata(errors.PsbtInputMetadata{Txid: checkpointTxid})
+		}
+
+		decodedCheckpointTxs[checkpointTxid] = ptx
 		outpoint := ptx.UnsignedTx.TxIn[0].PreviousOutPoint
 		spentVtxoKeys = append(spentVtxoKeys, domain.Outpoint{
 			Txid: outpoint.Hash.String(),

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1169,6 +1169,7 @@ func (s *service) FinalizeOffchainTx(
 	}()
 
 	decodedCheckpointTxs := make(map[string]*psbt.Packet)
+	spentVtxoKeys := make([]domain.Outpoint, 0, len(finalCheckpointTxs))
 	for _, checkpoint := range finalCheckpointTxs {
 		// verify the tapscript signatures
 		valid, ptx, err := s.builder.VerifyVtxoTapscriptSigs(checkpoint, true)
@@ -1179,6 +1180,25 @@ func (s *service) FinalizeOffchainTx(
 		}
 
 		decodedCheckpointTxs[ptx.UnsignedTx.TxID()] = ptx
+		outpoint := ptx.UnsignedTx.TxIn[0].PreviousOutPoint
+		spentVtxoKeys = append(spentVtxoKeys, domain.Outpoint{
+			Txid: outpoint.Hash.String(),
+			VOut: outpoint.Index,
+		})
+	}
+
+	// re-check spent vtxos, reject if any input is unrolled
+	spentVtxos, err := s.repoManager.Vtxos().GetVtxos(ctx, spentVtxoKeys)
+	if err != nil {
+		return errors.INTERNAL_ERROR.New("failed to fetch vtxos: %w", err).
+			WithMetadata(map[string]any{"vtxos": spentVtxoKeys})
+	}
+	for _, vtxo := range spentVtxos {
+		if vtxo.Unrolled {
+			return errors.VTXO_ALREADY_UNROLLED.New(
+				"%s already unrolled", vtxo.Outpoint,
+			).WithMetadata(errors.VtxoMetadata{VtxoOutpoint: vtxo.Outpoint.String()})
+		}
 	}
 
 	finalCheckpointTxsMap := make(map[string]string)

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -3549,7 +3549,7 @@ func TestSweep(t *testing.T) {
 		require.NoError(t, err)
 
 		// give time for the server to process the sweep and indexer to sync the vtxo table
-		time.Sleep(60 * time.Second)
+		time.Sleep(80 * time.Second)
 
 		// verify that all vtxos have been swept
 		aliceVtxos, _, err = alice.ListVtxos(ctx)

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -1323,6 +1323,151 @@ func TestOffchainTx(t *testing.T) {
 		})
 	})
 
+	// In this test, Alice submits an offchain tx spending a vtxo, then unrolls the same
+	// vtxo onchain before finalizing. The server should reject the finalization because
+	// the input vtxo is marked "unrolled"
+	t.Run("reject finalize of tx spending unrolled vtxo", func(t *testing.T) {
+		ctx := t.Context()
+		explorer, err := mempool_explorer.NewExplorer(
+			"http://localhost:3000", arklib.BitcoinRegTest,
+			mempool_explorer.WithTracker(false),
+		)
+		require.NoError(t, err)
+
+		alice, aliceWallet, _, arkSvc := setupArkSDKwithPublicKey(t)
+		t.Cleanup(func() { alice.Stop() })
+		t.Cleanup(func() { arkSvc.Close() })
+
+		vtxo := faucetOffchain(t, alice, 0.00021)
+
+		_, offchainAddresses, _, _, err := aliceWallet.GetAddresses(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, offchainAddresses)
+		offchainAddress := offchainAddresses[0]
+
+		serverParams, err := arkSvc.GetInfo(ctx)
+		require.NoError(t, err)
+
+		vtxoScript, err := script.ParseVtxoScript(offchainAddress.Tapscripts)
+		require.NoError(t, err)
+		forfeitClosures := vtxoScript.ForfeitClosures()
+		require.Len(t, forfeitClosures, 1)
+		closure := forfeitClosures[0]
+
+		scriptBytes, err := closure.Script()
+		require.NoError(t, err)
+
+		_, vtxoTapTree, err := vtxoScript.TapTree()
+		require.NoError(t, err)
+
+		merkleProof, err := vtxoTapTree.GetTaprootMerkleProof(
+			txscript.NewBaseTapLeaf(scriptBytes).TapHash(),
+		)
+		require.NoError(t, err)
+
+		ctrlBlock, err := txscript.ParseControlBlock(merkleProof.ControlBlock)
+		require.NoError(t, err)
+
+		tapscript := &waddrmgr.Tapscript{
+			ControlBlock:   ctrlBlock,
+			RevealedScript: merkleProof.Script,
+		}
+
+		checkpointTapscript, err := hex.DecodeString(serverParams.CheckpointTapscript)
+		require.NoError(t, err)
+
+		vtxoHash, err := chainhash.NewHashFromStr(vtxo.Txid)
+		require.NoError(t, err)
+
+		addr, err := arklib.DecodeAddressV0(offchainAddress.Address)
+		require.NoError(t, err)
+		pkscript, err := addr.GetPkScript()
+		require.NoError(t, err)
+
+		ptx, checkpointsPtx, err := offchain.BuildTxs(
+			[]offchain.VtxoInput{
+				{
+					Outpoint: &wire.OutPoint{
+						Hash:  *vtxoHash,
+						Index: vtxo.VOut,
+					},
+					Tapscript:          tapscript,
+					Amount:             int64(vtxo.Amount),
+					RevealedTapscripts: offchainAddress.Tapscripts,
+				},
+			},
+			[]*wire.TxOut{
+				{
+					Value:    int64(vtxo.Amount),
+					PkScript: pkscript,
+				},
+			},
+			checkpointTapscript,
+		)
+		require.NoError(t, err)
+
+		encodedCheckpoints := make([]string, 0, len(checkpointsPtx))
+		for _, checkpoint := range checkpointsPtx {
+			encoded, err := checkpoint.B64Encode()
+			require.NoError(t, err)
+			encodedCheckpoints = append(encodedCheckpoints, encoded)
+		}
+
+		encodedArkTx, err := ptx.B64Encode()
+		require.NoError(t, err)
+		signedArkTx, err := aliceWallet.SignTransaction(ctx, explorer, encodedArkTx)
+		require.NoError(t, err)
+
+		// Submit the offchain tx but do NOT finalize it yet
+		txid, _, signedCheckpoints, err := arkSvc.SubmitTx(ctx, signedArkTx, encodedCheckpoints)
+		require.NoError(t, err)
+		require.NotEmpty(t, txid)
+
+		// Fund alice's onchain address to cover unroll network fees
+		onchainAddr, _, _, err := alice.Receive(ctx)
+		require.NoError(t, err)
+
+		faucetOnchain(t, onchainAddr, 0.01)
+		time.Sleep(5 * time.Second)
+
+		// Unroll the input vtxo onchain. Submit has already marked it spent server-side,
+		// so we pass the vtxo explicitly to bypass the SDK's spendable filter.
+		unrollRes, err := alice.Unroll(ctx, arksdk.WithVtxosToUnroll([]types.Vtxo{vtxo}))
+		require.NoError(t, err)
+		require.NotEmpty(t, unrollRes)
+
+		// Generate a block to confirm the ark tx just unrolled so the server can react
+		// by marking the input vtxo as unrolled
+		err = generateBlocks(1)
+		require.NoError(t, err)
+		time.Sleep(8 * time.Second)
+
+		// The server should now have marked the input vtxo as unrolled
+		_, spentVtxos, err := alice.ListVtxos(ctx)
+		require.NoError(t, err)
+
+		var inputUnrolled bool
+		for _, v := range spentVtxos {
+			if v.Txid == vtxo.Txid && v.VOut == vtxo.VOut {
+				inputUnrolled = v.Unrolled
+				break
+			}
+		}
+		require.True(t, inputUnrolled, "input vtxo should be marked unrolled")
+
+		// Sign the checkpoints so the finalize request is otherwise valid
+		finalCheckpoints := make([]string, 0, len(signedCheckpoints))
+		for _, checkpoint := range signedCheckpoints {
+			finalCheckpoint, err := aliceWallet.SignTransaction(ctx, explorer, checkpoint)
+			require.NoError(t, err)
+			finalCheckpoints = append(finalCheckpoints, finalCheckpoint)
+		}
+
+		// Finalize must now be rejected because the input vtxo is unrolled
+		err = arkSvc.FinalizeTx(ctx, txid, finalCheckpoints)
+		require.ErrorContains(t, err, "unrolled")
+	})
+
 	// In this test, we ensure that a tx with too many OP_RETURN outputs gets rejected.
 	// The server is configured with a max of 3 OP_RETURN outputs, so submitting 4 should fail.
 	t.Run("too many op return outputs", func(t *testing.T) {

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -1326,7 +1326,7 @@ func TestOffchainTx(t *testing.T) {
 	// In this test, Alice submits an offchain tx spending a vtxo, then unrolls the same
 	// vtxo onchain before finalizing. The server should reject the finalization because
 	// the input vtxo is marked "unrolled"
-	t.Run("reject finalize of tx spending unrolled vtxo", func(t *testing.T) {
+	t.Run("reject finalization of tx with unrolled inputs", func(t *testing.T) {
 		ctx := t.Context()
 		explorer, err := mempool_explorer.NewExplorer(
 			"http://localhost:3000", arklib.BitcoinRegTest,


### PR DESCRIPTION
@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction finalization to validate that spending inputs are not unrolled, preventing finalization failures and protecting against invalid transaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->