### PR TITLE
fix(client-lib): fetch all indexer pages and chunk large vtxo filters

### DIFF
--- a/pkg/client-lib/indexer/grpc/client.go
+++ b/pkg/client-lib/indexer/grpc/client.go
@@ -691,29 +691,59 @@ func (a *grpcClient) paginatedGetVtxos(
 	o, _ := indexer.ApplyGetVtxosOptions(opts...)
 	svc := a.svc()
 
-	vtxos, err := paginatedFetch(ctx, func(
-		ctx context.Context, page *arkv1.IndexerPageRequest,
-	) ([]types.Vtxo, *arkv1.IndexerPageResponse, error) {
-		resp, err := svc.GetVtxos(ctx, &arkv1.GetVtxosRequest{
-			Scripts:         o.Scripts,
-			Outpoints:       o.FormattedOutpoints(),
-			SpendableOnly:   o.SpendableOnly,
-			SpentOnly:       o.SpentOnly,
-			RecoverableOnly: o.RecoverableOnly,
-			PendingOnly:     o.PendingOnly,
-			After:           o.After,
-			Before:          o.Before,
-			Page:            page,
+	fetchPages := func(scripts []string, outpoints []types.Outpoint) ([]types.Vtxo, error) {
+		return paginatedFetch(ctx, func(
+			ctx context.Context, page *arkv1.IndexerPageRequest,
+		) ([]types.Vtxo, *arkv1.IndexerPageResponse, error) {
+			resp, err := svc.GetVtxos(ctx, &arkv1.GetVtxosRequest{
+				Scripts:         scripts,
+				Outpoints:       formatOutpoints(outpoints),
+				SpendableOnly:   o.SpendableOnly,
+				SpentOnly:       o.SpentOnly,
+				RecoverableOnly: o.RecoverableOnly,
+				PendingOnly:     o.PendingOnly,
+				After:           o.After,
+				Before:          o.Before,
+				Page:            page,
+			})
+			if err != nil {
+				return nil, nil, err
+			}
+			return newIndexerVtxos(resp.GetVtxos()), resp.GetPage(), nil
 		})
+	}
+
+	var vtxos []types.Vtxo
+	appendPages := func(scripts []string, outpoints []types.Outpoint) error {
+		pageVtxos, err := fetchPages(scripts, outpoints)
 		if err != nil {
-			return nil, nil, err
+			return err
 		}
-		return newIndexerVtxos(resp.GetVtxos()), resp.GetPage(), nil
-	})
-	if err != nil {
-		return nil, err
+		vtxos = append(vtxos, pageVtxos...)
+		return nil
+	}
+
+	for offset := 0; offset < len(o.Scripts); offset += maxPageSize {
+		end := min(offset+maxPageSize, len(o.Scripts))
+		if err := appendPages(o.Scripts[offset:end], nil); err != nil {
+			return nil, err
+		}
+	}
+	for offset := 0; offset < len(o.Outpoints); offset += maxPageSize {
+		end := min(offset+maxPageSize, len(o.Outpoints))
+		if err := appendPages(nil, o.Outpoints[offset:end]); err != nil {
+			return nil, err
+		}
 	}
 	return &indexer.VtxosResponse{Vtxos: vtxos}, nil
+}
+
+func formatOutpoints(outpoints []types.Outpoint) []string {
+	outs := make([]string, 0, len(outpoints))
+	for _, outpoint := range outpoints {
+		outs = append(outs, fmt.Sprintf("%s:%d", outpoint.Txid, outpoint.VOut))
+	}
+	return outs
 }
 
 func (a *grpcClient) paginatedGetVirtualTxs(
@@ -748,7 +778,7 @@ func paginatedFetch[T any](
 	) ([]T, *arkv1.IndexerPageResponse, error),
 ) ([]T, error) {
 	var all []T
-	pageIndex := int32(0)
+	pageIndex := int32(1)
 	reqCount := 0
 	for {
 		items, page, err := fetch(ctx, &arkv1.IndexerPageRequest{
@@ -762,7 +792,7 @@ func paginatedFetch[T any](
 		all = append(all, items...)
 		reqCount++
 
-		if page == nil || page.GetNext() >= page.GetTotal() {
+		if page == nil || page.GetCurrent() >= page.GetTotal() {
 			break
 		}
 		if reqCount >= maxPages {

--- a/pkg/client-lib/indexer/grpc/paginated_fetch_test.go
+++ b/pkg/client-lib/indexer/grpc/paginated_fetch_test.go
@@ -21,17 +21,17 @@ func TestPaginatedFetch(t *testing.T) {
 			{
 				name:       "single page",
 				totalPages: 1,
-				wantItems:  []int{0},
+				wantItems:  []int{1},
 			},
 			{
 				name:       "multiple pages",
 				totalPages: 3,
-				wantItems:  []int{0, 1, 2},
+				wantItems:  []int{1, 2, 3},
 			},
 			{
 				name:       "nil page response stops after first page",
 				totalPages: 0, // unused, fetch returns nil page
-				wantItems:  []int{0},
+				wantItems:  []int{1},
 			},
 			{
 				name:       "throttles after maxReqsPerSec requests",
@@ -39,7 +39,7 @@ func TestPaginatedFetch(t *testing.T) {
 				wantItems: func() []int {
 					items := make([]int, maxReqsPerSec+2)
 					for i := range items {
-						items[i] = i
+						items[i] = i + 1
 					}
 					return items
 				}(),
@@ -84,11 +84,11 @@ func TestPaginatedFetch(t *testing.T) {
 				name: "fetch error propagates",
 				ctx:  context.Background(),
 				fetch: func(_ context.Context, page *arkv1.IndexerPageRequest) ([]int, *arkv1.IndexerPageResponse, error) {
-					if page.GetIndex() == 1 {
+					if page.GetIndex() == 2 {
 						return nil, nil, fmt.Errorf("server error")
 					}
 					return []int{1}, &arkv1.IndexerPageResponse{
-						Current: 0, Next: 1, Total: 3,
+						Current: 1, Next: 2, Total: 3,
 					}, nil
 				},
 				wantErr: "server error",


### PR DESCRIPTION
## Summary

This fixes two client-lib indexer issues found while running large HD wallet restore stress tests.

## Fixes

### Fetch the final page from paginated indexer responses

`paginatedFetch` was starting from page `0` and stopping when `page.Next >= page.Total`.

arkd pagination is one-based. For a response with 10 total pages, page 9 returns:

- `Current = 9`
- `Next = 10`
- `Total = 10`

The previous stop condition treated that as complete and never fetched page 10. In practice, a 10k VTXO restore only imported 9k VTXOs.

This PR changes the client to:

- start pagination from page `1`
- stop when `page.Current >= page.Total`

### Avoid oversized GetVtxos filter requests

`GetVtxos` already paginated the response, but large calls still sent the full scripts/outpoints filter on every page request.

For example, a 50k wallet restore produced requests shaped like:

```text
GetVtxos(scripts=50000, page=1)
GetVtxos(scripts=50000, page=2)
```

Even though the response was paginated, the input filter was still too large. On sqlite-backed arkd this could fail with:

```
SQL logic error: too many SQL variables
```
This PR splits large GetVtxos script/outpoint filters into bounded batches and paginates each batch independently. That keeps request filter size bounded while still fetching all result pages for each batch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured pagination logic to process different request types in separate batches rather than combined operations.
  * Modified page indexing to begin from 1 instead of 0, with corresponding updates to pagination termination conditions.

* **Tests**
  * Updated pagination test cases, including valid and error scenarios, to reflect the new pagination behavior and indexing approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/arkd/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->