### PR TITLE
Use `minRelayTxFee` as fallback for fee estimation

### DIFF
--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -397,7 +397,8 @@ func (n *nbxplorer) GetNewUnusedAddress(ctx context.Context, derivationScheme st
 // EstimateFeeRate retrieves fee rate from /v1/cryptos/{cryptoCode}/fees/{blockCount} endpoint.
 func (n *nbxplorer) EstimateFeeRate(ctx context.Context) (chainfee.SatPerKVByte, error) {
 	blockCount := 1
-	data, err := n.makeRequest(ctx, "GET", fmt.Sprintf("/v1/cryptos/%s/fees/%d", btcCryptoCode, blockCount), nil)
+	fallback := float64(n.minRelayTxFee) / 1000
+	data, err := n.makeRequest(ctx, "GET", fmt.Sprintf("/v1/cryptos/%s/fees/%d?fallbackFeeRate=%f", btcCryptoCode, blockCount, fallback), nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to estimate fee rate: %w", err)
 	}


### PR DESCRIPTION
When `arkd-wallet` starts, it calls `nbxplorer` to estimate the current fee rate. `nbxplorer` delegates this to `bitcoind`'s `estimatesmartfee` RPC. If `bitcoind` doesn't have enough mempool data to estimate it returns nothing. `nbxplorer` passes that back as a zero fee rate, and `arkd-wallet` rejects it with `invalid fee rate received: 0.000000` and fails.

The fix passes `fallbackFeeRate` as a query parameter to the `nbxplorer` fee estimation endpoint. This is a supported but previously unused parameter in their API. When `bitcoind` can't estimate, `nbxplorer` returns the fallback value instead of zero. We use `minRelayTxFee` as the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback fee rate estimation to ensure more reliable transaction fee calculation, providing improved handling when primary fee sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->