### PR TITLE
Connection pooling for gateway stream connections

### DIFF
--- a/cmd/arkd/main.go
+++ b/cmd/arkd/main.go
@@ -45,6 +45,7 @@ func startAction(_ *cli.Context) error {
 		HeartbeatInterval:    cfg.HeartbeatInterval,
 		EnablePprof:          cfg.EnablePprof,
 		MaxConcurrentStreams: cfg.MaxConcurrentStreams,
+		StreamConnPoolSize:   cfg.StreamConnPoolSize,
 	}
 
 	svc, err := grpcservice.NewService(Version, svcConfig, cfg)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,6 +295,7 @@ var (
 	defaultIndexerAuthTokenExpiry        = 300 // 5 minutes in seconds
 	defaultMaxConcurrentStreams          = uint32(1000)
 	defaultStreamConnPoolSize            = uint32(4)
+	maxStreamConnPoolSize                = uint32(64)
 	defaultMaxOpReturnOuts               = uint32(3)
 )
 
@@ -462,7 +463,10 @@ func LoadConfig() (*Config, error) {
 		IndexerAuthTokenExpiry:        viper.GetInt64(IndexerAuthTokenExpiry),
 		IndexerSigningKey:             viper.GetString(IndexerSigningKey),
 		MaxConcurrentStreams:          viper.GetUint32(MaxConcurrentStreams),
-		StreamConnPoolSize:            max(1, viper.GetUint32(StreamConnPoolSize)),
+		// Default to 1 or maxStreamConnPoolSize if out of bounds
+		StreamConnPoolSize: min(
+			maxStreamConnPoolSize, max(1, viper.GetUint32(StreamConnPoolSize)),
+		),
 		// Default to 1 if set to 0
 		MaxOpReturnOutputs: max(1, viper.GetUint32(MaxOpReturnOutputs)),
 	}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,6 +147,7 @@ type Config struct {
 	// SENSITIVE: must never be logged.
 	IndexerSigningKey    string
 	MaxConcurrentStreams uint32
+	StreamConnPoolSize   uint32
 
 	fee            ports.FeeManager
 	repo           ports.RepoManager
@@ -252,6 +253,7 @@ var (
 	// IndexerSigningKey is a hex-encoded private key. SENSITIVE: never log this value.
 	IndexerSigningKey    = "INDEXER_SIGNING_PRIVKEY" // #nosec G101
 	MaxConcurrentStreams = "MAX_CONCURRENT_STREAMS"
+	StreamConnPoolSize   = "STREAM_CONN_POOL_SIZE"
 
 	defaultDatadir             = arklib.AppDataDir("arkd", false)
 	defaultSessionDuration     = 30
@@ -292,6 +294,7 @@ var (
 	defaultIndexerExposure               = "public"
 	defaultIndexerAuthTokenExpiry        = 300 // 5 minutes in seconds
 	defaultMaxConcurrentStreams          = uint32(1000)
+	defaultStreamConnPoolSize            = uint32(4)
 	defaultMaxOpReturnOuts               = uint32(3)
 )
 
@@ -342,6 +345,7 @@ func LoadConfig() (*Config, error) {
 	viper.SetDefault(IndexerExposure, defaultIndexerExposure)
 	viper.SetDefault(IndexerAuthTokenExpiry, defaultIndexerAuthTokenExpiry)
 	viper.SetDefault(MaxConcurrentStreams, defaultMaxConcurrentStreams)
+	viper.SetDefault(StreamConnPoolSize, defaultStreamConnPoolSize)
 	viper.SetDefault(MaxOpReturnOutputs, defaultMaxOpReturnOuts)
 
 	if err := initDatadir(); err != nil {
@@ -458,6 +462,7 @@ func LoadConfig() (*Config, error) {
 		IndexerAuthTokenExpiry:        viper.GetInt64(IndexerAuthTokenExpiry),
 		IndexerSigningKey:             viper.GetString(IndexerSigningKey),
 		MaxConcurrentStreams:          viper.GetUint32(MaxConcurrentStreams),
+		StreamConnPoolSize:            max(1, viper.GetUint32(StreamConnPoolSize)),
 		// Default to 1 if set to 0
 		MaxOpReturnOutputs: max(1, viper.GetUint32(MaxOpReturnOutputs)),
 	}, nil

--- a/internal/interface/grpc/config.go
+++ b/internal/interface/grpc/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	HeartbeatInterval    int64
 	EnablePprof          bool
 	MaxConcurrentStreams uint32
+	StreamConnPoolSize   uint32
 }
 
 func (c Config) Validate() error {

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -55,7 +55,7 @@ type service struct {
 	otelShutdown      func(context.Context) error
 	pyroscopeShutdown func() error
 	unaryConn         *grpc.ClientConn
-	streamConn        *grpc.ClientConn
+	streamConns       []*grpc.ClientConn
 	adminConn         *grpc.ClientConn
 }
 
@@ -210,8 +210,8 @@ func (s *service) stop() {
 			log.Warn("failed to close unary transport connection")
 		}
 	}
-	if s.streamConn != nil {
-		if err := s.streamConn.Close(); err != nil {
+	for _, sc := range s.streamConns {
+		if err := sc.Close(); err != nil {
 			log.Warn("failed to close stream transport connection")
 		}
 	}
@@ -375,18 +375,40 @@ func (s *service) newServer(tlsConfig *tls.Config, withPprof bool) error {
 	if err != nil {
 		return err
 	}
-	streamConn, err := grpc.NewClient(
-		s.config.gatewayAddress(), gatewayOpts,
-	)
-	if err != nil {
-		if err := unaryConn.Close(); err != nil {
-			log.Warn("failed to close unary transport connection")
-		}
-		return err
-	}
 	s.unaryConn = unaryConn
-	s.streamConn = streamConn
-	conn := &splitConn{unary: unaryConn, stream: streamConn}
+
+	// Connection pool for streaming RPCs. Each connection has its own
+	// HTTP/2 MAX_CONCURRENT_STREAMS budget, so a pool of N multiplies
+	// the gateway's concurrent stream capacity by N.
+	poolSize := s.config.StreamConnPoolSize
+	if poolSize == 0 {
+		poolSize = 1
+	}
+	streamConns := make([]*grpc.ClientConn, 0, poolSize)
+	for i := uint32(0); i < poolSize; i++ {
+		sc, err := grpc.NewClient(
+			s.config.gatewayAddress(), gatewayOpts,
+		)
+		if err != nil {
+			if closeErr := unaryConn.Close(); closeErr != nil {
+				log.Warn("failed to close unary transport connection")
+			}
+			for _, prev := range streamConns {
+				if closeErr := prev.Close(); closeErr != nil {
+					log.Warn("failed to close stream transport connection")
+				}
+			}
+			return err
+		}
+		streamConns = append(streamConns, sc)
+	}
+	s.streamConns = streamConns
+
+	streamPool := make([]grpc.ClientConnInterface, len(streamConns))
+	for i, sc := range streamConns {
+		streamPool[i] = sc
+	}
+	conn := &splitConn{unary: unaryConn, streamPool: streamPool}
 
 	customMatcher := func(key string) (string, bool) {
 		switch key {
@@ -461,10 +483,12 @@ func (s *service) newServer(tlsConfig *tls.Config, withPprof bool) error {
 				log.Warn("failed to close unary transport connection")
 			}
 			s.unaryConn = nil
-			if closeErr := s.streamConn.Close(); closeErr != nil {
-				log.Warn("failed to close stream transport connection")
+			for _, sc := range s.streamConns {
+				if closeErr := sc.Close(); closeErr != nil {
+					log.Warn("failed to close stream transport connection")
+				}
 			}
-			s.streamConn = nil
+			s.streamConns = nil
 			return err
 		}
 		s.adminConn = adminConn
@@ -647,10 +671,13 @@ func isHttpRequest(req *http.Request) bool {
 		strings.Contains(req.Header.Get("Content-Type"), "application/json")
 }
 
-// splitConn routes unary and streaming RPCs to separate grpc.ClientConn
+// splitConn routes unary RPCs to a dedicated connection and round-robins
+// streaming RPCs across a pool of connections. Each connection carries an
+// independent HTTP/2 MAX_CONCURRENT_STREAMS budget.
 type splitConn struct {
-	unary  grpc.ClientConnInterface
-	stream grpc.ClientConnInterface
+	unary       grpc.ClientConnInterface
+	streamPool  []grpc.ClientConnInterface
+	streamIndex atomic.Uint64
 }
 
 func (c *splitConn) Invoke(
@@ -659,8 +686,13 @@ func (c *splitConn) Invoke(
 	return c.unary.Invoke(ctx, method, args, reply, opts...)
 }
 
+// Called by the meshapi gateway to create new streams. Uses a simple round-robin
+// selection strategy to atomically increment the counter and wrap around
+// the pool size to select the next connection.
 func (c *splitConn) NewStream(
 	ctx context.Context, desc *grpc.StreamDesc, method string, opts ...grpc.CallOption,
 ) (grpc.ClientStream, error) {
-	return c.stream.NewStream(ctx, desc, method, opts...)
+	idx := c.streamIndex.Add(1) - 1
+	conn := c.streamPool[idx%uint64(len(c.streamPool))]
+	return conn.NewStream(ctx, desc, method, opts...)
 }

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -403,6 +403,7 @@ func (s *service) newServer(tlsConfig *tls.Config, withPprof bool) error {
 		streamConns = append(streamConns, sc)
 	}
 	s.streamConns = streamConns
+	log.Infof("stream connection pool size: %d", poolSize)
 
 	streamPool := make([]grpc.ClientConnInterface, len(streamConns))
 	for i, sc := range streamConns {

--- a/internal/interface/grpc/service_test.go
+++ b/internal/interface/grpc/service_test.go
@@ -1,0 +1,131 @@
+package grpcservice
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// Mock connection object implementing grpc.ClientConnInterface
+// to count unary vs stream call counts.
+type mockConn struct {
+	invokeCalls atomic.Int64
+	streamCalls atomic.Int64
+}
+
+func (m *mockConn) Invoke(
+	_ context.Context, _ string, _, _ any, _ ...grpc.CallOption,
+) error {
+	m.invokeCalls.Add(1)
+	return nil
+}
+
+func (m *mockConn) NewStream(
+	_ context.Context, _ *grpc.StreamDesc, _ string, _ ...grpc.CallOption,
+) (grpc.ClientStream, error) {
+	m.streamCalls.Add(1)
+	return nil, nil
+}
+
+func TestSplitConnInvoke(t *testing.T) {
+	t.Run("routes unary only", func(t *testing.T) {
+		unary := &mockConn{}
+		streams := []grpc.ClientConnInterface{&mockConn{}, &mockConn{}}
+		sc := &splitConn{unary: unary, streamPool: streams}
+
+		for i := 0; i < 10; i++ {
+			require.NoError(t, sc.Invoke(context.Background(), "/test", nil, nil))
+		}
+
+		require.Equal(t, int64(10), unary.invokeCalls.Load())
+		for i, s := range streams {
+			mock := s.(*mockConn)
+			require.Zero(t, mock.invokeCalls.Load(), "stream pool[%d] received invoke calls", i)
+			require.Zero(t, mock.streamCalls.Load(), "stream pool[%d] received stream calls", i)
+		}
+	})
+}
+
+func TestSplitConnNewStream(t *testing.T) {
+	t.Run("round robins across pool", func(t *testing.T) {
+		unary := &mockConn{}
+		poolSize := 4
+		streams := make([]grpc.ClientConnInterface, poolSize)
+		for i := range streams {
+			streams[i] = &mockConn{}
+		}
+		sc := &splitConn{unary: unary, streamPool: streams}
+
+		totalCalls := 100
+		for i := 0; i < totalCalls; i++ {
+			_, err := sc.NewStream(context.Background(), nil, "/test")
+			require.NoError(t, err)
+		}
+
+		expectedPerConn := int64(totalCalls / poolSize)
+		for i, s := range streams {
+			require.Equal(t, expectedPerConn, s.(*mockConn).streamCalls.Load(),
+				"stream pool[%d] call count", i)
+		}
+		require.Zero(t, unary.streamCalls.Load(), "unary conn received stream calls")
+	})
+
+	t.Run("pool size one", func(t *testing.T) {
+		unary := &mockConn{}
+		single := &mockConn{}
+		sc := &splitConn{unary: unary, streamPool: []grpc.ClientConnInterface{single}}
+
+		for i := 0; i < 50; i++ {
+			_, err := sc.NewStream(context.Background(), nil, "/test")
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, int64(50), single.streamCalls.Load())
+	})
+
+	t.Run("concurrent creation safe and evenly distributed", func(t *testing.T) {
+		unary := &mockConn{}
+		poolSize := 4
+		streams := make([]grpc.ClientConnInterface, poolSize)
+		for i := range streams {
+			streams[i] = &mockConn{}
+		}
+		sc := &splitConn{unary: unary, streamPool: streams}
+
+		goroutines := 100
+		callsPerGoroutine := 100
+		totalCalls := goroutines * callsPerGoroutine
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			go func() {
+				defer wg.Done()
+				for i := 0; i < callsPerGoroutine; i++ {
+					_, err := sc.NewStream(context.Background(), nil, "/test")
+					require.NoError(t, err)
+				}
+			}()
+		}
+		wg.Wait()
+
+		var totalObserved int64
+		for _, s := range streams {
+			totalObserved += s.(*mockConn).streamCalls.Load()
+		}
+		require.Equal(t, int64(totalCalls), totalObserved)
+
+		// Verify roughly even distribution (allow 20% deviation).
+		expected := int64(totalCalls / poolSize)
+		tolerance := expected / 5
+		for i, s := range streams {
+			got := s.(*mockConn).streamCalls.Load()
+			require.InDelta(t, expected, got, float64(tolerance),
+				"stream pool[%d] distribution", i)
+		}
+	})
+}


### PR DESCRIPTION
Pools the gateway's streaming RPCs across multiple HTTP/2 connections to multiply the effective MAX_CONCURRENT_STREAMS capacity. Each connection in the pool carries an independent stream budget, and `splitConn` round-robins `NewStream` calls across them.

Configurable via `ARKD_STREAM_CONN_POOL_SIZE` (default 4). A pool size of 1 preserves the previous single-connection behavior.

---
Good work has already been done on streaming scalability by splitting unary RPCs from streaming RPCs into separate connections. However, they are both still limited to the same `MAX_CONCURRENT_STREAMS` value per connection.

This PR implements a basic round-robin connection pool for stream connections, allowing us to scale streaming capacity separately from the unary connection.

### Alternative Approaches

1. An enhanced version of this PR can be constructed to replace the round-robin routing strategy with a "least loaded picker". A count of streams per connection is maintained and new streams are routed to the connection which has the most capacity. This approach mitigates risks of long-lived streams unevenly saturating a certain connection's capacity and resulting in stream queues which leave requests hanging silently. I believe this is a reasonable improvement and plan to open a separate PR for consideration.

2. Research has suggested the current bottleneck necessitating connection pooling is a limitation of the `grpc-go` architecture when used looping back to the same server. One solution is to decouple the gateway from the application server and route requests using the `dns:///` protocol in a round-robin fashion. This is only relevant if the architecture moves to a separate gateway process, and is more infrastructure complexity but a viable longer term consideration.

3. Research has suggested that replacing our current gateway implementation with https://github.com/connectrpc/connect-go is both feasible and a reasonable alternative architecture to consider. The architecture of this solution eliminates these connection scalability concerns entirely. I have a local branch which has the migration mostly prototyped, but still working through some backward compatibility nuances from the E2E tests. This solution is bigger change, bigger risk, but also worth considering while we're still in an alpha stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `STREAM_CONN_POOL_SIZE` environment variable configuration parameter to control the size of gRPC streaming connection pools, enabling operators to tune connection resource allocation for their workload.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/arkd/pull/1073?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->