### PR TITLE
Wait for projection db updates before sending events through streams

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -296,11 +296,11 @@ func (s *service) Start() error {
 }
 
 func (s *service) registerEventHandlers() {
-	s.repoManager.Events().RegisterEventsHandler(
-		domain.RoundTopic, func(events []domain.Event) {
-			round := domain.NewRoundFromEvents(events)
+	s.repoManager.RegisterBatchUpdateHandler(
+		func(round domain.Round) {
 			go s.propagateEvents(context.Background(), round)
 
+			events := round.Events()
 			lastEvent := events[len(events)-1]
 			if lastEvent.GetType() == domain.EventTypeBatchSwept {
 				batchSweptEvent := lastEvent.(domain.BatchSwept)
@@ -347,15 +347,13 @@ func (s *service) registerEventHandlers() {
 		},
 	)
 
-	s.repoManager.Events().RegisterEventsHandler(
-		domain.OffchainTxTopic, func(events []domain.Event) {
-			offchainTx := domain.NewOffchainTxFromEvents(events)
-
+	s.repoManager.RegisterOffchainTxUpdateHandler(
+		func(offchainTx domain.OffchainTx) {
 			if !offchainTx.IsFinalized() {
 				return
 			}
 
-			txid, spentVtxoKeys, newVtxos, err := decodeTx(*offchainTx)
+			txid, spentVtxoKeys, newVtxos, err := decodeTx(offchainTx)
 			if err != nil {
 				log.WithError(err).Warn("failed to decode offchain tx")
 				return
@@ -3330,7 +3328,7 @@ func (s *service) listenToScannerNotifications() {
 	}
 }
 
-func (s *service) propagateEvents(ctx context.Context, round *domain.Round) {
+func (s *service) propagateEvents(ctx context.Context, round domain.Round) {
 	lastEvent := round.Events()[len(round.Events())-1]
 	events := make([]domain.Event, 0)
 	switch ev := lastEvent.(type) {
@@ -3454,7 +3452,7 @@ func (s *service) propagateRoundSigningNoncesGeneratedEvent(
 	s.eventsCh <- events
 }
 
-func (s *service) scheduleSweepBatchOutput(round *domain.Round) {
+func (s *service) scheduleSweepBatchOutput(round domain.Round) {
 	// Schedule the sweeping procedure only for completed round.
 	if !round.IsEnded() {
 		return

--- a/internal/core/application/utils.go
+++ b/internal/core/application/utils.go
@@ -242,7 +242,7 @@ func calcNextScheduledSession(
 	return nextStartTime, nextEndTime
 }
 
-func getNewVtxosFromRound(round *domain.Round) []domain.Vtxo {
+func getNewVtxosFromRound(round domain.Round) []domain.Vtxo {
 	if len(round.VtxoTree) <= 0 {
 		return nil
 	}

--- a/internal/core/ports/repo_manager.go
+++ b/internal/core/ports/repo_manager.go
@@ -11,5 +11,7 @@ type RepoManager interface {
 	Convictions() domain.ConvictionRepository
 	Assets() domain.AssetRepository
 	Fees() domain.FeeRepository
+	RegisterBatchUpdateHandler(handler func(data domain.Round))
+	RegisterOffchainTxUpdateHandler(handler func(data domain.OffchainTx))
 	Close()
 }

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -546,7 +546,9 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 				return false
 			}
 
-			batch, batchErr := s.roundStore.GetRoundWithCommitmentTxid(ctx, offchainTx.RootCommitmentTxId)
+			batch, batchErr := s.roundStore.GetRoundWithCommitmentTxid(
+				ctx, offchainTx.RootCommitmentTxId,
+			)
 			// We consider the tx swept if:
 			// - there is an error fetching the batch (this is just fallback, should never happen)
 			// - the batch is swept

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -93,15 +93,17 @@ type ServiceConfig struct {
 }
 
 type service struct {
-	eventStore            domain.EventRepository
-	roundStore            domain.RoundRepository
-	vtxoStore             domain.VtxoRepository
-	scheduledSessionStore domain.ScheduledSessionRepo
-	offchainTxStore       domain.OffchainTxRepository
-	convictionStore       domain.ConvictionRepository
-	assetStore            domain.AssetRepository
-	intentFeesStore       domain.FeeRepository
-	txDecoder             ports.TxDecoder
+	eventStore              domain.EventRepository
+	roundStore              domain.RoundRepository
+	vtxoStore               domain.VtxoRepository
+	scheduledSessionStore   domain.ScheduledSessionRepo
+	offchainTxStore         domain.OffchainTxRepository
+	convictionStore         domain.ConvictionRepository
+	assetStore              domain.AssetRepository
+	intentFeesStore         domain.FeeRepository
+	txDecoder               ports.TxDecoder
+	batchUpdateHandler      *updateHandler[domain.Round]
+	offchainTxUpdateHandler *updateHandler[domain.OffchainTx]
 }
 
 func NewService(config ServiceConfig, txDecoder ports.TxDecoder) (ports.RepoManager, error) {
@@ -360,15 +362,17 @@ func NewService(config ServiceConfig, txDecoder ports.TxDecoder) (ports.RepoMana
 	}
 
 	svc := &service{
-		eventStore:            eventStore,
-		roundStore:            roundStore,
-		vtxoStore:             vtxoStore,
-		scheduledSessionStore: scheduledSessionStore,
-		offchainTxStore:       offchainTxStore,
-		txDecoder:             txDecoder,
-		convictionStore:       convictionStore,
-		assetStore:            assetStore,
-		intentFeesStore:       intentFeesStore,
+		eventStore:              eventStore,
+		roundStore:              roundStore,
+		vtxoStore:               vtxoStore,
+		scheduledSessionStore:   scheduledSessionStore,
+		offchainTxStore:         offchainTxStore,
+		txDecoder:               txDecoder,
+		convictionStore:         convictionStore,
+		assetStore:              assetStore,
+		intentFeesStore:         intentFeesStore,
+		batchUpdateHandler:      newUpdateHandler[domain.Round](),
+		offchainTxUpdateHandler: newUpdateHandler[domain.OffchainTx](),
 	}
 
 	// Register handlers that take care of keeping the projection store up-to-date.
@@ -414,6 +418,14 @@ func (s *service) Fees() domain.FeeRepository {
 	return s.intentFeesStore
 }
 
+func (s *service) RegisterBatchUpdateHandler(handler func(data domain.Round)) {
+	s.batchUpdateHandler.set(handler)
+}
+
+func (s *service) RegisterOffchainTxUpdateHandler(handler func(data domain.OffchainTx)) {
+	s.offchainTxUpdateHandler.set(handler)
+}
+
 func (s *service) Close() {
 	s.eventStore.Close()
 	s.roundStore.Close()
@@ -427,7 +439,14 @@ func (s *service) updateProjectionsAfterRoundEvents(events []domain.Event) {
 	ctx := context.Background()
 	round := domain.NewRoundFromEvents(events)
 
-	if err := s.roundStore.AddOrUpdateRound(ctx, *round); err != nil {
+	var err error
+	defer func() {
+		if err == nil {
+			s.batchUpdateHandler.dispatch(*round)
+		}
+	}()
+
+	if err = s.roundStore.AddOrUpdateRound(ctx, *round); err != nil {
 		log.WithError(err).Errorf("failed to add or update round %s", round.Id)
 		return
 	}
@@ -443,7 +462,8 @@ func (s *service) updateProjectionsAfterRoundEvents(events []domain.Event) {
 	if lastEvent.GetType() == domain.EventTypeBatchSwept {
 		event := lastEvent.(domain.BatchSwept)
 		allSweptVtxos := append(event.LeafVtxos, event.PreconfirmedVtxos...)
-		sweptCount, err := repo.SweepVtxos(ctx, allSweptVtxos)
+		var sweptCount int
+		sweptCount, err = repo.SweepVtxos(ctx, allSweptVtxos)
 		if err != nil {
 			log.WithError(err).Warn("failed to sweep vtxos")
 		} else {
@@ -463,7 +483,7 @@ func (s *service) updateProjectionsAfterRoundEvents(events []domain.Event) {
 
 	if len(spentVtxos) > 0 {
 		for {
-			if err := repo.SettleVtxos(ctx, spentVtxos, round.CommitmentTxid); err != nil {
+			if err = repo.SettleVtxos(ctx, spentVtxos, round.CommitmentTxid); err != nil {
 				log.WithError(err).Warn("failed to spend vtxos, retrying...")
 				time.Sleep(100 * time.Millisecond)
 				continue
@@ -476,7 +496,7 @@ func (s *service) updateProjectionsAfterRoundEvents(events []domain.Event) {
 	if len(newVtxos) > 0 {
 		for {
 			// this will take care of updating asset projections as well
-			if err := repo.AddVtxos(ctx, newVtxos); err != nil {
+			if err = repo.AddVtxos(ctx, newVtxos); err != nil {
 				log.WithError(err).Warn("failed to add new vtxos, retrying soon")
 				time.Sleep(100 * time.Millisecond)
 				continue
@@ -493,7 +513,14 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 	ctx := context.Background()
 	offchainTx := domain.NewOffchainTxFromEvents(events)
 
-	if err := s.offchainTxStore.AddOrUpdateOffchainTx(ctx, offchainTx); err != nil {
+	var err error
+	defer func() {
+		if err == nil {
+			s.offchainTxUpdateHandler.dispatch(*offchainTx)
+		}
+	}()
+
+	if err = s.offchainTxStore.AddOrUpdateOffchainTx(ctx, offchainTx); err != nil {
 		log.WithError(err).Errorf("failed to add or update offchain tx %s", offchainTx.ArkTxid)
 		return
 	}
@@ -503,7 +530,9 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 	case offchainTx.IsAccepted():
 		spentVtxos := make(map[domain.Outpoint]string)
 		for _, tx := range offchainTx.CheckpointTxs {
-			txid, ins, _, err := s.txDecoder.DecodeTx(tx)
+			var txid string
+			var ins []ports.TxIn
+			txid, ins, _, err = s.txDecoder.DecodeTx(tx)
 			if err != nil {
 				log.WithError(err).Warn("failed to decode checkpoint tx")
 				continue
@@ -515,26 +544,31 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 
 		// as soon as the checkpoint txs are signed by the signer,
 		// we must mark the vtxos as spent to prevent double spending.
-		if err := s.vtxoStore.SpendVtxos(ctx, spentVtxos, offchainTx.ArkTxid); err != nil {
+		if err = s.vtxoStore.SpendVtxos(ctx, spentVtxos, offchainTx.ArkTxid); err != nil {
 			log.WithError(err).Warn("failed to spend vtxos")
 			return
 		}
 		log.Debugf("spent %d vtxos", len(spentVtxos))
 	case offchainTx.IsFinalized():
-		txid, _, outs, err := s.txDecoder.DecodeTx(offchainTx.ArkTx)
+		var txid string
+		var outs []ports.TxOut
+		txid, _, outs, err = s.txDecoder.DecodeTx(offchainTx.ArkTx)
 		if err != nil {
 			log.WithError(err).Warn("failed to decode ark tx")
 			return
 		}
 
-		issuances, assets, err := getAssetsFromTxOuts(txid, outs)
+		var issuances []domain.Asset
+		var assets map[uint32][]domain.AssetDenomination
+		issuances, assets, err = getAssetsFromTxOuts(txid, outs)
 		if err != nil {
 			log.WithError(err).Warn("failed to get assets from tx")
 			return
 		}
 
 		txSwept := false
-		batch, err := s.roundStore.GetRoundWithCommitmentTxid(ctx, offchainTx.RootCommitmentTxId)
+		var batch *domain.Round
+		batch, err = s.roundStore.GetRoundWithCommitmentTxid(ctx, offchainTx.RootCommitmentTxId)
 		// We consider the tx swept if:
 		// - there is an error fetching the batch (this is just fallback, should never happen)
 		// - the batch is swept
@@ -586,7 +620,8 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 			assetsByTx := map[string][]domain.Asset{
 				offchainTx.ArkTxid: issuances,
 			}
-			count, err := s.assetStore.AddAssets(ctx, assetsByTx)
+			var count int
+			count, err = s.assetStore.AddAssets(ctx, assetsByTx)
 			if err != nil {
 				log.WithError(err).Warnf(
 					"failed to add issued assets in offchain tx %s", offchainTx.ArkTxid,
@@ -598,7 +633,7 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 			}
 		}
 
-		if err := s.vtxoStore.AddVtxos(ctx, newVtxos); err != nil {
+		if err = s.vtxoStore.AddVtxos(ctx, newVtxos); err != nil {
 			log.WithError(err).Warn("failed to add vtxos")
 			return
 		}

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -438,206 +438,193 @@ func (s *service) Close() {
 func (s *service) updateProjectionsAfterRoundEvents(events []domain.Event) {
 	ctx := context.Background()
 	round := domain.NewRoundFromEvents(events)
-
-	var err error
-	defer func() {
-		if err == nil {
-			s.batchUpdateHandler.dispatch(*round)
+	updateFn := func() bool {
+		if err := s.roundStore.AddOrUpdateRound(ctx, *round); err != nil {
+			log.WithError(err).Errorf("failed to add or update round %s", round.Id)
+			return false
 		}
-	}()
+		log.Debugf("added or updated round %s", round.Id)
 
-	if err = s.roundStore.AddOrUpdateRound(ctx, *round); err != nil {
-		log.WithError(err).Errorf("failed to add or update round %s", round.Id)
-		return
-	}
-	log.Debugf("added or updated round %s", round.Id)
+		if !round.IsEnded() {
+			return true
+		}
 
-	if !round.IsEnded() {
-		return
-	}
+		repo := s.vtxoStore
 
-	repo := s.vtxoStore
-
-	lastEvent := events[len(events)-1]
-	if lastEvent.GetType() == domain.EventTypeBatchSwept {
-		event := lastEvent.(domain.BatchSwept)
-		allSweptVtxos := append(event.LeafVtxos, event.PreconfirmedVtxos...)
-		var sweptCount int
-		sweptCount, err = repo.SweepVtxos(ctx, allSweptVtxos)
-		if err != nil {
-			log.WithError(err).Warn("failed to sweep vtxos")
-		} else {
+		lastEvent := events[len(events)-1]
+		if lastEvent.GetType() == domain.EventTypeBatchSwept {
+			event := lastEvent.(domain.BatchSwept)
+			allSweptVtxos := append(event.LeafVtxos, event.PreconfirmedVtxos...)
+			sweptCount, err := repo.SweepVtxos(ctx, allSweptVtxos)
+			if err != nil {
+				log.WithError(err).Warn("failed to sweep vtxos, retrying...")
+				return false
+			}
 			log.Debugf("swept %d vtxos", sweptCount)
+
+			if event.FullySwept {
+				log.WithField("commitment_txid", round.CommitmentTxid).Debugf(
+					"round %s fully swept", round.Id,
+				)
+			}
+			return true
 		}
 
-		if event.FullySwept {
-			log.WithField("commitment_txid", round.CommitmentTxid).Debugf(
-				"round %s fully swept", round.Id,
-			)
-		}
-		return
-	}
+		spentVtxos := getSpentVtxoKeysFromRound(*round, s.txDecoder)
+		newVtxos := getNewVtxosFromRound(*round, s.txDecoder)
 
-	spentVtxos := getSpentVtxoKeysFromRound(*round, s.txDecoder)
-	newVtxos := getNewVtxosFromRound(*round, s.txDecoder)
-
-	if len(spentVtxos) > 0 {
-		for {
-			if err = repo.SettleVtxos(ctx, spentVtxos, round.CommitmentTxid); err != nil {
+		if len(spentVtxos) > 0 {
+			if err := repo.SettleVtxos(ctx, spentVtxos, round.CommitmentTxid); err != nil {
 				log.WithError(err).Warn("failed to spend vtxos, retrying...")
-				time.Sleep(100 * time.Millisecond)
-				continue
+				return false
 			}
 			log.Debugf("spent %d vtxos", len(spentVtxos))
-			break
 		}
-	}
 
-	if len(newVtxos) > 0 {
-		for {
+		if len(newVtxos) > 0 {
 			// this will take care of updating asset projections as well
-			if err = repo.AddVtxos(ctx, newVtxos); err != nil {
+			if err := repo.AddVtxos(ctx, newVtxos); err != nil {
 				log.WithError(err).Warn("failed to add new vtxos, retrying soon")
-				time.Sleep(100 * time.Millisecond)
-				continue
+				return false
 			}
 
 			log.Debugf("added %d new vtxos", len(newVtxos))
-			break
-		}
 
+		}
+		return true
+	}
+
+	dispatch := updateFn()
+	if dispatch {
+		go s.batchUpdateHandler.dispatch(*round)
 	}
 }
 
 func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) {
 	ctx := context.Background()
 	offchainTx := domain.NewOffchainTxFromEvents(events)
-
-	var err error
-	defer func() {
-		if err == nil {
-			s.offchainTxUpdateHandler.dispatch(*offchainTx)
+	updateFn := func() bool {
+		if err := s.offchainTxStore.AddOrUpdateOffchainTx(ctx, offchainTx); err != nil {
+			log.WithError(err).Errorf("failed to add or update offchain tx %s", offchainTx.ArkTxid)
+			return false
 		}
-	}()
+		log.Debugf("added or updated offchain tx %s", offchainTx.ArkTxid)
 
-	if err = s.offchainTxStore.AddOrUpdateOffchainTx(ctx, offchainTx); err != nil {
-		log.WithError(err).Errorf("failed to add or update offchain tx %s", offchainTx.ArkTxid)
-		return
+		switch {
+		case offchainTx.IsAccepted():
+			spentVtxos := make(map[domain.Outpoint]string)
+			for _, tx := range offchainTx.CheckpointTxs {
+				txid, ins, _, err := s.txDecoder.DecodeTx(tx)
+				if err != nil {
+					log.WithError(err).Warn("failed to decode checkpoint tx")
+					continue
+				}
+				for _, in := range ins {
+					spentVtxos[in] = txid
+				}
+			}
+
+			// as soon as the checkpoint txs are signed by the signer,
+			// we must mark the vtxos as spent to prevent double spending.
+			if err := s.vtxoStore.SpendVtxos(ctx, spentVtxos, offchainTx.ArkTxid); err != nil {
+				log.WithError(err).Warn("failed to spend vtxos")
+				return false
+			}
+			if len(spentVtxos) > 0 {
+				log.Debugf("spent %d vtxos", len(spentVtxos))
+			}
+		case offchainTx.IsFinalized():
+			txid, _, outs, err := s.txDecoder.DecodeTx(offchainTx.ArkTx)
+			if err != nil {
+				log.WithError(err).Warn("failed to decode ark tx")
+				return false
+			}
+
+			issuances, assets, err := getAssetsFromTxOuts(txid, outs)
+			if err != nil {
+				log.WithError(err).Warn("failed to get assets from tx")
+				return false
+			}
+
+			batch, batchErr := s.roundStore.GetRoundWithCommitmentTxid(ctx, offchainTx.RootCommitmentTxId)
+			// We consider the tx swept if:
+			// - there is an error fetching the batch (this is just fallback, should never happen)
+			// - the batch is swept
+			// - the tx expired (meaning one or all its inputs expired and are already swept or about
+			// to be swept)
+			txSwept := batchErr != nil || (batch != nil && len(batch.SweepTxs) > 0) ||
+				time.Now().After(time.Unix(offchainTx.ExpiryTimestamp, 0))
+			// once the offchain tx is finalized, the user signed the checkpoint txs
+			// thus, we can create the new vtxos in the db.
+			newVtxos := make([]domain.Vtxo, 0, len(outs))
+			for outIndex, out := range outs {
+				// ignore anchor and extension
+				if bytes.Equal(out.PkScript, txutils.ANCHOR_PKSCRIPT) ||
+					extension.IsExtension(out.PkScript) {
+					continue
+				}
+
+				// at that point, we should only have valid taproot script
+				if len(out.PkScript) != 34 {
+					continue
+				}
+
+				outputSwept := txSwept
+				if !outputSwept {
+					outputSwept = script.IsSubDustScript(out.PkScript)
+				}
+
+				newVtxos = append(newVtxos, domain.Vtxo{
+					Outpoint: domain.Outpoint{
+						Txid: txid,
+						VOut: uint32(outIndex),
+					},
+					PubKey:             hex.EncodeToString(out.PkScript[2:]),
+					Amount:             uint64(out.Amount),
+					ExpiresAt:          offchainTx.ExpiryTimestamp,
+					CommitmentTxids:    offchainTx.CommitmentTxidsList(),
+					RootCommitmentTxid: offchainTx.RootCommitmentTxId,
+					Preconfirmed:       true,
+					CreatedAt:          offchainTx.StartingTimestamp,
+					// mark the vtxo as "swept" if it is below dust limit to prevent it from being spent again in a future offchain tx
+					// the only way to spend a swept vtxo is by collecting enough dust to cover the minSettlementVtxoAmount and then settle.
+					// because sub-dust vtxos are using OP_RETURN output script, they can't be unilaterally exited.
+					Swept:  outputSwept,
+					Assets: assets[uint32(outIndex)],
+				})
+			}
+
+			if len(issuances) > 0 {
+				assetsByTx := map[string][]domain.Asset{
+					offchainTx.ArkTxid: issuances,
+				}
+				count, err := s.assetStore.AddAssets(ctx, assetsByTx)
+				if err != nil {
+					log.WithError(err).Warnf(
+						"failed to add issued assets in offchain tx %s", offchainTx.ArkTxid,
+					)
+					return false
+				}
+				if count > 0 {
+					log.Infof("added %d issued assets", count)
+				}
+			}
+
+			if err := s.vtxoStore.AddVtxos(ctx, newVtxos); err != nil {
+				log.WithError(err).Warn("failed to add vtxos")
+				return false
+			}
+			if len(newVtxos) > 0 {
+				log.Debugf("added %d vtxos", len(newVtxos))
+			}
+		}
+
+		return true
 	}
-	log.Debugf("added or updated offchain tx %s", offchainTx.ArkTxid)
 
-	switch {
-	case offchainTx.IsAccepted():
-		spentVtxos := make(map[domain.Outpoint]string)
-		for _, tx := range offchainTx.CheckpointTxs {
-			var txid string
-			var ins []ports.TxIn
-			txid, ins, _, err = s.txDecoder.DecodeTx(tx)
-			if err != nil {
-				log.WithError(err).Warn("failed to decode checkpoint tx")
-				continue
-			}
-			for _, in := range ins {
-				spentVtxos[in] = txid
-			}
-		}
-
-		// as soon as the checkpoint txs are signed by the signer,
-		// we must mark the vtxos as spent to prevent double spending.
-		if err = s.vtxoStore.SpendVtxos(ctx, spentVtxos, offchainTx.ArkTxid); err != nil {
-			log.WithError(err).Warn("failed to spend vtxos")
-			return
-		}
-		log.Debugf("spent %d vtxos", len(spentVtxos))
-	case offchainTx.IsFinalized():
-		var txid string
-		var outs []ports.TxOut
-		txid, _, outs, err = s.txDecoder.DecodeTx(offchainTx.ArkTx)
-		if err != nil {
-			log.WithError(err).Warn("failed to decode ark tx")
-			return
-		}
-
-		var issuances []domain.Asset
-		var assets map[uint32][]domain.AssetDenomination
-		issuances, assets, err = getAssetsFromTxOuts(txid, outs)
-		if err != nil {
-			log.WithError(err).Warn("failed to get assets from tx")
-			return
-		}
-
-		txSwept := false
-		var batch *domain.Round
-		batch, err = s.roundStore.GetRoundWithCommitmentTxid(ctx, offchainTx.RootCommitmentTxId)
-		// We consider the tx swept if:
-		// - there is an error fetching the batch (this is just fallback, should never happen)
-		// - the batch is swept
-		// - the tx expired (meaning one or all its inputs expired and are already swept or about
-		// to be swept)
-		txSwept = err != nil || (batch != nil && len(batch.SweepTxs) > 0) ||
-			time.Now().After(time.Unix(offchainTx.ExpiryTimestamp, 0))
-		// once the offchain tx is finalized, the user signed the checkpoint txs
-		// thus, we can create the new vtxos in the db.
-		newVtxos := make([]domain.Vtxo, 0, len(outs))
-		for outIndex, out := range outs {
-			// ignore anchor and extension
-			if bytes.Equal(out.PkScript, txutils.ANCHOR_PKSCRIPT) ||
-				extension.IsExtension(out.PkScript) {
-				continue
-			}
-
-			// at that point, we should only have valid taproot script
-			if len(out.PkScript) != 34 {
-				continue
-			}
-
-			outputSwept := txSwept
-			if !outputSwept {
-				outputSwept = script.IsSubDustScript(out.PkScript)
-			}
-
-			newVtxos = append(newVtxos, domain.Vtxo{
-				Outpoint: domain.Outpoint{
-					Txid: txid,
-					VOut: uint32(outIndex),
-				},
-				PubKey:             hex.EncodeToString(out.PkScript[2:]),
-				Amount:             uint64(out.Amount),
-				ExpiresAt:          offchainTx.ExpiryTimestamp,
-				CommitmentTxids:    offchainTx.CommitmentTxidsList(),
-				RootCommitmentTxid: offchainTx.RootCommitmentTxId,
-				Preconfirmed:       true,
-				CreatedAt:          offchainTx.StartingTimestamp,
-				// mark the vtxo as "swept" if it is below dust limit to prevent it from being spent again in a future offchain tx
-				// the only way to spend a swept vtxo is by collecting enough dust to cover the minSettlementVtxoAmount and then settle.
-				// because sub-dust vtxos are using OP_RETURN output script, they can't be unilaterally exited.
-				Swept:  outputSwept,
-				Assets: assets[uint32(outIndex)],
-			})
-		}
-
-		if len(issuances) > 0 {
-			assetsByTx := map[string][]domain.Asset{
-				offchainTx.ArkTxid: issuances,
-			}
-			var count int
-			count, err = s.assetStore.AddAssets(ctx, assetsByTx)
-			if err != nil {
-				log.WithError(err).Warnf(
-					"failed to add issued assets in offchain tx %s", offchainTx.ArkTxid,
-				)
-				return
-			}
-			if count > 0 {
-				log.Infof("added %d issued assets", count)
-			}
-		}
-
-		if err = s.vtxoStore.AddVtxos(ctx, newVtxos); err != nil {
-			log.WithError(err).Warn("failed to add vtxos")
-			return
-		}
-		log.Debugf("added %d vtxos", len(newVtxos))
+	dispatch := updateFn()
+	if dispatch {
+		go s.offchainTxUpdateHandler.dispatch(*offchainTx)
 	}
 }
 

--- a/internal/infrastructure/db/update_handler.go
+++ b/internal/infrastructure/db/update_handler.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"sync"
+
+	"github.com/arkade-os/arkd/internal/core/domain"
+)
+
+type updateHandler[T domain.Round | domain.OffchainTx] struct {
+	lock    *sync.RWMutex
+	handler func(data T)
+}
+
+func newUpdateHandler[T domain.Round | domain.OffchainTx]() *updateHandler[T] {
+	return &updateHandler[T]{lock: &sync.RWMutex{}}
+}
+
+func (u *updateHandler[T]) set(handler func(data T)) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+	if u.handler != nil {
+		return
+	}
+	u.handler = handler
+}
+
+func (u *updateHandler[T]) dispatch(data T) {
+	u.lock.RLock()
+	defer u.lock.RUnlock()
+	if u.handler == nil {
+		return
+	}
+	go u.handler(data)
+}

--- a/internal/infrastructure/db/update_handler.go
+++ b/internal/infrastructure/db/update_handler.go
@@ -30,5 +30,5 @@ func (u *updateHandler[T]) dispatch(data T) {
 	if u.handler == nil {
 		return
 	}
-	go u.handler(data)
+	u.handler(data)
 }

--- a/internal/infrastructure/db/update_handler_test.go
+++ b/internal/infrastructure/db/update_handler_test.go
@@ -84,28 +84,6 @@ func TestUpdateHandlerDispatch(t *testing.T) {
 			})
 		}
 
-		t.Run("does not block the caller", func(t *testing.T) {
-			h := newUpdateHandler[domain.OffchainTx]()
-
-			release := make(chan struct{})
-			entered := make(chan struct{})
-			h.set(func(data domain.OffchainTx) {
-				close(entered)
-				<-release
-			})
-
-			start := time.Now()
-			h.dispatch(domain.OffchainTx{})
-			require.Less(t, time.Since(start), 100*time.Millisecond)
-
-			select {
-			case <-entered:
-			case <-time.After(time.Second):
-				t.Fatal("handler goroutine did not start")
-			}
-			close(release)
-		})
-
 		t.Run("no-op when handler not set", func(t *testing.T) {
 			h := newUpdateHandler[domain.OffchainTx]()
 

--- a/internal/infrastructure/db/update_handler_test.go
+++ b/internal/infrastructure/db/update_handler_test.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/internal/core/domain"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateHandlerSet(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		fixtures := []struct {
+			name    string
+			numSets int
+		}{
+			{
+				name:    "sets handler when unset",
+				numSets: 1,
+			},
+			{
+				name:    "ignores second set (write-once)",
+				numSets: 2,
+			},
+			{
+				name:    "ignores all subsequent sets",
+				numSets: 5,
+			},
+		}
+
+		for _, f := range fixtures {
+			t.Run(f.name, func(t *testing.T) {
+				h := newUpdateHandler[domain.OffchainTx]()
+
+				var active atomic.Int32
+				for i := 0; i < f.numSets; i++ {
+					id := int32(i + 1)
+					h.set(func(data domain.OffchainTx) {
+						active.Store(id)
+					})
+				}
+
+				h.dispatch(domain.OffchainTx{})
+
+				// Only the first handler ever installed should run.
+				require.Eventually(t, func() bool {
+					return active.Load() == 1
+				}, time.Second, 10*time.Millisecond)
+			})
+		}
+	})
+}
+
+func TestUpdateHandlerDispatch(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		fixtures := []struct {
+			name string
+			data domain.OffchainTx
+		}{
+			{
+				name: "dispatches data to handler",
+				data: domain.OffchainTx{},
+			},
+		}
+
+		for _, f := range fixtures {
+			t.Run(f.name, func(t *testing.T) {
+				h := newUpdateHandler[domain.OffchainTx]()
+
+				received := make(chan domain.OffchainTx, 1)
+				h.set(func(data domain.OffchainTx) {
+					received <- data
+				})
+
+				h.dispatch(f.data)
+
+				select {
+				case got := <-received:
+					require.Equal(t, f.data.ArkTxid, got.ArkTxid)
+				case <-time.After(time.Second):
+					t.Fatal("handler was not invoked within timeout")
+				}
+			})
+		}
+
+		t.Run("does not block the caller", func(t *testing.T) {
+			h := newUpdateHandler[domain.OffchainTx]()
+
+			release := make(chan struct{})
+			entered := make(chan struct{})
+			h.set(func(data domain.OffchainTx) {
+				close(entered)
+				<-release
+			})
+
+			start := time.Now()
+			h.dispatch(domain.OffchainTx{})
+			require.Less(t, time.Since(start), 100*time.Millisecond)
+
+			select {
+			case <-entered:
+			case <-time.After(time.Second):
+				t.Fatal("handler goroutine did not start")
+			}
+			close(release)
+		})
+
+		t.Run("no-op when handler not set", func(t *testing.T) {
+			h := newUpdateHandler[domain.OffchainTx]()
+
+			require.NotPanics(t, func() {
+				h.dispatch(domain.OffchainTx{})
+			})
+		})
+	})
+}


### PR DESCRIPTION
In 90ee4eb287ba6b364d7a24ea90d097474d71c929 we had to introduce a query to the db in `updateProkectionsAfterOffchainTxEvents` to make sure we update vtxos records with the correct swept status, and we now see this latency is getting evident when clients get notified and make requests to the indexer right after, as they may ask for data that is not yet in db.

This PR mitigates the problem by making indexer and arkd send events and notify clients only AFTER the projection db has been updated, and not while the update is ongoing.

The other mitigation will be done in another pr and is related to improving the performance of the subject query (return only the sweep txs instead of the whole batch data - check #1040).

Please @louisinger review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal event update flow to use type-specific, concurrency-safe update handlers and conditional dispatch for batch and offchain updates.

* **Tests**
  * Added tests covering handler registration and dispatch behavior to ensure single-install semantics and correct invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->