### PR TITLE
fix(sweeper): guard scheduleSweepBatchOutput against nil/transient failures

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -3482,8 +3482,17 @@ func (s *service) propagateRoundSigningNoncesGeneratedEvent(
 }
 
 func (s *service) scheduleSweepBatchOutput(round *domain.Round) {
+	// Background goroutine — recover from unexpected panics (nil wallet
+	// returns, transient nbxplorer loss, dropped domain pointers) so a
+	// single broken round does not crash the process.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("panic in scheduleSweepBatchOutput: %v", r)
+		}
+	}()
+
 	// Schedule the sweeping procedure only for completed round.
-	if !round.IsEnded() {
+	if round == nil || !round.IsEnded() {
 		return
 	}
 
@@ -3493,11 +3502,13 @@ func (s *service) scheduleSweepBatchOutput(round *domain.Round) {
 	}
 
 	blockTimestamp, err := waitForConfirmation(context.Background(), round.CommitmentTxid, s.wallet)
-	if err != nil {
-		log.WithError(err).Warnf(
-			"failed to wait for confirmation of commitment tx %s, schedule task time may be inaccurate",
-			round.CommitmentTxid,
-		)
+	if err != nil || blockTimestamp == nil {
+		if err != nil {
+			log.WithError(err).Warnf(
+				"failed to wait for confirmation of commitment tx %s, schedule task time may be inaccurate",
+				round.CommitmentTxid,
+			)
+		}
 		blockTimestamp = &ports.BlockTimestamp{Time: time.Now().Unix()}
 	}
 


### PR DESCRIPTION
Refs arkade-os/arkd#1031.

## Problem

`scheduleSweepBatchOutput` is a background goroutine spawned by `registerEvent`. When nbxplorer loses its DB connection (observed during rolling maintenance on 2026-04-22) the wallet path can return a nil `*ports.BlockTimestamp` alongside a nil error, or the caller can hand in a nil `*domain.Round`. Either case derefs nil on this line and crashes the entire `arkd` process, aborting in-progress rounds.

```
panic: runtime error: invalid memory address or nil pointer dereference
... scheduleSweepBatchOutput(0x…, 0x…)
    service.go:3480 +0x17e
```

## Fix

- Nil-guard the `round` argument and the `blockTimestamp` returned from `waitForConfirmation`.
- Add a top-level `defer recover()` so any future panic inside this background goroutine (nbxplorer error shape change, dropped pointer, etc.) logs and exits the goroutine rather than killing the process.

## Test

`go build ./internal/core/application/...` and `go vet ./internal/core/application/...` clean. No behavior change on the happy path; transient errors now log and no-op instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system stability by adding safeguards against unexpected runtime failures that could previously crash the system.
  * Improved error handling for edge cases where critical data might be missing or incomplete, with fallback mechanisms.
  * Enhanced logging to better track and diagnose issues when errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->