### PR TITLE
Fix explorer polling fallback panic when poll interval is unset

### DIFF
--- a/pkg/client-lib/explorer/mempool/explorer.go
+++ b/pkg/client-lib/explorer/mempool/explorer.go
@@ -61,9 +61,10 @@ import (
 )
 
 const (
-	BitcoinExplorer = "bitcoin"
-	pongInterval    = 60 * time.Second
-	pingInterval    = (pongInterval * 9) / 10
+	BitcoinExplorer     = "bitcoin"
+	defaultPollInterval = 10 * time.Second
+	pongInterval        = 60 * time.Second
+	pingInterval        = (pongInterval * 9) / 10
 )
 
 var (
@@ -117,7 +118,9 @@ func NewExplorer(baseUrl string, net arklib.Network, opts ...Option) (explorer.E
 		return nil, fmt.Errorf("invalid base url: %s", err)
 	}
 
-	svcOpts := &explorerSvc{}
+	svcOpts := &explorerSvc{
+		pollInterval: defaultPollInterval,
+	}
 	for _, opt := range opts {
 		opt(svcOpts)
 	}
@@ -129,6 +132,9 @@ func NewExplorer(baseUrl string, net arklib.Network, opts ...Option) (explorer.E
 			net:        net,
 			noTracking: svcOpts.noTracking,
 		}, nil
+	}
+	if svcOpts.pollInterval <= 0 {
+		return nil, fmt.Errorf("poll interval must be positive")
 	}
 
 	svc := &explorerSvc{

--- a/pkg/client-lib/explorer/mempool/explorer.go
+++ b/pkg/client-lib/explorer/mempool/explorer.go
@@ -69,11 +69,11 @@ const (
 
 var (
 	defaultExplorerUrls = utils.SupportedType[string]{
-		arklib.Bitcoin.Name:        "https://mempool.space/api",
+		arklib.Bitcoin.Name:        "https://mempool.arkade.sh/api",
 		arklib.BitcoinTestNet.Name: "https://mempool.space/testnet/api",
 		//arklib.BitcoinTestNet4.Name: "https://mempool.space/testnet4/api", //TODO uncomment once supported
-		arklib.BitcoinSigNet.Name:    "https://mempool.space/signet/api",
-		arklib.BitcoinMutinyNet.Name: "https://mutinynet.com/api",
+		arklib.BitcoinSigNet.Name:    "https://mempool.signet.arkade.sh/api",
+		arklib.BitcoinMutinyNet.Name: "https://mempool.mutinynet.arkade.sh/api",
 		arklib.BitcoinRegTest.Name:   "http://127.0.0.1:3000",
 	}
 )

--- a/pkg/client-lib/explorer/service_test.go
+++ b/pkg/client-lib/explorer/service_test.go
@@ -1093,6 +1093,38 @@ func TestStopClearsSubscriptions(t *testing.T) {
 	})
 }
 
+func TestNewExplorerPollInterval(t *testing.T) {
+	t.Run("uses default interval on websocket fallback", func(t *testing.T) {
+		//The test server is just a plain HTTP test server.
+		//It does not register /v1/ws, so websocket setup fails and the explorer falls back to polling.
+		ts := newTestServer(t)
+
+		svc, err := mempool.NewExplorer(
+			ts.URL, arklib.Bitcoin, mempool.WithTracker(true),
+		)
+		require.NoError(t, err)
+
+		require.NotPanics(t, func() { svc.Start() })
+		t.Cleanup(svc.Stop)
+		time.Sleep(25 * time.Millisecond)
+
+		require.Equal(t, 0, svc.GetConnectionCount())
+	})
+
+	t.Run("rejects non-positive interval", func(t *testing.T) {
+		ts := newTestServer(t)
+
+		for _, interval := range []time.Duration{0, -time.Second} {
+			_, err := mempool.NewExplorer(
+				ts.URL, arklib.Bitcoin,
+				mempool.WithTracker(true),
+				mempool.WithPollInterval(interval),
+			)
+			require.ErrorContains(t, err, "poll interval must be positive")
+		}
+	})
+}
+
 func TestStartIsIdempotent(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		ts := newTestServer(t)


### PR DESCRIPTION
## Summary

Fixes a panic in the mempool explorer when websocket tracking falls back to polling without an explicit `WithPollInterval`.

`WithPollInterval` documented a 10s default, but `NewExplorer` initialized options with a zero-value service, leaving `pollInterval` as `0` unless callers explicitly set it. When websocket setup failed, polling called `time.NewTicker(0)` and panicked.

## Changes

- Add a real `10s` default polling interval in `NewExplorer`
- Reject non-positive polling intervals for tracking-enabled explorers
- Add regression tests for websocket fallback without `WithPollInterval`
- Add validation tests for zero and negative poll intervals

Fixes #1075 

@altafan @Kukks please review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explorer now validates that the polling interval is positive and returns an error for invalid values.
  * A default polling interval is applied during initialization.

* **Changes**
  * Default network endpoints for Bitcoin networks updated to new mempool providers.

* **Tests**
  * Added tests covering polling fallback behavior and poll-interval validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/arkd/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->