### PR TITLE
Fix single-key wallet NextIndex returning 0 causing empty addresses

### DIFF
--- a/pkg/client-lib/wallet/singlekey/wallet.go
+++ b/pkg/client-lib/wallet/singlekey/wallet.go
@@ -110,6 +110,10 @@ func (w *singlekeyWallet) IsLocked() bool {
 }
 
 func (w *singlekeyWallet) NextIndex(_ context.Context) (uint32, error) {
+	if w.walletData != nil {
+		return 1, nil
+	}
+
 	return 0, nil
 }
 


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                
                            
  `NextIndex()` returned `0` unconditionally. The go-sdk's `getAllocatedAddresses` filters keys with `getIndex(keyRef.Id) >= nextIndex`, so the single key at `"m/0/0"` (index 0) was       
  skipped when `nextIndex=0` (`0 >= 0` = true), resulting in empty address lists.
                                                                                                                                                                                            
  Fix: return `1` when the wallet is initialized (one key allocated), `0` otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wallet index tracking to properly reflect wallet initialization state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->