### PR TITLE
Fix gRPC max receive message size for arkd client connections

### DIFF
--- a/pkg/client-lib/client/grpc/client.go
+++ b/pkg/client-lib/client/grpc/client.go
@@ -48,6 +48,7 @@ func NewClient(serverUrl string) (client.TransportClient, error) {
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDisableServiceConfig(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(20 << 20)),
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{
 				BaseDelay:  1 * time.Second,

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -52,6 +52,7 @@ func NewClient(serverUrl string) (indexer.Indexer, error) {
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDisableServiceConfig(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(20 << 20)),
 		grpc.WithConnectParams(grpc.ConnectParams{
 			Backoff: backoff.Config{
 				BaseDelay:  1 * time.Second,
@@ -743,8 +744,8 @@ func (a *grpcClient) paginatedGetVirtualTxs(
 func paginatedFetch[T any](
 	ctx context.Context,
 	fetch func(
-		ctx context.Context, page *arkv1.IndexerPageRequest,
-	) ([]T, *arkv1.IndexerPageResponse, error),
+	ctx context.Context, page *arkv1.IndexerPageRequest,
+) ([]T, *arkv1.IndexerPageResponse, error),
 ) ([]T, error) {
 	var all []T
 	pageIndex := int32(0)

--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -744,8 +744,8 @@ func (a *grpcClient) paginatedGetVirtualTxs(
 func paginatedFetch[T any](
 	ctx context.Context,
 	fetch func(
-	ctx context.Context, page *arkv1.IndexerPageRequest,
-) ([]T, *arkv1.IndexerPageResponse, error),
+		ctx context.Context, page *arkv1.IndexerPageRequest,
+	) ([]T, *arkv1.IndexerPageResponse, error),
 ) ([]T, error) {
 	var all []T
 	pageIndex := int32(0)

--- a/pkg/client-lib/send.go
+++ b/pkg/client-lib/send.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -179,37 +180,33 @@ func (a *service) createOffchainTx(
 
 	vtxos := make([]types.VtxoWithTapTree, 0)
 
-	spendableVtxos := make([]types.Vtxo, 0)
 	if len(options.vtxos) > 0 {
-		for _, v := range options.vtxos {
-			spendableVtxos = append(spendableVtxos, v.Vtxo)
-		}
-	}else {
-		spendableVtxos, err = a.getSpendableVtxos(ctx, &getVtxosFilter{
+		vtxos = slices.Clone(options.vtxos)
+	} else {
+		spendableVtxos, err := a.getSpendableVtxos(ctx, &getVtxosFilter{
 			withoutExpirySorting: options.withoutExpirySorting,
 		})
 		if err != nil {
 			return "", nil, nil, nil, err
 		}
-	}
 
-
-	for _, offchainAddr := range offchainAddrs {
-		for _, v := range spendableVtxos {
-			if v.IsRecoverable() {
-				continue
-			}
-
-			vtxoAddr, err := v.Address(a.SignerPubKey, a.Network)
-			if err != nil {
-				return "", nil, nil, nil, err
-			}
-
-			if vtxoAddr == offchainAddr.Address {
-				vtxos = append(vtxos, types.VtxoWithTapTree{
-					Vtxo:       v,
-					Tapscripts: offchainAddr.Tapscripts,
-				})
+		for _, offchainAddr := range offchainAddrs {
+			for _, v := range spendableVtxos {
+				if v.IsRecoverable() {
+					continue
+				}
+	
+				vtxoAddr, err := v.Address(a.SignerPubKey, a.Network)
+				if err != nil {
+					return "", nil, nil, nil, err
+				}
+	
+				if vtxoAddr == offchainAddr.Address {
+					vtxos = append(vtxos, types.VtxoWithTapTree{
+						Vtxo:       v,
+						Tapscripts: offchainAddr.Tapscripts,
+					})
+				}
 			}
 		}
 	}

--- a/pkg/client-lib/send.go
+++ b/pkg/client-lib/send.go
@@ -178,12 +178,21 @@ func (a *service) createOffchainTx(
 	}
 
 	vtxos := make([]types.VtxoWithTapTree, 0)
-	spendableVtxos, err := a.getSpendableVtxos(ctx, &getVtxosFilter{
-		withoutExpirySorting: options.withoutExpirySorting,
-	})
-	if err != nil {
-		return "", nil, nil, nil, err
+
+	spendableVtxos := make([]types.Vtxo, 0)
+	if len(options.vtxos) > 0 {
+		for _, v := range options.vtxos {
+			spendableVtxos = append(spendableVtxos, v.Vtxo)
+		}
+	}else {
+		spendableVtxos, err = a.getSpendableVtxos(ctx, &getVtxosFilter{
+			withoutExpirySorting: options.withoutExpirySorting,
+		})
+		if err != nil {
+			return "", nil, nil, nil, err
+		}
 	}
+
 
 	for _, offchainAddr := range offchainAddrs {
 		for _, v := range spendableVtxos {


### PR DESCRIPTION
 - The SendOffChain response from arkd can exceed the default gRPC client receive limit of 4 MB when many VTXOs are involved (~4.2 MB observed in production)                              
  - Add grpc.MaxCallRecvMsgSize(20 << 20) (20 MB) to the gRPC dial options in both the arkd transport client and indexer client

@altafan @Kukks please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow providing explicit spendable inputs when creating offchain transactions, enabling custom coin selection for sends.

* **Bug Fixes**
  * Increased gRPC client per-call receive message size limit to 20MB to support larger RPC responses without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->