### PR TITLE
Startup retry loop for `nbxplorer` connection

### DIFF
--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -45,7 +45,7 @@ type nbxplorer struct {
 }
 
 const (
-	nbxplorerMaxRetries   = 30
+	nbxplorerMaxRetries    = 30
 	nbxplorerRetryInterval = 5 * time.Second
 )
 

--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -44,6 +44,11 @@ type nbxplorer struct {
 	groupID string
 }
 
+const (
+	nbxplorerMaxRetries   = 30
+	nbxplorerRetryInterval = 5 * time.Second
+)
+
 func New(rawURL string) (ports.Nbxplorer, error) {
 	rawURL = strings.TrimSuffix(rawURL, "/")
 
@@ -67,9 +72,24 @@ func New(rawURL string) (ports.Nbxplorer, error) {
 		groupID:    "",
 	}
 
-	status, err := svc.GetBitcoinStatus(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to nbxplorer: %s", err)
+	var status *ports.BitcoinStatus
+
+	for attempt := 1; attempt <= nbxplorerMaxRetries; attempt++ {
+		status, err = svc.GetBitcoinStatus(context.Background())
+		if err == nil {
+			break
+		}
+
+		if attempt == nbxplorerMaxRetries {
+			return nil, fmt.Errorf("failed to connect to nbxplorer after %d attempts: %s", nbxplorerMaxRetries, err)
+		}
+
+		log.WithFields(log.Fields{
+			"attempt": attempt,
+			"error":   err.Error(),
+		}).Warn("nbxplorer not ready, retrying")
+
+		time.Sleep(nbxplorerRetryInterval)
 	}
 
 	svc.minRelayTxFee = status.MinRelayTxFee


### PR DESCRIPTION
Avoids an `arkd-wallet` crash and restart by ensuring `nbxplorer` can serve RPCs before continuing with a connection. Retries 30 times at 5 second intervals for a total of 2.5 minutes, leaving the orchestrator to restart afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a bounded connection retry mechanism for the Bitcoin service: multiple reconnection attempts with wait intervals, per-attempt warnings on failure, and clearer error reporting when all retries are exhausted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arkade-os/arkd/pull/1083?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->