### PR TITLE
Hotfix: prevent failure on SubmitTx to affect finalization of pending tx

### DIFF
--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -466,21 +466,6 @@ func (s *service) SubmitOffchainTx(
 	offchainTx := domain.NewOffchainTx()
 	var changes []domain.Event
 
-	defer func() {
-		if structErr != nil {
-			change := offchainTx.Fail(structErr)
-			changes = append(changes, change)
-		}
-
-		if len(changes) > 0 {
-			if err := s.repoManager.Events().Save(
-				ctx, domain.OffchainTxTopic, txid, changes,
-			); err != nil {
-				log.WithError(err).Errorf("failed to save events for offchain tx %s", txid)
-			}
-		}
-	}()
-
 	vtxoRepo := s.repoManager.Vtxos()
 
 	ins := make([]offchain.VtxoInput, 0)
@@ -535,6 +520,21 @@ func (s *service) SubmitOffchainTx(
 		return nil, errors.INTERNAL_ERROR.Wrap(err)
 	}
 	changes = []domain.Event{event}
+
+	defer func() {
+		if structErr != nil {
+			change := offchainTx.Fail(structErr)
+			changes = append(changes, change)
+		}
+
+		if len(changes) > 0 {
+			if err := s.repoManager.Events().Save(
+				ctx, domain.OffchainTxTopic, txid, changes,
+			); err != nil {
+				log.WithError(err).Errorf("failed to save events for offchain tx %s", txid)
+			}
+		}
+	}()
 
 	// get all the vtxos inputs
 	spentVtxos, err := vtxoRepo.GetVtxos(ctx, spentVtxoKeys)

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -720,7 +720,6 @@ func TestUnrolledVtxoRejoinBatch(t *testing.T) {
 			require.NotZero(t, unrolledVtxo.Amount)
 			require.Empty(t, unrolledVtxo.Assets)
 
-
 			boardingUtxo := types.Utxo{
 				Outpoint:   unrolledVtxo.Outpoint,
 				Amount:     unrolledVtxo.Amount,
@@ -1358,6 +1357,13 @@ func TestOffchainTx(t *testing.T) {
 		txid, _, _, err := aliceClient.SubmitTx(ctx, signedArkTx, encodedCheckpoints)
 		require.NoError(t, err)
 		require.NotEmpty(t, txid)
+
+		time.Sleep(time.Second)
+
+		// Ensure a second submit fails and that it doesn't affect the finalization of the tx.
+		_, _, _, err = aliceClient.SubmitTx(ctx, signedArkTx, encodedCheckpoints)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "duplicated")
 
 		time.Sleep(time.Second)
 


### PR DESCRIPTION
This prevents a duplicated SubmitTx request from affecting the finalization of a pending tx by recording the error in the events only after the domain tx is successfully requested.

Please @louisinger @bitcoin-coder-bob review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in offline transaction submission to properly track early-stage failures.
  * Enhanced duplicate transaction detection to reject resubmitted transactions with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->