### PR TITLE
RoundRepository: add GetSweepTxs

### DIFF
--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -495,13 +495,13 @@ func (i *indexerService) GetVirtualTxsByIntent(
 func (i *indexerService) GetBatchSweepTxs(
 	ctx context.Context, batchOutpoint Outpoint,
 ) ([]string, error) {
-	round, err := i.repoManager.Rounds().GetRoundWithCommitmentTxid(ctx, batchOutpoint.Txid)
+	sweepTxs, err := i.repoManager.Rounds().GetSweepTxs(ctx, batchOutpoint.Txid)
 	if err != nil {
 		return nil, err
 	}
 
-	txids := make([]string, 0, len(round.SweepTxs))
-	for txid := range round.SweepTxs {
+	txids := make([]string, 0, len(sweepTxs))
+	for txid := range sweepTxs {
 		txids = append(txids, txid)
 	}
 

--- a/internal/core/domain/round_repo.go
+++ b/internal/core/domain/round_repo.go
@@ -12,6 +12,7 @@ type RoundRepository interface {
 	GetRoundWithCommitmentTxid(ctx context.Context, txid string) (*Round, error)
 	GetRoundStats(ctx context.Context, commitmentTxid string) (*RoundStats, error)
 	GetRoundForfeitTxs(ctx context.Context, commitmentTxid string) ([]ForfeitTx, error)
+	GetSweepTxs(ctx context.Context, commitmentTxid string) (map[string]string, error)
 	GetRoundConnectorTree(ctx context.Context, commitmentTxid string) (tree.FlatTxTree, error)
 	GetRoundVtxoTree(ctx context.Context, txid string) (tree.FlatTxTree, error)
 	GetSweepableRounds(ctx context.Context) ([]string, error)

--- a/internal/infrastructure/db/badger/ark_repo.go
+++ b/internal/infrastructure/db/badger/ark_repo.go
@@ -131,6 +131,12 @@ func (r *arkRepository) GetRoundForfeitTxs(
 	return nil, nil
 }
 
+func (r *arkRepository) GetSweepTxs(
+	ctx context.Context, commitmentTxid string,
+) (map[string]string, error) {
+	return nil, nil
+}
+
 func (r *arkRepository) GetRoundConnectorTree(
 	ctx context.Context, commitmentTxid string,
 ) (tree.FlatTxTree, error) {

--- a/internal/infrastructure/db/postgres/round_repo.go
+++ b/internal/infrastructure/db/postgres/round_repo.go
@@ -329,6 +329,22 @@ func (r *roundRepository) GetRoundForfeitTxs(
 	return forfeits, nil
 }
 
+func (r *roundRepository) GetSweepTxs(
+	ctx context.Context, commitmentTxid string,
+) (map[string]string, error) {
+	rows, err := r.querier.SelectRoundSweepTxs(ctx, commitmentTxid)
+	if err != nil {
+		return nil, err
+	}
+
+	sweepTxs := make(map[string]string, len(rows))
+	for _, row := range rows {
+		sweepTxs[row.Txid] = row.Tx
+	}
+
+	return sweepTxs, nil
+}
+
 func (r *roundRepository) GetRoundConnectorTree(
 	ctx context.Context, commitmentTxid string,
 ) (tree.FlatTxTree, error) {

--- a/internal/infrastructure/db/postgres/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/db/postgres/sqlc/queries/query.sql.go
@@ -1041,6 +1041,40 @@ func (q *Queries) SelectRoundStats(ctx context.Context, txid string) (SelectRoun
 	return i, err
 }
 
+const selectRoundSweepTxs = `-- name: SelectRoundSweepTxs :many
+SELECT t.txid, t.tx FROM tx t WHERE t.round_id = (
+    SELECT tx.round_id FROM tx WHERE tx.txid = $1 AND type = 'commitment'
+) AND t.type = 'sweep'
+`
+
+type SelectRoundSweepTxsRow struct {
+	Txid string
+	Tx   string
+}
+
+func (q *Queries) SelectRoundSweepTxs(ctx context.Context, txid string) ([]SelectRoundSweepTxsRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectRoundSweepTxs, txid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectRoundSweepTxsRow
+	for rows.Next() {
+		var i SelectRoundSweepTxsRow
+		if err := rows.Scan(&i.Txid, &i.Tx); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectRoundVtxoTree = `-- name: SelectRoundVtxoTree :many
 SELECT txid, tx, round_id, type, position, children FROM tx WHERE round_id = (
     SELECT tx.round_id FROM tx WHERE tx.txid = $1 AND type = 'commitment'

--- a/internal/infrastructure/db/postgres/sqlc/query.sql
+++ b/internal/infrastructure/db/postgres/sqlc/query.sql
@@ -202,6 +202,11 @@ SELECT t.* FROM tx t WHERE t.round_id IN (
     SELECT tx.round_id FROM tx WHERE tx.txid = @txid AND type = 'commitment'
 ) AND t.type = 'forfeit';
 
+-- name: SelectRoundSweepTxs :many
+SELECT t.txid, t.tx FROM tx t WHERE t.round_id = (
+    SELECT tx.round_id FROM tx WHERE tx.txid = @txid AND type = 'commitment'
+) AND t.type = 'sweep';
+
 -- name: SelectRoundStats :one
 SELECT
     r.swept,

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -534,13 +534,13 @@ func (s *service) updateProjectionsAfterOffchainTxEvents(events []domain.Event) 
 		}
 
 		txSwept := false
-		batch, err := s.roundStore.GetRoundWithCommitmentTxid(ctx, offchainTx.RootCommitmentTxId)
+		sweepTxs, err := s.roundStore.GetSweepTxs(ctx, offchainTx.RootCommitmentTxId)
 		// We consider the tx swept if:
-		// - there is an error fetching the batch (this is just fallback, should never happen)
+		// - there is an error fetching the sweep txs (this is just fallback, should never happen)
 		// - the batch is swept
 		// - the tx expired (meaning one or all its inputs expired and are already swept or about
 		// to be swept)
-		txSwept = err != nil || (batch != nil && len(batch.SweepTxs) > 0) ||
+		txSwept = err != nil || len(sweepTxs) > 0 ||
 			time.Now().After(time.Unix(offchainTx.ExpiryTimestamp, 0))
 		// once the offchain tx is finalized, the user signed the checkpoint txs
 		// thus, we can create the new vtxos in the db.

--- a/internal/infrastructure/db/service_test.go
+++ b/internal/infrastructure/db/service_test.go
@@ -419,6 +419,10 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 		require.NoError(t, err)
 		require.Empty(t, emptyForfeitTxs)
 
+		emptySweepTxs, err := svc.Rounds().GetSweepTxs(ctx, "nonexistent")
+		require.NoError(t, err)
+		require.Empty(t, emptySweepTxs)
+
 		emptyConnectorTree, err := svc.Rounds().GetRoundConnectorTree(ctx, "nonexistent")
 		require.NoError(t, err)
 		require.Empty(t, emptyConnectorTree)
@@ -612,6 +616,11 @@ func testRoundRepository(t *testing.T, svc ports.RepoManager) {
 		require.NoError(t, err)
 		require.NotNil(t, roundById)
 		roundsMatch(t, *sweptRound, *roundById)
+
+		sweepTxs, err := svc.Rounds().GetSweepTxs(ctx, commitmentTxid)
+		require.NoError(t, err)
+		require.Len(t, sweepTxs, 1)
+		require.Equal(t, sweepTx, sweepTxs[sweepTxid])
 
 		roundsIds, err := svc.Rounds().GetRoundIds(ctx, 0, 0, false, true)
 		require.NoError(t, err)

--- a/internal/infrastructure/db/sqlite/round_repo.go
+++ b/internal/infrastructure/db/sqlite/round_repo.go
@@ -394,6 +394,22 @@ func (r *roundRepository) GetRoundForfeitTxs(
 	return forfeits, nil
 }
 
+func (r *roundRepository) GetSweepTxs(
+	ctx context.Context, commitmentTxid string,
+) (map[string]string, error) {
+	rows, err := r.querier.SelectRoundSweepTxs(ctx, commitmentTxid)
+	if err != nil {
+		return nil, err
+	}
+
+	sweepTxs := make(map[string]string, len(rows))
+	for _, row := range rows {
+		sweepTxs[row.Txid] = row.Tx
+	}
+
+	return sweepTxs, nil
+}
+
 func (r *roundRepository) GetRoundConnectorTree(
 	ctx context.Context, commitmentTxid string,
 ) (tree.FlatTxTree, error) {

--- a/internal/infrastructure/db/sqlite/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/db/sqlite/sqlc/queries/query.sql.go
@@ -1123,6 +1123,40 @@ func (q *Queries) SelectRoundStats(ctx context.Context, txid string) (SelectRoun
 	return i, err
 }
 
+const selectRoundSweepTxs = `-- name: SelectRoundSweepTxs :many
+SELECT t.txid, t.tx FROM tx t WHERE t.round_id = (
+    SELECT tx.round_id FROM tx WHERE tx.txid = ?1 AND type = 'commitment'
+) AND t.type = 'sweep'
+`
+
+type SelectRoundSweepTxsRow struct {
+	Txid string
+	Tx   string
+}
+
+func (q *Queries) SelectRoundSweepTxs(ctx context.Context, txid string) ([]SelectRoundSweepTxsRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectRoundSweepTxs, txid)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectRoundSweepTxsRow
+	for rows.Next() {
+		var i SelectRoundSweepTxsRow
+		if err := rows.Scan(&i.Txid, &i.Tx); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectRoundVtxoTree = `-- name: SelectRoundVtxoTree :many
 SELECT txid, tx, round_id, type, position, children FROM tx WHERE round_id = (
     SELECT tx.round_id FROM tx WHERE tx.txid = ?1 AND type = 'commitment'

--- a/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -204,6 +204,11 @@ SELECT t.* FROM tx t WHERE t.round_id IN (
     SELECT tx.round_id FROM tx WHERE tx.txid = @txid AND type = 'commitment'
 ) AND t.type = 'forfeit';
 
+-- name: SelectRoundSweepTxs :many
+SELECT t.txid, t.tx FROM tx t WHERE t.round_id = (
+    SELECT tx.round_id FROM tx WHERE tx.txid = @txid AND type = 'commitment'
+) AND t.type = 'sweep';
+
 -- name: SelectRoundStats :one
 SELECT
     r.swept,


### PR DESCRIPTION
add new `GetSweepTxs` database getter to make `updateProjectionsAfterOffchainTxEvents` lighter.
BONUS: also use it for indexer's GetBatchSweepTxs method.

it closes #1037

@altafan please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced sweep transaction data retrieval by introducing a dedicated query method implemented across Postgres, SQLite, and Badger database layers, improving query efficiency, consistency, and maintainability of transaction state tracking.

* **Tests**
  * Added comprehensive test coverage for the new sweep transaction query method, including validation for both empty results and populated result sets with expected transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->