### PR TITLE
fix: print repo-root-relative path after build-cli completes

### DIFF
--- a/pkg/ark-cli/scripts/build
+++ b/pkg/ark-cli/scripts/build
@@ -22,8 +22,8 @@ echo "Building ark for $GOOS $GOARCH"
 echo "Version: $VERSION"
 
 # Change to the parent directory
-ORIG_DIR=$(pwd)
-pushd $PARENT_PATH > /dev/null
+REPO_ROOT=$(git rev-parse --show-toplevel)
+pushd "$PARENT_PATH" > /dev/null
 
 # Create build directory if it doesn't exist
 mkdir -p build
@@ -31,7 +31,7 @@ mkdir -p build
 # Build the binary with version information
 GO111MODULE=on go build -ldflags="-s -w -X 'main.Version=$VERSION'" -o build/ark-$GOOS-$GOARCH main.go
 
-echo "Build complete: ${PARENT_PATH#$ORIG_DIR/}/build/ark-$GOOS-$GOARCH"
+echo "Build complete: ${PARENT_PATH#$REPO_ROOT/}/build/ark-$GOOS-$GOARCH"
 
 # Return to the original directory
 popd > /dev/null

--- a/pkg/ark-cli/scripts/build
+++ b/pkg/ark-cli/scripts/build
@@ -22,7 +22,8 @@ echo "Building ark for $GOOS $GOARCH"
 echo "Version: $VERSION"
 
 # Change to the parent directory
-pushd $PARENT_PATH
+ORIG_DIR=$(pwd)
+pushd $PARENT_PATH > /dev/null
 
 # Create build directory if it doesn't exist
 mkdir -p build
@@ -30,7 +31,7 @@ mkdir -p build
 # Build the binary with version information
 GO111MODULE=on go build -ldflags="-s -w -X 'main.Version=$VERSION'" -o build/ark-$GOOS-$GOARCH main.go
 
-echo "Build complete: build/ark-$GOOS-$GOARCH"
+echo "Build complete: ${PARENT_PATH#$ORIG_DIR/}/build/ark-$GOOS-$GOARCH"
 
 # Return to the original directory
-popd
+popd > /dev/null


### PR DESCRIPTION
fixes #1030

`before` vs `after`
<img width="944" height="208" alt="cli-output-b4-vs-after" src="https://github.com/user-attachments/assets/9c9740f7-5e82-423b-9b3e-6244d1208018" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build output now correctly displays the artifact path relative to your original working directory instead of using a hard-coded path reference.

* **Chores**
  * Improved build process output clarity by reducing unnecessary diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->