### PR TITLE
feat(identity): add ClaimKey method to interface

### DIFF
--- a/pkg/client-lib/identity/identity.go
+++ b/pkg/client-lib/identity/identity.go
@@ -31,6 +31,7 @@ type Identity interface {
 	GetKeyIndex(ctx context.Context, id string) (index uint32, err error)
 	NewKey(ctx context.Context) (key *KeyRef, err error)
 	GetKey(ctx context.Context, id string) (key *KeyRef, err error)
+	ClaimKey(ctx context.Context, id string) error
 	ListKeys(ctx context.Context) (keys []KeyRef, err error)
 	SignTransaction(
 		ctx context.Context, tx string, keys map[string]string,

--- a/pkg/client-lib/identity/identity_test.go
+++ b/pkg/client-lib/identity/identity_test.go
@@ -182,20 +182,50 @@ func TestListKeys(t *testing.T) {
 }
 
 func TestClaimKey(t *testing.T) {
-	t.Run("not initialized", func(t *testing.T) {
-		svc := newTestIdentity(t)
-		err := svc.ClaimKey(t.Context(), "anything")
-		require.Error(t, err)
+	t.Run("valid", func(t *testing.T) {
+		t.Run("initialized is a no op", func(t *testing.T) {
+			svc, _ := newUnlockedTestIdentity(t)
+
+			require.NoError(t, svc.ClaimKey(t.Context(), "anything"))
+			require.NoError(t, svc.ClaimKey(t.Context(), "anything")) // idempotent
+
+			keys, err := svc.ListKeys(t.Context())
+			require.NoError(t, err)
+			require.Len(t, keys, 1)
+		})
+
+		t.Run("locked is also a no op in singlekey", func(t *testing.T) {
+			svc, _ := newUnlockedTestIdentity(t)
+			require.NoError(t, svc.Lock(t.Context()))
+			require.True(t, svc.IsLocked())
+
+			// pubkey only operation, callable while locked
+			require.NoError(t, svc.ClaimKey(t.Context(), "anything"))
+
+			keys, err := svc.ListKeys(t.Context())
+			require.NoError(t, err)
+			require.Len(t, keys, 1)
+		})
 	})
 
-	t.Run("initialized is a no op", func(t *testing.T) {
-		svc, _ := newUnlockedTestIdentity(t)
-		require.NoError(t, svc.ClaimKey(t.Context(), "anything"))
-		require.NoError(t, svc.ClaimKey(t.Context(), "anything")) // idempotent
-
-		keys, err := svc.ListKeys(t.Context())
-		require.NoError(t, err)
-		require.Len(t, keys, 1) // singlekey always reports its one key
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			setup  func(t *testing.T) identity.Identity
+			expErr string
+		}{
+			{
+				"not initialized",
+				func(t *testing.T) identity.Identity { return newTestIdentity(t) },
+				"identity not initialized",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := tt.setup(t).ClaimKey(t.Context(), "anything")
+				require.ErrorContains(t, err, tt.expErr)
+			})
+		}
 	})
 }
 

--- a/pkg/client-lib/identity/identity_test.go
+++ b/pkg/client-lib/identity/identity_test.go
@@ -181,6 +181,24 @@ func TestListKeys(t *testing.T) {
 	})
 }
 
+func TestClaimKey(t *testing.T) {
+	t.Run("not initialized", func(t *testing.T) {
+		svc := newTestIdentity(t)
+		err := svc.ClaimKey(t.Context(), "anything")
+		require.Error(t, err)
+	})
+
+	t.Run("initialized is a no op", func(t *testing.T) {
+		svc, _ := newUnlockedTestIdentity(t)
+		require.NoError(t, svc.ClaimKey(t.Context(), "anything"))
+		require.NoError(t, svc.ClaimKey(t.Context(), "anything")) // idempotent
+
+		keys, err := svc.ListKeys(t.Context())
+		require.NoError(t, err)
+		require.Len(t, keys, 1) // singlekey always reports its one key
+	})
+}
+
 func newTestIdentity(t *testing.T) identity.Identity {
 	t.Helper()
 	store, err := identityinmemorystore.NewStore()

--- a/pkg/client-lib/identity/singlekey/identity.go
+++ b/pkg/client-lib/identity/singlekey/identity.go
@@ -154,6 +154,13 @@ func (s *service) NewKey(ctx context.Context) (*identity.KeyRef, error) {
 	}, nil
 }
 
+func (s *service) ClaimKey(_ context.Context, _ string) error {
+	if s.data == nil {
+		return ErrNotInitialized
+	}
+	return nil
+}
+
 func (s *service) GetKey(ctx context.Context, _ string) (*identity.KeyRef, error) {
 	if s.data == nil {
 		return nil, ErrNotInitialized


### PR DESCRIPTION
fixes #1066 

allow callers that allocate keys by id via `GetKey` (for example the go-sdk contract manager) to register the allocation so `ListKeys` reflects them across restarts. The singlekey backend implements `ClaimKey` as a no op since it has only one key.

Refs: arkade-os/go-sdk#180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new public Identity API method to support additional key-management operations.

* **Tests**
  * Added test coverage validating idempotent behavior and proper error handling when identity state is uninitialized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/arkd/pull/1067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->