### PR TITLE
test(e2e): pause background miner during fraud mempool assertions

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -2099,9 +2099,14 @@ func TestReactToFraud(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, leafTx)
 
-			bumpAndBroadcastTx(t, leafTx, expl)
+			pauseBackgroundMiner(t)
+			defer resumeBackgroundMiner(t)
 
-			// Give time to the explorer to track down the broadcasted txs.
+			broadcastTxWithAnchorBump(t, leafTx, expl)
+
+			// Give time to the explorer to track down the broadcasted txs while
+			// they are still unconfirmed. Confirmation is triggered explicitly
+			// below so this assertion does not race CI's block production.
 			time.Sleep(5 * time.Second)
 
 			// The vtxo is now unrolled and unspent in the Bitcoin mempool.
@@ -2201,9 +2206,14 @@ func TestReactToFraud(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, leafTx)
 
-			bumpAndBroadcastTx(t, leafTx, expl)
+			pauseBackgroundMiner(t)
+			defer resumeBackgroundMiner(t)
 
-			// Give time to the explorer to track down the broadcasted txs.
+			broadcastTxWithAnchorBump(t, leafTx, expl)
+
+			// Give time to the explorer to track down the broadcasted txs while
+			// they are still unconfirmed. Confirmation is triggered explicitly
+			// below so this assertion does not race CI's block production.
 			time.Sleep(5 * time.Second)
 
 			// The vtxo is now unrolled and unspent in the Bitcoin mempool.

--- a/internal/test/e2e/utils_test.go
+++ b/internal/test/e2e/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -44,7 +45,21 @@ const (
 	adminUrl    = "http://127.0.0.1:7071"
 	serverUrl   = "127.0.0.1:7070"
 	explorerUrl = "http://127.0.0.1:3000"
+	blockMinerPauseFile = "/tmp/dark-go-e2e.pause-miner"
 )
+
+func pauseBackgroundMiner(t *testing.T) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(blockMinerPauseFile, []byte("pause\n"), 0o644))
+}
+
+func resumeBackgroundMiner(t *testing.T) {
+	t.Helper()
+	err := os.Remove(blockMinerPauseFile)
+	if err != nil && !os.IsNotExist(err) {
+		require.NoError(t, err)
+	}
+}
 
 func generateBlocks(n int) error {
 	_, err := runCommand("nigiri", "rpc", "--generate", fmt.Sprintf("%d", n))
@@ -137,7 +152,7 @@ func newCommand(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-func bumpAndBroadcastTx(t *testing.T, tx string, explorer explorer.Explorer) {
+func broadcastTxWithAnchorBump(t *testing.T, tx string, explorer explorer.Explorer) {
 	var transaction wire.MsgTx
 	err := transaction.Deserialize(hex.NewDecoder(strings.NewReader(tx)))
 	require.NoError(t, err)
@@ -146,8 +161,12 @@ func bumpAndBroadcastTx(t *testing.T, tx string, explorer explorer.Explorer) {
 
 	_, err = explorer.Broadcast(tx, childTx)
 	require.NoError(t, err)
+}
 
-	err = generateBlocks(1)
+func bumpAndBroadcastTx(t *testing.T, tx string, explorer explorer.Explorer) {
+	broadcastTxWithAnchorBump(t, tx, explorer)
+
+	err := generateBlocks(1)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary\n- add a pause file helper for the Go e2e background miner\n- pause mining around the fraud mempool assertions so they can verify the unconfirmed state deterministically\n- keep explicit manual block generation for the confirmation phase\n\n## Why\nThese fraud subtests assert a mempool-only intermediate state, but the CI harness mines a block every 2 seconds in the background. That makes the same SHA pass or fail depending on timing. This change keeps the test strict without weakening the assertion.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test infrastructure for fraud detection scenarios with enhanced control over test execution timing and transaction verification flow to reduce timing-related test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->