### PR TITLE
fix(indexer): enforce pagination when no page param is supplied

### DIFF
--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -1064,7 +1064,7 @@ func hashOutpoints(outpoints []Outpoint) ([]byte, error) {
 
 func paginate[T any](items []T, params *Page, maxSize int32) ([]T, PageResp) {
 	if params == nil {
-		return items, PageResp{}
+		params = &Page{PageSize: maxSize, PageNum: 1}
 	}
 	if params.PageSize <= 0 {
 		params.PageSize = maxSize

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -601,14 +601,12 @@ func (i *indexerService) buildVtxoChain(
 
 			// if the vtxo is not preconfirmed, it means it's a leaf of a batch tree
 			// add the branch until the commitment tx
-			flatVtxoTree, err := i.GetVtxoTree(ctx, Outpoint{
-				Txid: vtxo.RootCommitmentTxid, VOut: 0,
-			}, nil)
+			flatVtxoTree, err := i.repoManager.Rounds().GetRoundVtxoTree(ctx, vtxo.RootCommitmentTxid)
 			if err != nil {
 				return nil, nil, err
 			}
 
-			vtxoTree, err := tree.NewTxTree(flatVtxoTree.Txs)
+			vtxoTree, err := tree.NewTxTree(flatVtxoTree)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
 Fixes #1048               

  ## Description                                                                                                                                                                                                         
  Right now if a client calls the indexer without a page param, the server just dumps back the entire result set. The fix is small: when no page is provided, the server falls back to the first page using the existing
  per-method size limit. That way responses are always bounded and clients always get back page info, so they know whether there's more to fetch.                                                                        
                       
  This will also need a bit of coordination with the SDKs as you mentioned, since older clients that never sent a page param will start seeing paginated responses.                                                      
                       
  Hi @altafan — I went with the per-method `maxPageSize` constants that were already there instead of adding a new `INDEXER_MAX_PAGE_SIZE` env var. The existing limits seemed reasonable as defaults, but happy to add 
  the env var if you wanted it tunable at runtime. Let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination behavior to ensure pagination fields are consistently computed and applied across all scenarios, including when no explicit page parameters are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->