### PR TITLE
Fix single-key wallet empty KeyID breaking go-sdk signing key resolution

### DIFF
--- a/pkg/client-lib/wallet/singlekey/bitcoin_wallet.go
+++ b/pkg/client-lib/wallet/singlekey/bitcoin_wallet.go
@@ -40,7 +40,7 @@ func (w *bitcoinWallet) NewKey(ctx context.Context) (*wallet.KeyRef, error) {
 		return nil, fmt.Errorf("wallet not initialized")
 	}
 	return &wallet.KeyRef{
-		Id:     "m/0/0",
+		Id:     "m",
 		PubKey: w.walletData.PubKey,
 	}, nil
 }
@@ -50,7 +50,7 @@ func (w *bitcoinWallet) GetKey(ctx context.Context, _ string) (*wallet.KeyRef, e
 		return nil, fmt.Errorf("wallet not initialized")
 	}
 	return &wallet.KeyRef{
-		Id:     "m/0/0",
+		Id:     "m",
 		PubKey: w.walletData.PubKey,
 	}, nil
 }

--- a/pkg/client-lib/wallet/singlekey/bitcoin_wallet.go
+++ b/pkg/client-lib/wallet/singlekey/bitcoin_wallet.go
@@ -39,14 +39,20 @@ func (w *bitcoinWallet) NewKey(ctx context.Context) (*wallet.KeyRef, error) {
 	if w.walletData == nil {
 		return nil, fmt.Errorf("wallet not initialized")
 	}
-	return &wallet.KeyRef{PubKey: w.walletData.PubKey}, nil
+	return &wallet.KeyRef{
+		Id:     "m/0/0",
+		PubKey: w.walletData.PubKey,
+	}, nil
 }
 
 func (w *bitcoinWallet) GetKey(ctx context.Context, _ string) (*wallet.KeyRef, error) {
 	if w.walletData == nil {
 		return nil, fmt.Errorf("wallet not initialized")
 	}
-	return &wallet.KeyRef{PubKey: w.walletData.PubKey}, nil
+	return &wallet.KeyRef{
+		Id:     "m/0/0",
+		PubKey: w.walletData.PubKey,
+	}, nil
 }
 
 func (w *bitcoinWallet) ListKeys(ctx context.Context) ([]wallet.KeyRef, error) {


### PR DESCRIPTION
## Summary

  - Single-key wallet's `NewKey()` and `GetKey()` now return a non-empty `KeyRef.Id` (`"m/0/0"`) matching the HD wallet's derivation path format
  - This fixes compatibility with go-sdk's `signingKeysByScript()` which skips entries where `keyID == ""`

  ## Context

  After the HD wallet was introduced in go-sdk, the signing key resolution logic (`signingKeysByScript` in go-sdk) builds a `map[script] → keyID` by iterating over all wallet addresses.
  Every helper (`addSigningKeyForOffchainAddress`, `addSigningKeyForOnchainAddress`, `addSigningKeyForCheckpointScript`) bails early when `keyID` is empty:

  ```go
  if keyID == "" {
      return nil
  }

  The single-key wallet was returning KeyRef{PubKey: pubkey} with an empty Id field, causing the signing keys map to be empty. This resulted in "missing signing keys" errors when calling
  Settle, CollaborativeExit, or SendOffChain.

  The HD wallet returns derivation paths like "m/0/0", "m/0/1", etc. The single-key wallet now returns "m/0/0" since it has exactly one key at a fixed conceptual "path”.

@altafan please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Wallet key references now include a derivation identifier ("m") along with the public key, improving key identification and consistency when retrieving or creating keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->