### PR TITLE
fix: waitForConfirmation fallback to time.Now() in case of error

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -3471,6 +3471,7 @@ func (s *service) scheduleSweepBatchOutput(round *domain.Round) {
 			"failed to wait for confirmation of commitment tx %s, schedule task time may be inaccurate",
 			round.CommitmentTxid,
 		)
+		blockTimestamp = &ports.BlockTimestamp{Time: time.Now().Unix()}
 	}
 
 	var expirationTimestamp int64

--- a/internal/core/application/sweeper.go
+++ b/internal/core/application/sweeper.go
@@ -474,6 +474,7 @@ func (s *sweeper) createBatchSweepTask(commitmentTxid, vtxoTreeRootTxid string) 
 					"failed to wait for confirmation of batch input tx %s, schedule task time "+
 						"may be inaccurate", rootInput,
 				)
+				blockTimestamp = &ports.BlockTimestamp{Time: time.Now().Unix()}
 			}
 
 			var expirationTimestamp int64


### PR DESCRIPTION
in case the sweeper waitForConfirmation fails, fallback to the current timestamp. it means the scheduler may schedule too early. it is not a problem because that situation is already handled by "BIP68 not final" retry loop. better to schedule the sweep earlier instead of not scheduling it at all like proposed in #1033 

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash in batch sweep task scheduling when confirmation handling failed, ensuring proper expiration timestamp initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->