### PR TITLE
[arkd-wallet] Improve Withdraw RPC + add GetMainAccountUtxos

### DIFF
--- a/api-spec/openapi/swagger/ark/v1/admin.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/admin.openapi.json
@@ -1032,6 +1032,36 @@
           }
         }
       }
+    },
+    "/v1/admin/wallet/utxos": {
+      "get": {
+        "tags": [
+          "AdminService"
+        ],
+        "operationId": "AdminService_GetMainAccountUtxos",
+        "responses": {
+          "200": {
+            "description": "a successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMainAccountUtxosResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1355,6 +1385,22 @@
         "properties": {
           "fees": {
             "$ref": "#/components/schemas/IntentFees"
+          }
+        }
+      },
+      "GetMainAccountUtxosRequest": {
+        "title": "GetMainAccountUtxosRequest",
+        "type": "object"
+      },
+      "GetMainAccountUtxosResponse": {
+        "title": "GetMainAccountUtxosResponse",
+        "type": "object",
+        "properties": {
+          "utxos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WalletUtxo"
+            }
           }
         }
       },
@@ -1896,6 +1942,36 @@
       "UpdateScheduledSessionConfigResponse": {
         "title": "UpdateScheduledSessionConfigResponse",
         "type": "object"
+      },
+      "WalletUtxo": {
+        "title": "WalletUtxo",
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "confirmations": {
+            "type": "integer",
+            "format": "uint32"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "script": {
+            "type": "string"
+          },
+          "txid": {
+            "type": "string"
+          },
+          "value": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "vout": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        }
       }
     }
   },

--- a/api-spec/openapi/swagger/arkwallet/v1/bitcoin_wallet.openapi.json
+++ b/api-spec/openapi/swagger/arkwallet/v1/bitcoin_wallet.openapi.json
@@ -494,6 +494,36 @@
         }
       }
     },
+    "/v1/wallet/main-account-utxos": {
+      "get": {
+        "tags": [
+          "WalletService"
+        ],
+        "operationId": "WalletService_GetMainAccountUtxos",
+        "responses": {
+          "200": {
+            "description": "a successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMainAccountUtxosResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Status"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/wallet/network": {
       "get": {
         "tags": [
@@ -1462,6 +1492,22 @@
           }
         }
       },
+      "GetMainAccountUtxosRequest": {
+        "title": "GetMainAccountUtxosRequest",
+        "type": "object"
+      },
+      "GetMainAccountUtxosResponse": {
+        "title": "GetMainAccountUtxosResponse",
+        "type": "object",
+        "properties": {
+          "utxos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WalletUtxo"
+            }
+          }
+        }
+      },
       "GetNetworkRequest": {
         "title": "GetNetworkRequest",
         "type": "object"
@@ -1945,6 +1991,36 @@
       "WaitForSyncResponse": {
         "title": "WaitForSyncResponse",
         "type": "object"
+      },
+      "WalletUtxo": {
+        "title": "WalletUtxo",
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "confirmations": {
+            "type": "integer",
+            "format": "uint32"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "script": {
+            "type": "string"
+          },
+          "txid": {
+            "type": "string"
+          },
+          "value": {
+            "type": "integer",
+            "format": "uint64"
+          },
+          "vout": {
+            "type": "integer",
+            "format": "uint32"
+          }
+        }
       },
       "WatchScriptsRequest": {
         "title": "WatchScriptsRequest",

--- a/api-spec/protobuf/ark/v1/admin.proto
+++ b/api-spec/protobuf/ark/v1/admin.proto
@@ -143,6 +143,11 @@ service AdminService {
       body: "*"
     };
   }
+  rpc GetMainAccountUtxos(GetMainAccountUtxosRequest) returns (GetMainAccountUtxosResponse) {
+    option (meshapi.gateway.http) = {
+      get: "/v1/admin/wallet/utxos"
+    };
+  }
 }
 
 message GetScheduledSweepRequest {}
@@ -384,6 +389,21 @@ message SweepRequest {
 message SweepResponse {
   string txid = 1;
   string hex = 2;
+}
+
+message GetMainAccountUtxosRequest {}
+message GetMainAccountUtxosResponse {
+  repeated WalletUtxo utxos = 1;
+}
+
+message WalletUtxo {
+  string txid = 1;
+  uint32 vout = 2;
+  uint64 value = 3;
+  string script = 4;
+  string address = 5;
+  uint32 confirmations = 6;
+  bool locked = 7;
 }
 
 message ListTokensRequest {

--- a/api-spec/protobuf/arkwallet/v1/bitcoin_wallet.proto
+++ b/api-spec/protobuf/arkwallet/v1/bitcoin_wallet.proto
@@ -116,6 +116,11 @@ service WalletService {
       get: "/v1/wallet/connector-utxos"
     };
   }
+  rpc GetMainAccountUtxos(GetMainAccountUtxosRequest) returns (GetMainAccountUtxosResponse) {
+    option (meshapi.gateway.http) = {
+      get: "/v1/wallet/main-account-utxos"
+    };
+  }
   rpc MainAccountBalance(MainAccountBalanceRequest) returns (MainAccountBalanceResponse) {
     option (meshapi.gateway.http) = {
       get: "/v1/wallet/main-account-balance"
@@ -345,6 +350,11 @@ message ListConnectorUtxosResponse {
   repeated TxInput utxos = 1;
 }
 
+message GetMainAccountUtxosRequest {}
+message GetMainAccountUtxosResponse {
+  repeated WalletUtxo utxos = 1;
+}
+
 message MainAccountBalanceRequest {}
 message MainAccountBalanceResponse {
   // TODO rename to available and locked
@@ -431,6 +441,16 @@ message TxInput {
   uint32 index = 2;
   string script = 3;
   uint64 value = 4;
+}
+
+message WalletUtxo {
+  string txid = 1;
+  uint32 vout = 2;
+  uint64 value = 3;
+  string script = 4;
+  string address = 5;
+  uint32 confirmations = 6;
+  bool locked = 7;
 }
 
 message TxOutpoint {

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.go
@@ -2858,6 +2858,178 @@ func (x *SweepResponse) GetHex() string {
 	return ""
 }
 
+type GetMainAccountUtxosRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMainAccountUtxosRequest) Reset() {
+	*x = GetMainAccountUtxosRequest{}
+	mi := &file_ark_v1_admin_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMainAccountUtxosRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMainAccountUtxosRequest) ProtoMessage() {}
+
+func (x *GetMainAccountUtxosRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMainAccountUtxosRequest.ProtoReflect.Descriptor instead.
+func (*GetMainAccountUtxosRequest) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{54}
+}
+
+type GetMainAccountUtxosResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Utxos         []*WalletUtxo          `protobuf:"bytes,1,rep,name=utxos,proto3" json:"utxos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMainAccountUtxosResponse) Reset() {
+	*x = GetMainAccountUtxosResponse{}
+	mi := &file_ark_v1_admin_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMainAccountUtxosResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMainAccountUtxosResponse) ProtoMessage() {}
+
+func (x *GetMainAccountUtxosResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMainAccountUtxosResponse.ProtoReflect.Descriptor instead.
+func (*GetMainAccountUtxosResponse) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *GetMainAccountUtxosResponse) GetUtxos() []*WalletUtxo {
+	if x != nil {
+		return x.Utxos
+	}
+	return nil
+}
+
+type WalletUtxo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	Vout          uint32                 `protobuf:"varint,2,opt,name=vout,proto3" json:"vout,omitempty"`
+	Value         uint64                 `protobuf:"varint,3,opt,name=value,proto3" json:"value,omitempty"`
+	Script        string                 `protobuf:"bytes,4,opt,name=script,proto3" json:"script,omitempty"`
+	Address       string                 `protobuf:"bytes,5,opt,name=address,proto3" json:"address,omitempty"`
+	Confirmations uint32                 `protobuf:"varint,6,opt,name=confirmations,proto3" json:"confirmations,omitempty"`
+	Locked        bool                   `protobuf:"varint,7,opt,name=locked,proto3" json:"locked,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WalletUtxo) Reset() {
+	*x = WalletUtxo{}
+	mi := &file_ark_v1_admin_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WalletUtxo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WalletUtxo) ProtoMessage() {}
+
+func (x *WalletUtxo) ProtoReflect() protoreflect.Message {
+	mi := &file_ark_v1_admin_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WalletUtxo.ProtoReflect.Descriptor instead.
+func (*WalletUtxo) Descriptor() ([]byte, []int) {
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *WalletUtxo) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *WalletUtxo) GetVout() uint32 {
+	if x != nil {
+		return x.Vout
+	}
+	return 0
+}
+
+func (x *WalletUtxo) GetValue() uint64 {
+	if x != nil {
+		return x.Value
+	}
+	return 0
+}
+
+func (x *WalletUtxo) GetScript() string {
+	if x != nil {
+		return x.Script
+	}
+	return ""
+}
+
+func (x *WalletUtxo) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *WalletUtxo) GetConfirmations() uint32 {
+	if x != nil {
+		return x.Confirmations
+	}
+	return 0
+}
+
+func (x *WalletUtxo) GetLocked() bool {
+	if x != nil {
+		return x.Locked
+	}
+	return false
+}
+
 type ListTokensRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Token         string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`       // base64 auth token
@@ -2870,7 +3042,7 @@ type ListTokensRequest struct {
 
 func (x *ListTokensRequest) Reset() {
 	*x = ListTokensRequest{}
-	mi := &file_ark_v1_admin_proto_msgTypes[54]
+	mi := &file_ark_v1_admin_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2882,7 +3054,7 @@ func (x *ListTokensRequest) String() string {
 func (*ListTokensRequest) ProtoMessage() {}
 
 func (x *ListTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_v1_admin_proto_msgTypes[54]
+	mi := &file_ark_v1_admin_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2895,7 +3067,7 @@ func (x *ListTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTokensRequest.ProtoReflect.Descriptor instead.
 func (*ListTokensRequest) Descriptor() ([]byte, []int) {
-	return file_ark_v1_admin_proto_rawDescGZIP(), []int{54}
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *ListTokensRequest) GetToken() string {
@@ -2935,7 +3107,7 @@ type ListTokensResponse struct {
 
 func (x *ListTokensResponse) Reset() {
 	*x = ListTokensResponse{}
-	mi := &file_ark_v1_admin_proto_msgTypes[55]
+	mi := &file_ark_v1_admin_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2947,7 +3119,7 @@ func (x *ListTokensResponse) String() string {
 func (*ListTokensResponse) ProtoMessage() {}
 
 func (x *ListTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_v1_admin_proto_msgTypes[55]
+	mi := &file_ark_v1_admin_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2960,7 +3132,7 @@ func (x *ListTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTokensResponse.ProtoReflect.Descriptor instead.
 func (*ListTokensResponse) Descriptor() ([]byte, []int) {
-	return file_ark_v1_admin_proto_rawDescGZIP(), []int{55}
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *ListTokensResponse) GetTokens() []*TokenInfo {
@@ -2981,7 +3153,7 @@ type TokenInfo struct {
 
 func (x *TokenInfo) Reset() {
 	*x = TokenInfo{}
-	mi := &file_ark_v1_admin_proto_msgTypes[56]
+	mi := &file_ark_v1_admin_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2993,7 +3165,7 @@ func (x *TokenInfo) String() string {
 func (*TokenInfo) ProtoMessage() {}
 
 func (x *TokenInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_v1_admin_proto_msgTypes[56]
+	mi := &file_ark_v1_admin_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3006,7 +3178,7 @@ func (x *TokenInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TokenInfo.ProtoReflect.Descriptor instead.
 func (*TokenInfo) Descriptor() ([]byte, []int) {
-	return file_ark_v1_admin_proto_rawDescGZIP(), []int{56}
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *TokenInfo) GetHash() string {
@@ -3042,7 +3214,7 @@ type RevokeTokensRequest struct {
 
 func (x *RevokeTokensRequest) Reset() {
 	*x = RevokeTokensRequest{}
-	mi := &file_ark_v1_admin_proto_msgTypes[57]
+	mi := &file_ark_v1_admin_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3054,7 +3226,7 @@ func (x *RevokeTokensRequest) String() string {
 func (*RevokeTokensRequest) ProtoMessage() {}
 
 func (x *RevokeTokensRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_v1_admin_proto_msgTypes[57]
+	mi := &file_ark_v1_admin_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3067,7 +3239,7 @@ func (x *RevokeTokensRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeTokensRequest.ProtoReflect.Descriptor instead.
 func (*RevokeTokensRequest) Descriptor() ([]byte, []int) {
-	return file_ark_v1_admin_proto_rawDescGZIP(), []int{57}
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *RevokeTokensRequest) GetToken() string {
@@ -3107,7 +3279,7 @@ type RevokeTokensResponse struct {
 
 func (x *RevokeTokensResponse) Reset() {
 	*x = RevokeTokensResponse{}
-	mi := &file_ark_v1_admin_proto_msgTypes[58]
+	mi := &file_ark_v1_admin_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3119,7 +3291,7 @@ func (x *RevokeTokensResponse) String() string {
 func (*RevokeTokensResponse) ProtoMessage() {}
 
 func (x *RevokeTokensResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_ark_v1_admin_proto_msgTypes[58]
+	mi := &file_ark_v1_admin_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3132,7 +3304,7 @@ func (x *RevokeTokensResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RevokeTokensResponse.ProtoReflect.Descriptor instead.
 func (*RevokeTokensResponse) Descriptor() ([]byte, []int) {
-	return file_ark_v1_admin_proto_rawDescGZIP(), []int{58}
+	return file_ark_v1_admin_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *RevokeTokensResponse) GetRevokedCount() int32 {
@@ -3311,7 +3483,19 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x10commitment_txids\x18\x02 \x03(\tR\x0fcommitmentTxids\"5\n" +
 	"\rSweepResponse\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x10\n" +
-	"\x03hex\x18\x02 \x01(\tR\x03hex\"m\n" +
+	"\x03hex\x18\x02 \x01(\tR\x03hex\"\x1c\n" +
+	"\x1aGetMainAccountUtxosRequest\"G\n" +
+	"\x1bGetMainAccountUtxosResponse\x12(\n" +
+	"\x05utxos\x18\x01 \x03(\v2\x12.ark.v1.WalletUtxoR\x05utxos\"\xba\x01\n" +
+	"\n" +
+	"WalletUtxo\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
+	"\x04vout\x18\x02 \x01(\rR\x04vout\x12\x14\n" +
+	"\x05value\x18\x03 \x01(\x04R\x05value\x12\x16\n" +
+	"\x06script\x18\x04 \x01(\tR\x06script\x12\x18\n" +
+	"\aaddress\x18\x05 \x01(\tR\aaddress\x12$\n" +
+	"\rconfirmations\x18\x06 \x01(\rR\rconfirmations\x12\x16\n" +
+	"\x06locked\x18\a \x01(\bR\x06locked\"m\n" +
 	"\x11ListTokensRequest\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\tR\x04hash\x12\x1a\n" +
@@ -3342,7 +3526,7 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x15CRIME_TYPE_MANUAL_BAN\x10\a*M\n" +
 	"\x0eConvictionType\x12\x1f\n" +
 	"\x1bCONVICTION_TYPE_UNSPECIFIED\x10\x00\x12\x1a\n" +
-	"\x16CONVICTION_TYPE_SCRIPT\x10\x012\xd1\x17\n" +
+	"\x16CONVICTION_TYPE_SCRIPT\x10\x012\xce\x18\n" +
 	"\fAdminService\x12o\n" +
 	"\x11GetScheduledSweep\x12 .ark.v1.GetScheduledSweepRequest\x1a!.ark.v1.GetScheduledSweepResponse\"\x15\xb2J\x12\x12\x10/v1/admin/sweeps\x12s\n" +
 	"\x0fGetRoundDetails\x12\x1e.ark.v1.GetRoundDetailsRequest\x1a\x1f.ark.v1.GetRoundDetailsResponse\"\x1f\xb2J\x1c\x12\x1a/v1/admin/round/{round_id}\x12W\n" +
@@ -3371,7 +3555,8 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x14GetExpiringLiquidity\x12#.ark.v1.GetExpiringLiquidityRequest\x1a$.ark.v1.GetExpiringLiquidityResponse\"!\xb2J\x1e\x12\x1c/v1/admin/liquidity/expiring\x12\x90\x01\n" +
 	"\x17GetRecoverableLiquidity\x12&.ark.v1.GetRecoverableLiquidityRequest\x1a'.ark.v1.GetRecoverableLiquidityResponse\"$\xb2J!\x12\x1f/v1/admin/liquidity/recoverable\x12t\n" +
 	"\x10GetCollectedFees\x12\x1f.ark.v1.GetCollectedFeesRequest\x1a .ark.v1.GetCollectedFeesResponse\"\x1d\xb2J\x1a\x12\x18/v1/admin/fees/collected\x12M\n" +
-	"\x05Sweep\x12\x14.ark.v1.SweepRequest\x1a\x15.ark.v1.SweepResponse\"\x17\xb2J\x14B\x01*\"\x0f/v1/admin/sweepBy\n" +
+	"\x05Sweep\x12\x14.ark.v1.SweepRequest\x1a\x15.ark.v1.SweepResponse\"\x17\xb2J\x14B\x01*\"\x0f/v1/admin/sweep\x12{\n" +
+	"\x13GetMainAccountUtxos\x12\".ark.v1.GetMainAccountUtxosRequest\x1a#.ark.v1.GetMainAccountUtxosResponse\"\x1b\xb2J\x18\x12\x16/v1/admin/wallet/utxosBy\n" +
 	"\n" +
 	"com.ark.v1B\n" +
 	"AdminProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"
@@ -3389,7 +3574,7 @@ func file_ark_v1_admin_proto_rawDescGZIP() []byte {
 }
 
 var file_ark_v1_admin_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_ark_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
+var file_ark_v1_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 62)
 var file_ark_v1_admin_proto_goTypes = []any{
 	(CrimeType)(0),                               // 0: ark.v1.CrimeType
 	(ConvictionType)(0),                          // 1: ark.v1.ConvictionType
@@ -3447,13 +3632,16 @@ var file_ark_v1_admin_proto_goTypes = []any{
 	(*GetCollectedFeesResponse)(nil),             // 53: ark.v1.GetCollectedFeesResponse
 	(*SweepRequest)(nil),                         // 54: ark.v1.SweepRequest
 	(*SweepResponse)(nil),                        // 55: ark.v1.SweepResponse
-	(*ListTokensRequest)(nil),                    // 56: ark.v1.ListTokensRequest
-	(*ListTokensResponse)(nil),                   // 57: ark.v1.ListTokensResponse
-	(*TokenInfo)(nil),                            // 58: ark.v1.TokenInfo
-	(*RevokeTokensRequest)(nil),                  // 59: ark.v1.RevokeTokensRequest
-	(*RevokeTokensResponse)(nil),                 // 60: ark.v1.RevokeTokensResponse
-	(*FeeInfo)(nil),                              // 61: ark.v1.FeeInfo
-	(*Intent)(nil),                               // 62: ark.v1.Intent
+	(*GetMainAccountUtxosRequest)(nil),           // 56: ark.v1.GetMainAccountUtxosRequest
+	(*GetMainAccountUtxosResponse)(nil),          // 57: ark.v1.GetMainAccountUtxosResponse
+	(*WalletUtxo)(nil),                           // 58: ark.v1.WalletUtxo
+	(*ListTokensRequest)(nil),                    // 59: ark.v1.ListTokensRequest
+	(*ListTokensResponse)(nil),                   // 60: ark.v1.ListTokensResponse
+	(*TokenInfo)(nil),                            // 61: ark.v1.TokenInfo
+	(*RevokeTokensRequest)(nil),                  // 62: ark.v1.RevokeTokensRequest
+	(*RevokeTokensResponse)(nil),                 // 63: ark.v1.RevokeTokensResponse
+	(*FeeInfo)(nil),                              // 64: ark.v1.FeeInfo
+	(*Intent)(nil),                               // 65: ark.v1.Intent
 }
 var file_ark_v1_admin_proto_depIdxs = []int32{
 	41, // 0: ark.v1.GetScheduledSweepResponse.sweeps:type_name -> ark.v1.ScheduledSweep
@@ -3467,69 +3655,72 @@ var file_ark_v1_admin_proto_depIdxs = []int32{
 	47, // 8: ark.v1.GetConvictionsByRoundResponse.convictions:type_name -> ark.v1.Conviction
 	47, // 9: ark.v1.GetActiveScriptConvictionsResponse.convictions:type_name -> ark.v1.Conviction
 	40, // 10: ark.v1.ScheduledSweep.outputs:type_name -> ark.v1.SweepableOutput
-	61, // 11: ark.v1.ScheduledSessionConfig.fees:type_name -> ark.v1.FeeInfo
+	64, // 11: ark.v1.ScheduledSessionConfig.fees:type_name -> ark.v1.FeeInfo
 	46, // 12: ark.v1.IntentInfo.receivers:type_name -> ark.v1.Output
 	43, // 13: ark.v1.IntentInfo.inputs:type_name -> ark.v1.IntentInput
 	43, // 14: ark.v1.IntentInfo.boarding_inputs:type_name -> ark.v1.IntentInput
-	62, // 15: ark.v1.IntentInfo.intent:type_name -> ark.v1.Intent
+	65, // 15: ark.v1.IntentInfo.intent:type_name -> ark.v1.Intent
 	1,  // 16: ark.v1.Conviction.type:type_name -> ark.v1.ConvictionType
 	0,  // 17: ark.v1.Conviction.crime_type:type_name -> ark.v1.CrimeType
-	58, // 18: ark.v1.ListTokensResponse.tokens:type_name -> ark.v1.TokenInfo
-	2,  // 19: ark.v1.AdminService.GetScheduledSweep:input_type -> ark.v1.GetScheduledSweepRequest
-	4,  // 20: ark.v1.AdminService.GetRoundDetails:input_type -> ark.v1.GetRoundDetailsRequest
-	6,  // 21: ark.v1.AdminService.GetRounds:input_type -> ark.v1.GetRoundsRequest
-	8,  // 22: ark.v1.AdminService.CreateNote:input_type -> ark.v1.CreateNoteRequest
-	10, // 23: ark.v1.AdminService.GetScheduledSessionConfig:input_type -> ark.v1.GetScheduledSessionConfigRequest
-	12, // 24: ark.v1.AdminService.UpdateScheduledSessionConfig:input_type -> ark.v1.UpdateScheduledSessionConfigRequest
-	14, // 25: ark.v1.AdminService.ClearScheduledSessionConfig:input_type -> ark.v1.ClearScheduledSessionConfigRequest
-	16, // 26: ark.v1.AdminService.ListIntents:input_type -> ark.v1.ListIntentsRequest
-	18, // 27: ark.v1.AdminService.DeleteIntents:input_type -> ark.v1.DeleteIntentsRequest
-	20, // 28: ark.v1.AdminService.GetIntentFees:input_type -> ark.v1.GetIntentFeesRequest
-	22, // 29: ark.v1.AdminService.UpdateIntentFees:input_type -> ark.v1.UpdateIntentFeesRequest
-	24, // 30: ark.v1.AdminService.ClearIntentFees:input_type -> ark.v1.ClearIntentFeesRequest
-	26, // 31: ark.v1.AdminService.GetConvictions:input_type -> ark.v1.GetConvictionsRequest
-	28, // 32: ark.v1.AdminService.GetConvictionsInRange:input_type -> ark.v1.GetConvictionsInRangeRequest
-	30, // 33: ark.v1.AdminService.GetConvictionsByRound:input_type -> ark.v1.GetConvictionsByRoundRequest
-	32, // 34: ark.v1.AdminService.GetActiveScriptConvictions:input_type -> ark.v1.GetActiveScriptConvictionsRequest
-	34, // 35: ark.v1.AdminService.PardonConviction:input_type -> ark.v1.PardonConvictionRequest
-	36, // 36: ark.v1.AdminService.BanScript:input_type -> ark.v1.BanScriptRequest
-	38, // 37: ark.v1.AdminService.RevokeAuth:input_type -> ark.v1.RevokeAuthRequest
-	56, // 38: ark.v1.AdminService.ListTokens:input_type -> ark.v1.ListTokensRequest
-	59, // 39: ark.v1.AdminService.RevokeTokens:input_type -> ark.v1.RevokeTokensRequest
-	48, // 40: ark.v1.AdminService.GetExpiringLiquidity:input_type -> ark.v1.GetExpiringLiquidityRequest
-	50, // 41: ark.v1.AdminService.GetRecoverableLiquidity:input_type -> ark.v1.GetRecoverableLiquidityRequest
-	52, // 42: ark.v1.AdminService.GetCollectedFees:input_type -> ark.v1.GetCollectedFeesRequest
-	54, // 43: ark.v1.AdminService.Sweep:input_type -> ark.v1.SweepRequest
-	3,  // 44: ark.v1.AdminService.GetScheduledSweep:output_type -> ark.v1.GetScheduledSweepResponse
-	5,  // 45: ark.v1.AdminService.GetRoundDetails:output_type -> ark.v1.GetRoundDetailsResponse
-	7,  // 46: ark.v1.AdminService.GetRounds:output_type -> ark.v1.GetRoundsResponse
-	9,  // 47: ark.v1.AdminService.CreateNote:output_type -> ark.v1.CreateNoteResponse
-	11, // 48: ark.v1.AdminService.GetScheduledSessionConfig:output_type -> ark.v1.GetScheduledSessionConfigResponse
-	13, // 49: ark.v1.AdminService.UpdateScheduledSessionConfig:output_type -> ark.v1.UpdateScheduledSessionConfigResponse
-	15, // 50: ark.v1.AdminService.ClearScheduledSessionConfig:output_type -> ark.v1.ClearScheduledSessionConfigResponse
-	17, // 51: ark.v1.AdminService.ListIntents:output_type -> ark.v1.ListIntentsResponse
-	19, // 52: ark.v1.AdminService.DeleteIntents:output_type -> ark.v1.DeleteIntentsResponse
-	21, // 53: ark.v1.AdminService.GetIntentFees:output_type -> ark.v1.GetIntentFeesResponse
-	23, // 54: ark.v1.AdminService.UpdateIntentFees:output_type -> ark.v1.UpdateIntentFeesResponse
-	25, // 55: ark.v1.AdminService.ClearIntentFees:output_type -> ark.v1.ClearIntentFeesResponse
-	27, // 56: ark.v1.AdminService.GetConvictions:output_type -> ark.v1.GetConvictionsResponse
-	29, // 57: ark.v1.AdminService.GetConvictionsInRange:output_type -> ark.v1.GetConvictionsInRangeResponse
-	31, // 58: ark.v1.AdminService.GetConvictionsByRound:output_type -> ark.v1.GetConvictionsByRoundResponse
-	33, // 59: ark.v1.AdminService.GetActiveScriptConvictions:output_type -> ark.v1.GetActiveScriptConvictionsResponse
-	35, // 60: ark.v1.AdminService.PardonConviction:output_type -> ark.v1.PardonConvictionResponse
-	37, // 61: ark.v1.AdminService.BanScript:output_type -> ark.v1.BanScriptResponse
-	39, // 62: ark.v1.AdminService.RevokeAuth:output_type -> ark.v1.RevokeAuthResponse
-	57, // 63: ark.v1.AdminService.ListTokens:output_type -> ark.v1.ListTokensResponse
-	60, // 64: ark.v1.AdminService.RevokeTokens:output_type -> ark.v1.RevokeTokensResponse
-	49, // 65: ark.v1.AdminService.GetExpiringLiquidity:output_type -> ark.v1.GetExpiringLiquidityResponse
-	51, // 66: ark.v1.AdminService.GetRecoverableLiquidity:output_type -> ark.v1.GetRecoverableLiquidityResponse
-	53, // 67: ark.v1.AdminService.GetCollectedFees:output_type -> ark.v1.GetCollectedFeesResponse
-	55, // 68: ark.v1.AdminService.Sweep:output_type -> ark.v1.SweepResponse
-	44, // [44:69] is the sub-list for method output_type
-	19, // [19:44] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	58, // 18: ark.v1.GetMainAccountUtxosResponse.utxos:type_name -> ark.v1.WalletUtxo
+	61, // 19: ark.v1.ListTokensResponse.tokens:type_name -> ark.v1.TokenInfo
+	2,  // 20: ark.v1.AdminService.GetScheduledSweep:input_type -> ark.v1.GetScheduledSweepRequest
+	4,  // 21: ark.v1.AdminService.GetRoundDetails:input_type -> ark.v1.GetRoundDetailsRequest
+	6,  // 22: ark.v1.AdminService.GetRounds:input_type -> ark.v1.GetRoundsRequest
+	8,  // 23: ark.v1.AdminService.CreateNote:input_type -> ark.v1.CreateNoteRequest
+	10, // 24: ark.v1.AdminService.GetScheduledSessionConfig:input_type -> ark.v1.GetScheduledSessionConfigRequest
+	12, // 25: ark.v1.AdminService.UpdateScheduledSessionConfig:input_type -> ark.v1.UpdateScheduledSessionConfigRequest
+	14, // 26: ark.v1.AdminService.ClearScheduledSessionConfig:input_type -> ark.v1.ClearScheduledSessionConfigRequest
+	16, // 27: ark.v1.AdminService.ListIntents:input_type -> ark.v1.ListIntentsRequest
+	18, // 28: ark.v1.AdminService.DeleteIntents:input_type -> ark.v1.DeleteIntentsRequest
+	20, // 29: ark.v1.AdminService.GetIntentFees:input_type -> ark.v1.GetIntentFeesRequest
+	22, // 30: ark.v1.AdminService.UpdateIntentFees:input_type -> ark.v1.UpdateIntentFeesRequest
+	24, // 31: ark.v1.AdminService.ClearIntentFees:input_type -> ark.v1.ClearIntentFeesRequest
+	26, // 32: ark.v1.AdminService.GetConvictions:input_type -> ark.v1.GetConvictionsRequest
+	28, // 33: ark.v1.AdminService.GetConvictionsInRange:input_type -> ark.v1.GetConvictionsInRangeRequest
+	30, // 34: ark.v1.AdminService.GetConvictionsByRound:input_type -> ark.v1.GetConvictionsByRoundRequest
+	32, // 35: ark.v1.AdminService.GetActiveScriptConvictions:input_type -> ark.v1.GetActiveScriptConvictionsRequest
+	34, // 36: ark.v1.AdminService.PardonConviction:input_type -> ark.v1.PardonConvictionRequest
+	36, // 37: ark.v1.AdminService.BanScript:input_type -> ark.v1.BanScriptRequest
+	38, // 38: ark.v1.AdminService.RevokeAuth:input_type -> ark.v1.RevokeAuthRequest
+	59, // 39: ark.v1.AdminService.ListTokens:input_type -> ark.v1.ListTokensRequest
+	62, // 40: ark.v1.AdminService.RevokeTokens:input_type -> ark.v1.RevokeTokensRequest
+	48, // 41: ark.v1.AdminService.GetExpiringLiquidity:input_type -> ark.v1.GetExpiringLiquidityRequest
+	50, // 42: ark.v1.AdminService.GetRecoverableLiquidity:input_type -> ark.v1.GetRecoverableLiquidityRequest
+	52, // 43: ark.v1.AdminService.GetCollectedFees:input_type -> ark.v1.GetCollectedFeesRequest
+	54, // 44: ark.v1.AdminService.Sweep:input_type -> ark.v1.SweepRequest
+	56, // 45: ark.v1.AdminService.GetMainAccountUtxos:input_type -> ark.v1.GetMainAccountUtxosRequest
+	3,  // 46: ark.v1.AdminService.GetScheduledSweep:output_type -> ark.v1.GetScheduledSweepResponse
+	5,  // 47: ark.v1.AdminService.GetRoundDetails:output_type -> ark.v1.GetRoundDetailsResponse
+	7,  // 48: ark.v1.AdminService.GetRounds:output_type -> ark.v1.GetRoundsResponse
+	9,  // 49: ark.v1.AdminService.CreateNote:output_type -> ark.v1.CreateNoteResponse
+	11, // 50: ark.v1.AdminService.GetScheduledSessionConfig:output_type -> ark.v1.GetScheduledSessionConfigResponse
+	13, // 51: ark.v1.AdminService.UpdateScheduledSessionConfig:output_type -> ark.v1.UpdateScheduledSessionConfigResponse
+	15, // 52: ark.v1.AdminService.ClearScheduledSessionConfig:output_type -> ark.v1.ClearScheduledSessionConfigResponse
+	17, // 53: ark.v1.AdminService.ListIntents:output_type -> ark.v1.ListIntentsResponse
+	19, // 54: ark.v1.AdminService.DeleteIntents:output_type -> ark.v1.DeleteIntentsResponse
+	21, // 55: ark.v1.AdminService.GetIntentFees:output_type -> ark.v1.GetIntentFeesResponse
+	23, // 56: ark.v1.AdminService.UpdateIntentFees:output_type -> ark.v1.UpdateIntentFeesResponse
+	25, // 57: ark.v1.AdminService.ClearIntentFees:output_type -> ark.v1.ClearIntentFeesResponse
+	27, // 58: ark.v1.AdminService.GetConvictions:output_type -> ark.v1.GetConvictionsResponse
+	29, // 59: ark.v1.AdminService.GetConvictionsInRange:output_type -> ark.v1.GetConvictionsInRangeResponse
+	31, // 60: ark.v1.AdminService.GetConvictionsByRound:output_type -> ark.v1.GetConvictionsByRoundResponse
+	33, // 61: ark.v1.AdminService.GetActiveScriptConvictions:output_type -> ark.v1.GetActiveScriptConvictionsResponse
+	35, // 62: ark.v1.AdminService.PardonConviction:output_type -> ark.v1.PardonConvictionResponse
+	37, // 63: ark.v1.AdminService.BanScript:output_type -> ark.v1.BanScriptResponse
+	39, // 64: ark.v1.AdminService.RevokeAuth:output_type -> ark.v1.RevokeAuthResponse
+	60, // 65: ark.v1.AdminService.ListTokens:output_type -> ark.v1.ListTokensResponse
+	63, // 66: ark.v1.AdminService.RevokeTokens:output_type -> ark.v1.RevokeTokensResponse
+	49, // 67: ark.v1.AdminService.GetExpiringLiquidity:output_type -> ark.v1.GetExpiringLiquidityResponse
+	51, // 68: ark.v1.AdminService.GetRecoverableLiquidity:output_type -> ark.v1.GetRecoverableLiquidityResponse
+	53, // 69: ark.v1.AdminService.GetCollectedFees:output_type -> ark.v1.GetCollectedFeesResponse
+	55, // 70: ark.v1.AdminService.Sweep:output_type -> ark.v1.SweepResponse
+	57, // 71: ark.v1.AdminService.GetMainAccountUtxos:output_type -> ark.v1.GetMainAccountUtxosResponse
+	46, // [46:72] is the sub-list for method output_type
+	20, // [20:46] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_ark_v1_admin_proto_init() }
@@ -3548,7 +3739,7 @@ func file_ark_v1_admin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_ark_v1_admin_proto_rawDesc), len(file_ark_v1_admin_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   59,
+			NumMessages:   62,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.rgw.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.rgw.go
@@ -439,6 +439,15 @@ func request_AdminService_Sweep_0(ctx context.Context, marshaler gateway.Marshal
 
 }
 
+func request_AdminService_GetMainAccountUtxos_0(ctx context.Context, marshaler gateway.Marshaler, mux *gateway.ServeMux, client AdminServiceClient, req *http.Request, pathParams gateway.Params) (proto.Message, gateway.ServerMetadata, error) {
+	var protoReq GetMainAccountUtxosRequest
+	var metadata gateway.ServerMetadata
+
+	msg, err := client.GetMainAccountUtxos(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
 // RegisterAdminServiceHandlerFromEndpoint is same as RegisterAdminServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterAdminServiceHandlerFromEndpoint(ctx context.Context, mux *gateway.ServeMux, endpoint string, opts []grpc.DialOption) error {
@@ -1019,6 +1028,28 @@ func RegisterAdminServiceHandlerClient(ctx context.Context, mux *gateway.ServeMu
 		}
 
 		resp, md, err := request_AdminService_Sweep_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
+		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)
+			return
+		}
+
+		mux.ForwardResponseMessage(annotatedContext, outboundMarshaler, w, req, resp)
+	})
+
+	mux.HandleWithParams("GET", "/v1/admin/wallet/utxos", func(w http.ResponseWriter, req *http.Request, pathParams gateway.Params) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := mux.MarshalerForRequest(req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = gateway.AnnotateContext(ctx, mux, req, "/ark.v1.AdminService/GetMainAccountUtxos", gateway.WithHTTPPathPattern("/v1/admin/wallet/utxos"))
+		if err != nil {
+			mux.HTTPError(ctx, outboundMarshaler, w, req, err)
+			return
+		}
+
+		resp, md, err := request_AdminService_GetMainAccountUtxos_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
 		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)

--- a/api-spec/protobuf/gen/ark/v1/admin_grpc.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin_grpc.pb.go
@@ -44,6 +44,7 @@ const (
 	AdminService_GetRecoverableLiquidity_FullMethodName      = "/ark.v1.AdminService/GetRecoverableLiquidity"
 	AdminService_GetCollectedFees_FullMethodName             = "/ark.v1.AdminService/GetCollectedFees"
 	AdminService_Sweep_FullMethodName                        = "/ark.v1.AdminService/Sweep"
+	AdminService_GetMainAccountUtxos_FullMethodName          = "/ark.v1.AdminService/GetMainAccountUtxos"
 )
 
 // AdminServiceClient is the client API for AdminService service.
@@ -75,6 +76,7 @@ type AdminServiceClient interface {
 	GetRecoverableLiquidity(ctx context.Context, in *GetRecoverableLiquidityRequest, opts ...grpc.CallOption) (*GetRecoverableLiquidityResponse, error)
 	GetCollectedFees(ctx context.Context, in *GetCollectedFeesRequest, opts ...grpc.CallOption) (*GetCollectedFeesResponse, error)
 	Sweep(ctx context.Context, in *SweepRequest, opts ...grpc.CallOption) (*SweepResponse, error)
+	GetMainAccountUtxos(ctx context.Context, in *GetMainAccountUtxosRequest, opts ...grpc.CallOption) (*GetMainAccountUtxosResponse, error)
 }
 
 type adminServiceClient struct {
@@ -335,6 +337,16 @@ func (c *adminServiceClient) Sweep(ctx context.Context, in *SweepRequest, opts .
 	return out, nil
 }
 
+func (c *adminServiceClient) GetMainAccountUtxos(ctx context.Context, in *GetMainAccountUtxosRequest, opts ...grpc.CallOption) (*GetMainAccountUtxosResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMainAccountUtxosResponse)
+	err := c.cc.Invoke(ctx, AdminService_GetMainAccountUtxos_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AdminServiceServer is the server API for AdminService service.
 // All implementations should embed UnimplementedAdminServiceServer
 // for forward compatibility.
@@ -364,6 +376,7 @@ type AdminServiceServer interface {
 	GetRecoverableLiquidity(context.Context, *GetRecoverableLiquidityRequest) (*GetRecoverableLiquidityResponse, error)
 	GetCollectedFees(context.Context, *GetCollectedFeesRequest) (*GetCollectedFeesResponse, error)
 	Sweep(context.Context, *SweepRequest) (*SweepResponse, error)
+	GetMainAccountUtxos(context.Context, *GetMainAccountUtxosRequest) (*GetMainAccountUtxosResponse, error)
 }
 
 // UnimplementedAdminServiceServer should be embedded to have
@@ -447,6 +460,9 @@ func (UnimplementedAdminServiceServer) GetCollectedFees(context.Context, *GetCol
 }
 func (UnimplementedAdminServiceServer) Sweep(context.Context, *SweepRequest) (*SweepResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Sweep not implemented")
+}
+func (UnimplementedAdminServiceServer) GetMainAccountUtxos(context.Context, *GetMainAccountUtxosRequest) (*GetMainAccountUtxosResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMainAccountUtxos not implemented")
 }
 func (UnimplementedAdminServiceServer) testEmbeddedByValue() {}
 
@@ -918,6 +934,24 @@ func _AdminService_Sweep_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AdminService_GetMainAccountUtxos_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMainAccountUtxosRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AdminServiceServer).GetMainAccountUtxos(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AdminService_GetMainAccountUtxos_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AdminServiceServer).GetMainAccountUtxos(ctx, req.(*GetMainAccountUtxosRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AdminService_ServiceDesc is the grpc.ServiceDesc for AdminService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1024,6 +1058,10 @@ var AdminService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Sweep",
 			Handler:    _AdminService_Sweep_Handler,
+		},
+		{
+			MethodName: "GetMainAccountUtxos",
+			Handler:    _AdminService_GetMainAccountUtxos_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api-spec/protobuf/gen/arkwallet/v1/bitcoin_wallet.pb.go
+++ b/api-spec/protobuf/gen/arkwallet/v1/bitcoin_wallet.pb.go
@@ -2054,6 +2054,86 @@ func (x *ListConnectorUtxosResponse) GetUtxos() []*TxInput {
 	return nil
 }
 
+type GetMainAccountUtxosRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMainAccountUtxosRequest) Reset() {
+	*x = GetMainAccountUtxosRequest{}
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMainAccountUtxosRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMainAccountUtxosRequest) ProtoMessage() {}
+
+func (x *GetMainAccountUtxosRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMainAccountUtxosRequest.ProtoReflect.Descriptor instead.
+func (*GetMainAccountUtxosRequest) Descriptor() ([]byte, []int) {
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{46}
+}
+
+type GetMainAccountUtxosResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Utxos         []*WalletUtxo          `protobuf:"bytes,1,rep,name=utxos,proto3" json:"utxos,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMainAccountUtxosResponse) Reset() {
+	*x = GetMainAccountUtxosResponse{}
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[47]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMainAccountUtxosResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMainAccountUtxosResponse) ProtoMessage() {}
+
+func (x *GetMainAccountUtxosResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[47]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMainAccountUtxosResponse.ProtoReflect.Descriptor instead.
+func (*GetMainAccountUtxosResponse) Descriptor() ([]byte, []int) {
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{47}
+}
+
+func (x *GetMainAccountUtxosResponse) GetUtxos() []*WalletUtxo {
+	if x != nil {
+		return x.Utxos
+	}
+	return nil
+}
+
 type MainAccountBalanceRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2062,7 +2142,7 @@ type MainAccountBalanceRequest struct {
 
 func (x *MainAccountBalanceRequest) Reset() {
 	*x = MainAccountBalanceRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[46]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2074,7 +2154,7 @@ func (x *MainAccountBalanceRequest) String() string {
 func (*MainAccountBalanceRequest) ProtoMessage() {}
 
 func (x *MainAccountBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[46]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2087,7 +2167,7 @@ func (x *MainAccountBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MainAccountBalanceRequest.ProtoReflect.Descriptor instead.
 func (*MainAccountBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{46}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{48}
 }
 
 type MainAccountBalanceResponse struct {
@@ -2101,7 +2181,7 @@ type MainAccountBalanceResponse struct {
 
 func (x *MainAccountBalanceResponse) Reset() {
 	*x = MainAccountBalanceResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[47]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2113,7 +2193,7 @@ func (x *MainAccountBalanceResponse) String() string {
 func (*MainAccountBalanceResponse) ProtoMessage() {}
 
 func (x *MainAccountBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[47]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2126,7 +2206,7 @@ func (x *MainAccountBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MainAccountBalanceResponse.ProtoReflect.Descriptor instead.
 func (*MainAccountBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{47}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *MainAccountBalanceResponse) GetConfirmed() uint64 {
@@ -2151,7 +2231,7 @@ type ConnectorsAccountBalanceRequest struct {
 
 func (x *ConnectorsAccountBalanceRequest) Reset() {
 	*x = ConnectorsAccountBalanceRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[48]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2163,7 +2243,7 @@ func (x *ConnectorsAccountBalanceRequest) String() string {
 func (*ConnectorsAccountBalanceRequest) ProtoMessage() {}
 
 func (x *ConnectorsAccountBalanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[48]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2176,7 +2256,7 @@ func (x *ConnectorsAccountBalanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectorsAccountBalanceRequest.ProtoReflect.Descriptor instead.
 func (*ConnectorsAccountBalanceRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{48}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{50}
 }
 
 type ConnectorsAccountBalanceResponse struct {
@@ -2189,7 +2269,7 @@ type ConnectorsAccountBalanceResponse struct {
 
 func (x *ConnectorsAccountBalanceResponse) Reset() {
 	*x = ConnectorsAccountBalanceResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[49]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2201,7 +2281,7 @@ func (x *ConnectorsAccountBalanceResponse) String() string {
 func (*ConnectorsAccountBalanceResponse) ProtoMessage() {}
 
 func (x *ConnectorsAccountBalanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[49]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2214,7 +2294,7 @@ func (x *ConnectorsAccountBalanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectorsAccountBalanceResponse.ProtoReflect.Descriptor instead.
 func (*ConnectorsAccountBalanceResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{49}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *ConnectorsAccountBalanceResponse) GetConfirmed() uint64 {
@@ -2240,7 +2320,7 @@ type LockConnectorUtxosRequest struct {
 
 func (x *LockConnectorUtxosRequest) Reset() {
 	*x = LockConnectorUtxosRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[50]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2252,7 +2332,7 @@ func (x *LockConnectorUtxosRequest) String() string {
 func (*LockConnectorUtxosRequest) ProtoMessage() {}
 
 func (x *LockConnectorUtxosRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[50]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2265,7 +2345,7 @@ func (x *LockConnectorUtxosRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockConnectorUtxosRequest.ProtoReflect.Descriptor instead.
 func (*LockConnectorUtxosRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{50}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *LockConnectorUtxosRequest) GetUtxos() []*TxOutpoint {
@@ -2283,7 +2363,7 @@ type LockConnectorUtxosResponse struct {
 
 func (x *LockConnectorUtxosResponse) Reset() {
 	*x = LockConnectorUtxosResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[51]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2295,7 +2375,7 @@ func (x *LockConnectorUtxosResponse) String() string {
 func (*LockConnectorUtxosResponse) ProtoMessage() {}
 
 func (x *LockConnectorUtxosResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[51]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2308,7 +2388,7 @@ func (x *LockConnectorUtxosResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockConnectorUtxosResponse.ProtoReflect.Descriptor instead.
 func (*LockConnectorUtxosResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{51}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{53}
 }
 
 type GetDustAmountRequest struct {
@@ -2319,7 +2399,7 @@ type GetDustAmountRequest struct {
 
 func (x *GetDustAmountRequest) Reset() {
 	*x = GetDustAmountRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[52]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2331,7 +2411,7 @@ func (x *GetDustAmountRequest) String() string {
 func (*GetDustAmountRequest) ProtoMessage() {}
 
 func (x *GetDustAmountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[52]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2344,7 +2424,7 @@ func (x *GetDustAmountRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDustAmountRequest.ProtoReflect.Descriptor instead.
 func (*GetDustAmountRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{52}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{54}
 }
 
 type GetDustAmountResponse struct {
@@ -2356,7 +2436,7 @@ type GetDustAmountResponse struct {
 
 func (x *GetDustAmountResponse) Reset() {
 	*x = GetDustAmountResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[53]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2368,7 +2448,7 @@ func (x *GetDustAmountResponse) String() string {
 func (*GetDustAmountResponse) ProtoMessage() {}
 
 func (x *GetDustAmountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[53]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2381,7 +2461,7 @@ func (x *GetDustAmountResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetDustAmountResponse.ProtoReflect.Descriptor instead.
 func (*GetDustAmountResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{53}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *GetDustAmountResponse) GetDustAmount() uint64 {
@@ -2400,7 +2480,7 @@ type WatchScriptsRequest struct {
 
 func (x *WatchScriptsRequest) Reset() {
 	*x = WatchScriptsRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[54]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2412,7 +2492,7 @@ func (x *WatchScriptsRequest) String() string {
 func (*WatchScriptsRequest) ProtoMessage() {}
 
 func (x *WatchScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[54]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2425,7 +2505,7 @@ func (x *WatchScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchScriptsRequest.ProtoReflect.Descriptor instead.
 func (*WatchScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{54}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *WatchScriptsRequest) GetScripts() []string {
@@ -2443,7 +2523,7 @@ type WatchScriptsResponse struct {
 
 func (x *WatchScriptsResponse) Reset() {
 	*x = WatchScriptsResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[55]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2455,7 +2535,7 @@ func (x *WatchScriptsResponse) String() string {
 func (*WatchScriptsResponse) ProtoMessage() {}
 
 func (x *WatchScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[55]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2468,7 +2548,7 @@ func (x *WatchScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchScriptsResponse.ProtoReflect.Descriptor instead.
 func (*WatchScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{55}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{57}
 }
 
 type UnwatchScriptsRequest struct {
@@ -2480,7 +2560,7 @@ type UnwatchScriptsRequest struct {
 
 func (x *UnwatchScriptsRequest) Reset() {
 	*x = UnwatchScriptsRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[56]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2492,7 +2572,7 @@ func (x *UnwatchScriptsRequest) String() string {
 func (*UnwatchScriptsRequest) ProtoMessage() {}
 
 func (x *UnwatchScriptsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[56]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2505,7 +2585,7 @@ func (x *UnwatchScriptsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnwatchScriptsRequest.ProtoReflect.Descriptor instead.
 func (*UnwatchScriptsRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{56}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *UnwatchScriptsRequest) GetScripts() []string {
@@ -2523,7 +2603,7 @@ type UnwatchScriptsResponse struct {
 
 func (x *UnwatchScriptsResponse) Reset() {
 	*x = UnwatchScriptsResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[57]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2535,7 +2615,7 @@ func (x *UnwatchScriptsResponse) String() string {
 func (*UnwatchScriptsResponse) ProtoMessage() {}
 
 func (x *UnwatchScriptsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[57]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2548,7 +2628,7 @@ func (x *UnwatchScriptsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnwatchScriptsResponse.ProtoReflect.Descriptor instead.
 func (*UnwatchScriptsResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{57}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{59}
 }
 
 type GetTransactionRequest struct {
@@ -2560,7 +2640,7 @@ type GetTransactionRequest struct {
 
 func (x *GetTransactionRequest) Reset() {
 	*x = GetTransactionRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[58]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2572,7 +2652,7 @@ func (x *GetTransactionRequest) String() string {
 func (*GetTransactionRequest) ProtoMessage() {}
 
 func (x *GetTransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[58]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2585,7 +2665,7 @@ func (x *GetTransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionRequest.ProtoReflect.Descriptor instead.
 func (*GetTransactionRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{58}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{60}
 }
 
 func (x *GetTransactionRequest) GetTxid() string {
@@ -2604,7 +2684,7 @@ type GetTransactionResponse struct {
 
 func (x *GetTransactionResponse) Reset() {
 	*x = GetTransactionResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[59]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2616,7 +2696,7 @@ func (x *GetTransactionResponse) String() string {
 func (*GetTransactionResponse) ProtoMessage() {}
 
 func (x *GetTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[59]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2629,7 +2709,7 @@ func (x *GetTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTransactionResponse.ProtoReflect.Descriptor instead.
 func (*GetTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{59}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetTransactionResponse) GetTxHex() string {
@@ -2648,7 +2728,7 @@ type SignMessageRequest struct {
 
 func (x *SignMessageRequest) Reset() {
 	*x = SignMessageRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[60]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2660,7 +2740,7 @@ func (x *SignMessageRequest) String() string {
 func (*SignMessageRequest) ProtoMessage() {}
 
 func (x *SignMessageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[60]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2673,7 +2753,7 @@ func (x *SignMessageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignMessageRequest.ProtoReflect.Descriptor instead.
 func (*SignMessageRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{60}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *SignMessageRequest) GetMessage() []byte {
@@ -2692,7 +2772,7 @@ type SignMessageResponse struct {
 
 func (x *SignMessageResponse) Reset() {
 	*x = SignMessageResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[61]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2704,7 +2784,7 @@ func (x *SignMessageResponse) String() string {
 func (*SignMessageResponse) ProtoMessage() {}
 
 func (x *SignMessageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[61]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2717,7 +2797,7 @@ func (x *SignMessageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignMessageResponse.ProtoReflect.Descriptor instead.
 func (*SignMessageResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{61}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *SignMessageResponse) GetSignature() []byte {
@@ -2737,7 +2817,7 @@ type VerifyMessageSignatureRequest struct {
 
 func (x *VerifyMessageSignatureRequest) Reset() {
 	*x = VerifyMessageSignatureRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[62]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2749,7 +2829,7 @@ func (x *VerifyMessageSignatureRequest) String() string {
 func (*VerifyMessageSignatureRequest) ProtoMessage() {}
 
 func (x *VerifyMessageSignatureRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[62]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2762,7 +2842,7 @@ func (x *VerifyMessageSignatureRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyMessageSignatureRequest.ProtoReflect.Descriptor instead.
 func (*VerifyMessageSignatureRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{62}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *VerifyMessageSignatureRequest) GetMessage() []byte {
@@ -2788,7 +2868,7 @@ type VerifyMessageSignatureResponse struct {
 
 func (x *VerifyMessageSignatureResponse) Reset() {
 	*x = VerifyMessageSignatureResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[63]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2800,7 +2880,7 @@ func (x *VerifyMessageSignatureResponse) String() string {
 func (*VerifyMessageSignatureResponse) ProtoMessage() {}
 
 func (x *VerifyMessageSignatureResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[63]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2813,7 +2893,7 @@ func (x *VerifyMessageSignatureResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VerifyMessageSignatureResponse.ProtoReflect.Descriptor instead.
 func (*VerifyMessageSignatureResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{63}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *VerifyMessageSignatureResponse) GetValid() bool {
@@ -2831,7 +2911,7 @@ type GetCurrentBlockTimeRequest struct {
 
 func (x *GetCurrentBlockTimeRequest) Reset() {
 	*x = GetCurrentBlockTimeRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[64]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2843,7 +2923,7 @@ func (x *GetCurrentBlockTimeRequest) String() string {
 func (*GetCurrentBlockTimeRequest) ProtoMessage() {}
 
 func (x *GetCurrentBlockTimeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[64]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2856,7 +2936,7 @@ func (x *GetCurrentBlockTimeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCurrentBlockTimeRequest.ProtoReflect.Descriptor instead.
 func (*GetCurrentBlockTimeRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{64}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{66}
 }
 
 type GetCurrentBlockTimeResponse struct {
@@ -2868,7 +2948,7 @@ type GetCurrentBlockTimeResponse struct {
 
 func (x *GetCurrentBlockTimeResponse) Reset() {
 	*x = GetCurrentBlockTimeResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[65]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2880,7 +2960,7 @@ func (x *GetCurrentBlockTimeResponse) String() string {
 func (*GetCurrentBlockTimeResponse) ProtoMessage() {}
 
 func (x *GetCurrentBlockTimeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[65]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2893,7 +2973,7 @@ func (x *GetCurrentBlockTimeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCurrentBlockTimeResponse.ProtoReflect.Descriptor instead.
 func (*GetCurrentBlockTimeResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{65}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *GetCurrentBlockTimeResponse) GetTimestamp() *BlockTimestamp {
@@ -2912,7 +2992,7 @@ type RescanUtxosRequest struct {
 
 func (x *RescanUtxosRequest) Reset() {
 	*x = RescanUtxosRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[66]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2924,7 +3004,7 @@ func (x *RescanUtxosRequest) String() string {
 func (*RescanUtxosRequest) ProtoMessage() {}
 
 func (x *RescanUtxosRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[66]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2937,7 +3017,7 @@ func (x *RescanUtxosRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RescanUtxosRequest.ProtoReflect.Descriptor instead.
 func (*RescanUtxosRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{66}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *RescanUtxosRequest) GetOutpoints() []string {
@@ -2955,7 +3035,7 @@ type RescanUtxosResponse struct {
 
 func (x *RescanUtxosResponse) Reset() {
 	*x = RescanUtxosResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[67]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2967,7 +3047,7 @@ func (x *RescanUtxosResponse) String() string {
 func (*RescanUtxosResponse) ProtoMessage() {}
 
 func (x *RescanUtxosResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[67]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2980,7 +3060,7 @@ func (x *RescanUtxosResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RescanUtxosResponse.ProtoReflect.Descriptor instead.
 func (*RescanUtxosResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{67}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{69}
 }
 
 type WithdrawRequest struct {
@@ -2996,7 +3076,7 @@ type WithdrawRequest struct {
 
 func (x *WithdrawRequest) Reset() {
 	*x = WithdrawRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[68]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3008,7 +3088,7 @@ func (x *WithdrawRequest) String() string {
 func (*WithdrawRequest) ProtoMessage() {}
 
 func (x *WithdrawRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[68]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3021,7 +3101,7 @@ func (x *WithdrawRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawRequest.ProtoReflect.Descriptor instead.
 func (*WithdrawRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{68}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *WithdrawRequest) GetAddress() string {
@@ -3054,7 +3134,7 @@ type WithdrawResponse struct {
 
 func (x *WithdrawResponse) Reset() {
 	*x = WithdrawResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[69]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3066,7 +3146,7 @@ func (x *WithdrawResponse) String() string {
 func (*WithdrawResponse) ProtoMessage() {}
 
 func (x *WithdrawResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[69]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3079,7 +3159,7 @@ func (x *WithdrawResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WithdrawResponse.ProtoReflect.Descriptor instead.
 func (*WithdrawResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{69}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *WithdrawResponse) GetTxid() string {
@@ -3098,7 +3178,7 @@ type LoadSignerKeyRequest struct {
 
 func (x *LoadSignerKeyRequest) Reset() {
 	*x = LoadSignerKeyRequest{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[70]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3110,7 +3190,7 @@ func (x *LoadSignerKeyRequest) String() string {
 func (*LoadSignerKeyRequest) ProtoMessage() {}
 
 func (x *LoadSignerKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[70]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3123,7 +3203,7 @@ func (x *LoadSignerKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadSignerKeyRequest.ProtoReflect.Descriptor instead.
 func (*LoadSignerKeyRequest) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{70}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *LoadSignerKeyRequest) GetPrivateKey() string {
@@ -3141,7 +3221,7 @@ type LoadSignerKeyResponse struct {
 
 func (x *LoadSignerKeyResponse) Reset() {
 	*x = LoadSignerKeyResponse{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[71]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3153,7 +3233,7 @@ func (x *LoadSignerKeyResponse) String() string {
 func (*LoadSignerKeyResponse) ProtoMessage() {}
 
 func (x *LoadSignerKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[71]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3166,7 +3246,7 @@ func (x *LoadSignerKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoadSignerKeyResponse.ProtoReflect.Descriptor instead.
 func (*LoadSignerKeyResponse) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{71}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{73}
 }
 
 type TxInput struct {
@@ -3181,7 +3261,7 @@ type TxInput struct {
 
 func (x *TxInput) Reset() {
 	*x = TxInput{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[72]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3193,7 +3273,7 @@ func (x *TxInput) String() string {
 func (*TxInput) ProtoMessage() {}
 
 func (x *TxInput) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[72]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3206,7 +3286,7 @@ func (x *TxInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TxInput.ProtoReflect.Descriptor instead.
 func (*TxInput) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{72}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *TxInput) GetTxid() string {
@@ -3237,6 +3317,98 @@ func (x *TxInput) GetValue() uint64 {
 	return 0
 }
 
+type WalletUtxo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
+	Vout          uint32                 `protobuf:"varint,2,opt,name=vout,proto3" json:"vout,omitempty"`
+	Value         uint64                 `protobuf:"varint,3,opt,name=value,proto3" json:"value,omitempty"`
+	Script        string                 `protobuf:"bytes,4,opt,name=script,proto3" json:"script,omitempty"`
+	Address       string                 `protobuf:"bytes,5,opt,name=address,proto3" json:"address,omitempty"`
+	Confirmations uint32                 `protobuf:"varint,6,opt,name=confirmations,proto3" json:"confirmations,omitempty"`
+	Locked        bool                   `protobuf:"varint,7,opt,name=locked,proto3" json:"locked,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WalletUtxo) Reset() {
+	*x = WalletUtxo{}
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[75]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WalletUtxo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WalletUtxo) ProtoMessage() {}
+
+func (x *WalletUtxo) ProtoReflect() protoreflect.Message {
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[75]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WalletUtxo.ProtoReflect.Descriptor instead.
+func (*WalletUtxo) Descriptor() ([]byte, []int) {
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{75}
+}
+
+func (x *WalletUtxo) GetTxid() string {
+	if x != nil {
+		return x.Txid
+	}
+	return ""
+}
+
+func (x *WalletUtxo) GetVout() uint32 {
+	if x != nil {
+		return x.Vout
+	}
+	return 0
+}
+
+func (x *WalletUtxo) GetValue() uint64 {
+	if x != nil {
+		return x.Value
+	}
+	return 0
+}
+
+func (x *WalletUtxo) GetScript() string {
+	if x != nil {
+		return x.Script
+	}
+	return ""
+}
+
+func (x *WalletUtxo) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *WalletUtxo) GetConfirmations() uint32 {
+	if x != nil {
+		return x.Confirmations
+	}
+	return 0
+}
+
+func (x *WalletUtxo) GetLocked() bool {
+	if x != nil {
+		return x.Locked
+	}
+	return false
+}
+
 type TxOutpoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Txid          string                 `protobuf:"bytes,1,opt,name=txid,proto3" json:"txid,omitempty"`
@@ -3247,7 +3419,7 @@ type TxOutpoint struct {
 
 func (x *TxOutpoint) Reset() {
 	*x = TxOutpoint{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[73]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3259,7 +3431,7 @@ func (x *TxOutpoint) String() string {
 func (*TxOutpoint) ProtoMessage() {}
 
 func (x *TxOutpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[73]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3272,7 +3444,7 @@ func (x *TxOutpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TxOutpoint.ProtoReflect.Descriptor instead.
 func (*TxOutpoint) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{73}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *TxOutpoint) GetTxid() string {
@@ -3299,7 +3471,7 @@ type BlockTimestamp struct {
 
 func (x *BlockTimestamp) Reset() {
 	*x = BlockTimestamp{}
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[74]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3311,7 +3483,7 @@ func (x *BlockTimestamp) String() string {
 func (*BlockTimestamp) ProtoMessage() {}
 
 func (x *BlockTimestamp) ProtoReflect() protoreflect.Message {
-	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[74]
+	mi := &file_arkwallet_v1_bitcoin_wallet_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3324,7 +3496,7 @@ func (x *BlockTimestamp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlockTimestamp.ProtoReflect.Descriptor instead.
 func (*BlockTimestamp) Descriptor() ([]byte, []int) {
-	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{74}
+	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *BlockTimestamp) GetHeight() uint32 {
@@ -3440,7 +3612,10 @@ const file_arkwallet_v1_bitcoin_wallet_proto_rawDesc = "" +
 	"\x19ListConnectorUtxosRequest\x12+\n" +
 	"\x11connector_address\x18\x01 \x01(\tR\x10connectorAddress\"I\n" +
 	"\x1aListConnectorUtxosResponse\x12+\n" +
-	"\x05utxos\x18\x01 \x03(\v2\x15.arkwallet.v1.TxInputR\x05utxos\"\x1b\n" +
+	"\x05utxos\x18\x01 \x03(\v2\x15.arkwallet.v1.TxInputR\x05utxos\"\x1c\n" +
+	"\x1aGetMainAccountUtxosRequest\"M\n" +
+	"\x1bGetMainAccountUtxosResponse\x12.\n" +
+	"\x05utxos\x18\x01 \x03(\v2\x18.arkwallet.v1.WalletUtxoR\x05utxos\"\x1b\n" +
 	"\x19MainAccountBalanceRequest\"\\\n" +
 	"\x1aMainAccountBalanceResponse\x12\x1c\n" +
 	"\tconfirmed\x18\x01 \x01(\x04R\tconfirmed\x12 \n" +
@@ -3495,14 +3670,23 @@ const file_arkwallet_v1_bitcoin_wallet_proto_rawDesc = "" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x14\n" +
 	"\x05index\x18\x02 \x01(\rR\x05index\x12\x16\n" +
 	"\x06script\x18\x03 \x01(\tR\x06script\x12\x14\n" +
-	"\x05value\x18\x04 \x01(\x04R\x05value\"6\n" +
+	"\x05value\x18\x04 \x01(\x04R\x05value\"\xba\x01\n" +
+	"\n" +
+	"WalletUtxo\x12\x12\n" +
+	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
+	"\x04vout\x18\x02 \x01(\rR\x04vout\x12\x14\n" +
+	"\x05value\x18\x03 \x01(\x04R\x05value\x12\x16\n" +
+	"\x06script\x18\x04 \x01(\tR\x06script\x12\x18\n" +
+	"\aaddress\x18\x05 \x01(\tR\aaddress\x12$\n" +
+	"\rconfirmations\x18\x06 \x01(\rR\rconfirmations\x12\x16\n" +
+	"\x06locked\x18\a \x01(\bR\x06locked\"6\n" +
 	"\n" +
 	"TxOutpoint\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x14\n" +
 	"\x05index\x18\x02 \x01(\rR\x05index\"<\n" +
 	"\x0eBlockTimestamp\x12\x16\n" +
 	"\x06height\x18\x01 \x01(\rR\x06height\x12\x12\n" +
-	"\x04time\x18\x02 \x01(\x03R\x04time2\xb7!\n" +
+	"\x04time\x18\x02 \x01(\x03R\x04time2\xc8\"\n" +
 	"\rWalletService\x12\\\n" +
 	"\aGenSeed\x12\x1c.arkwallet.v1.GenSeedRequest\x1a\x1d.arkwallet.v1.GenSeedResponse\"\x14\xb2J\x11\x12\x0f/v1/wallet/seed\x12^\n" +
 	"\x06Create\x12\x1b.arkwallet.v1.CreateRequest\x1a\x1c.arkwallet.v1.CreateResponse\"\x19\xb2J\x16B\x01*\"\x11/v1/wallet/create\x12b\n" +
@@ -3524,7 +3708,8 @@ const file_arkwallet_v1_bitcoin_wallet_proto_rawDesc = "" +
 	"\x11GetOutpointStatus\x12&.arkwallet.v1.GetOutpointStatusRequest\x1a'.arkwallet.v1.GetOutpointStatusResponse\"\x1f\xb2J\x1c\x12\x1a/v1/wallet/outpoint-status\x12w\n" +
 	"\fEstimateFees\x12!.arkwallet.v1.EstimateFeesRequest\x1a\".arkwallet.v1.EstimateFeesResponse\" \xb2J\x1dB\x01*\"\x18/v1/wallet/estimate-fees\x12`\n" +
 	"\aFeeRate\x12\x1c.arkwallet.v1.FeeRateRequest\x1a\x1d.arkwallet.v1.FeeRateResponse\"\x18\xb2J\x15\x12\x13/v1/wallet/fee-rate\x12\x88\x01\n" +
-	"\x12ListConnectorUtxos\x12'.arkwallet.v1.ListConnectorUtxosRequest\x1a(.arkwallet.v1.ListConnectorUtxosResponse\"\x1f\xb2J\x1c\x12\x1a/v1/wallet/connector-utxos\x12\x8d\x01\n" +
+	"\x12ListConnectorUtxos\x12'.arkwallet.v1.ListConnectorUtxosRequest\x1a(.arkwallet.v1.ListConnectorUtxosResponse\"\x1f\xb2J\x1c\x12\x1a/v1/wallet/connector-utxos\x12\x8e\x01\n" +
+	"\x13GetMainAccountUtxos\x12(.arkwallet.v1.GetMainAccountUtxosRequest\x1a).arkwallet.v1.GetMainAccountUtxosResponse\"\"\xb2J\x1f\x12\x1d/v1/wallet/main-account-utxos\x12\x8d\x01\n" +
 	"\x12MainAccountBalance\x12'.arkwallet.v1.MainAccountBalanceRequest\x1a(.arkwallet.v1.MainAccountBalanceResponse\"$\xb2J!\x12\x1f/v1/wallet/main-account-balance\x12\xa5\x01\n" +
 	"\x18ConnectorsAccountBalance\x12-.arkwallet.v1.ConnectorsAccountBalanceRequest\x1a..arkwallet.v1.ConnectorsAccountBalanceResponse\"*\xb2J'\x12%/v1/wallet/connectors-account-balance\x12\x90\x01\n" +
 	"\x12LockConnectorUtxos\x12'.arkwallet.v1.LockConnectorUtxosRequest\x1a(.arkwallet.v1.LockConnectorUtxosResponse\"'\xb2J$B\x01*\"\x1f/v1/wallet/lock-connector-utxos\x12n\n" +
@@ -3553,7 +3738,7 @@ func file_arkwallet_v1_bitcoin_wallet_proto_rawDescGZIP() []byte {
 	return file_arkwallet_v1_bitcoin_wallet_proto_rawDescData
 }
 
-var file_arkwallet_v1_bitcoin_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 75)
+var file_arkwallet_v1_bitcoin_wallet_proto_msgTypes = make([]protoimpl.MessageInfo, 78)
 var file_arkwallet_v1_bitcoin_wallet_proto_goTypes = []any{
 	(*GetReadyUpdateRequest)(nil),            // 0: arkwallet.v1.GetReadyUpdateRequest
 	(*GetReadyUpdateResponse)(nil),           // 1: arkwallet.v1.GetReadyUpdateResponse
@@ -3601,116 +3786,122 @@ var file_arkwallet_v1_bitcoin_wallet_proto_goTypes = []any{
 	(*FeeRateResponse)(nil),                  // 43: arkwallet.v1.FeeRateResponse
 	(*ListConnectorUtxosRequest)(nil),        // 44: arkwallet.v1.ListConnectorUtxosRequest
 	(*ListConnectorUtxosResponse)(nil),       // 45: arkwallet.v1.ListConnectorUtxosResponse
-	(*MainAccountBalanceRequest)(nil),        // 46: arkwallet.v1.MainAccountBalanceRequest
-	(*MainAccountBalanceResponse)(nil),       // 47: arkwallet.v1.MainAccountBalanceResponse
-	(*ConnectorsAccountBalanceRequest)(nil),  // 48: arkwallet.v1.ConnectorsAccountBalanceRequest
-	(*ConnectorsAccountBalanceResponse)(nil), // 49: arkwallet.v1.ConnectorsAccountBalanceResponse
-	(*LockConnectorUtxosRequest)(nil),        // 50: arkwallet.v1.LockConnectorUtxosRequest
-	(*LockConnectorUtxosResponse)(nil),       // 51: arkwallet.v1.LockConnectorUtxosResponse
-	(*GetDustAmountRequest)(nil),             // 52: arkwallet.v1.GetDustAmountRequest
-	(*GetDustAmountResponse)(nil),            // 53: arkwallet.v1.GetDustAmountResponse
-	(*WatchScriptsRequest)(nil),              // 54: arkwallet.v1.WatchScriptsRequest
-	(*WatchScriptsResponse)(nil),             // 55: arkwallet.v1.WatchScriptsResponse
-	(*UnwatchScriptsRequest)(nil),            // 56: arkwallet.v1.UnwatchScriptsRequest
-	(*UnwatchScriptsResponse)(nil),           // 57: arkwallet.v1.UnwatchScriptsResponse
-	(*GetTransactionRequest)(nil),            // 58: arkwallet.v1.GetTransactionRequest
-	(*GetTransactionResponse)(nil),           // 59: arkwallet.v1.GetTransactionResponse
-	(*SignMessageRequest)(nil),               // 60: arkwallet.v1.SignMessageRequest
-	(*SignMessageResponse)(nil),              // 61: arkwallet.v1.SignMessageResponse
-	(*VerifyMessageSignatureRequest)(nil),    // 62: arkwallet.v1.VerifyMessageSignatureRequest
-	(*VerifyMessageSignatureResponse)(nil),   // 63: arkwallet.v1.VerifyMessageSignatureResponse
-	(*GetCurrentBlockTimeRequest)(nil),       // 64: arkwallet.v1.GetCurrentBlockTimeRequest
-	(*GetCurrentBlockTimeResponse)(nil),      // 65: arkwallet.v1.GetCurrentBlockTimeResponse
-	(*RescanUtxosRequest)(nil),               // 66: arkwallet.v1.RescanUtxosRequest
-	(*RescanUtxosResponse)(nil),              // 67: arkwallet.v1.RescanUtxosResponse
-	(*WithdrawRequest)(nil),                  // 68: arkwallet.v1.WithdrawRequest
-	(*WithdrawResponse)(nil),                 // 69: arkwallet.v1.WithdrawResponse
-	(*LoadSignerKeyRequest)(nil),             // 70: arkwallet.v1.LoadSignerKeyRequest
-	(*LoadSignerKeyResponse)(nil),            // 71: arkwallet.v1.LoadSignerKeyResponse
-	(*TxInput)(nil),                          // 72: arkwallet.v1.TxInput
-	(*TxOutpoint)(nil),                       // 73: arkwallet.v1.TxOutpoint
-	(*BlockTimestamp)(nil),                   // 74: arkwallet.v1.BlockTimestamp
+	(*GetMainAccountUtxosRequest)(nil),       // 46: arkwallet.v1.GetMainAccountUtxosRequest
+	(*GetMainAccountUtxosResponse)(nil),      // 47: arkwallet.v1.GetMainAccountUtxosResponse
+	(*MainAccountBalanceRequest)(nil),        // 48: arkwallet.v1.MainAccountBalanceRequest
+	(*MainAccountBalanceResponse)(nil),       // 49: arkwallet.v1.MainAccountBalanceResponse
+	(*ConnectorsAccountBalanceRequest)(nil),  // 50: arkwallet.v1.ConnectorsAccountBalanceRequest
+	(*ConnectorsAccountBalanceResponse)(nil), // 51: arkwallet.v1.ConnectorsAccountBalanceResponse
+	(*LockConnectorUtxosRequest)(nil),        // 52: arkwallet.v1.LockConnectorUtxosRequest
+	(*LockConnectorUtxosResponse)(nil),       // 53: arkwallet.v1.LockConnectorUtxosResponse
+	(*GetDustAmountRequest)(nil),             // 54: arkwallet.v1.GetDustAmountRequest
+	(*GetDustAmountResponse)(nil),            // 55: arkwallet.v1.GetDustAmountResponse
+	(*WatchScriptsRequest)(nil),              // 56: arkwallet.v1.WatchScriptsRequest
+	(*WatchScriptsResponse)(nil),             // 57: arkwallet.v1.WatchScriptsResponse
+	(*UnwatchScriptsRequest)(nil),            // 58: arkwallet.v1.UnwatchScriptsRequest
+	(*UnwatchScriptsResponse)(nil),           // 59: arkwallet.v1.UnwatchScriptsResponse
+	(*GetTransactionRequest)(nil),            // 60: arkwallet.v1.GetTransactionRequest
+	(*GetTransactionResponse)(nil),           // 61: arkwallet.v1.GetTransactionResponse
+	(*SignMessageRequest)(nil),               // 62: arkwallet.v1.SignMessageRequest
+	(*SignMessageResponse)(nil),              // 63: arkwallet.v1.SignMessageResponse
+	(*VerifyMessageSignatureRequest)(nil),    // 64: arkwallet.v1.VerifyMessageSignatureRequest
+	(*VerifyMessageSignatureResponse)(nil),   // 65: arkwallet.v1.VerifyMessageSignatureResponse
+	(*GetCurrentBlockTimeRequest)(nil),       // 66: arkwallet.v1.GetCurrentBlockTimeRequest
+	(*GetCurrentBlockTimeResponse)(nil),      // 67: arkwallet.v1.GetCurrentBlockTimeResponse
+	(*RescanUtxosRequest)(nil),               // 68: arkwallet.v1.RescanUtxosRequest
+	(*RescanUtxosResponse)(nil),              // 69: arkwallet.v1.RescanUtxosResponse
+	(*WithdrawRequest)(nil),                  // 70: arkwallet.v1.WithdrawRequest
+	(*WithdrawResponse)(nil),                 // 71: arkwallet.v1.WithdrawResponse
+	(*LoadSignerKeyRequest)(nil),             // 72: arkwallet.v1.LoadSignerKeyRequest
+	(*LoadSignerKeyResponse)(nil),            // 73: arkwallet.v1.LoadSignerKeyResponse
+	(*TxInput)(nil),                          // 74: arkwallet.v1.TxInput
+	(*WalletUtxo)(nil),                       // 75: arkwallet.v1.WalletUtxo
+	(*TxOutpoint)(nil),                       // 76: arkwallet.v1.TxOutpoint
+	(*BlockTimestamp)(nil),                   // 77: arkwallet.v1.BlockTimestamp
 }
 var file_arkwallet_v1_bitcoin_wallet_proto_depIdxs = []int32{
 	8,  // 0: arkwallet.v1.NotificationStreamResponse.entries:type_name -> arkwallet.v1.VtoxsPerScript
 	9,  // 1: arkwallet.v1.VtoxsPerScript.vtxos:type_name -> arkwallet.v1.VtxoWithKey
-	72, // 2: arkwallet.v1.SelectUtxosResponse.utxos:type_name -> arkwallet.v1.TxInput
-	72, // 3: arkwallet.v1.ListConnectorUtxosResponse.utxos:type_name -> arkwallet.v1.TxInput
-	73, // 4: arkwallet.v1.LockConnectorUtxosRequest.utxos:type_name -> arkwallet.v1.TxOutpoint
-	74, // 5: arkwallet.v1.GetCurrentBlockTimeResponse.timestamp:type_name -> arkwallet.v1.BlockTimestamp
-	10, // 6: arkwallet.v1.WalletService.GenSeed:input_type -> arkwallet.v1.GenSeedRequest
-	12, // 7: arkwallet.v1.WalletService.Create:input_type -> arkwallet.v1.CreateRequest
-	14, // 8: arkwallet.v1.WalletService.Restore:input_type -> arkwallet.v1.RestoreRequest
-	16, // 9: arkwallet.v1.WalletService.Unlock:input_type -> arkwallet.v1.UnlockRequest
-	18, // 10: arkwallet.v1.WalletService.Lock:input_type -> arkwallet.v1.LockRequest
-	20, // 11: arkwallet.v1.WalletService.Status:input_type -> arkwallet.v1.StatusRequest
-	22, // 12: arkwallet.v1.WalletService.GetNetwork:input_type -> arkwallet.v1.GetNetworkRequest
-	24, // 13: arkwallet.v1.WalletService.GetForfeitPubkey:input_type -> arkwallet.v1.GetForfeitPubkeyRequest
-	26, // 14: arkwallet.v1.WalletService.DeriveConnectorAddress:input_type -> arkwallet.v1.DeriveConnectorAddressRequest
-	28, // 15: arkwallet.v1.WalletService.DeriveAddresses:input_type -> arkwallet.v1.DeriveAddressesRequest
-	30, // 16: arkwallet.v1.WalletService.SignTransaction:input_type -> arkwallet.v1.SignTransactionRequest
-	32, // 17: arkwallet.v1.WalletService.SignTransactionTapscript:input_type -> arkwallet.v1.SignTransactionTapscriptRequest
-	34, // 18: arkwallet.v1.WalletService.SelectUtxos:input_type -> arkwallet.v1.SelectUtxosRequest
-	36, // 19: arkwallet.v1.WalletService.BroadcastTransaction:input_type -> arkwallet.v1.BroadcastTransactionRequest
-	0,  // 20: arkwallet.v1.WalletService.GetReadyUpdate:input_type -> arkwallet.v1.GetReadyUpdateRequest
-	2,  // 21: arkwallet.v1.WalletService.IsTransactionConfirmed:input_type -> arkwallet.v1.IsTransactionConfirmedRequest
-	4,  // 22: arkwallet.v1.WalletService.GetOutpointStatus:input_type -> arkwallet.v1.GetOutpointStatusRequest
-	40, // 23: arkwallet.v1.WalletService.EstimateFees:input_type -> arkwallet.v1.EstimateFeesRequest
-	42, // 24: arkwallet.v1.WalletService.FeeRate:input_type -> arkwallet.v1.FeeRateRequest
-	44, // 25: arkwallet.v1.WalletService.ListConnectorUtxos:input_type -> arkwallet.v1.ListConnectorUtxosRequest
-	46, // 26: arkwallet.v1.WalletService.MainAccountBalance:input_type -> arkwallet.v1.MainAccountBalanceRequest
-	48, // 27: arkwallet.v1.WalletService.ConnectorsAccountBalance:input_type -> arkwallet.v1.ConnectorsAccountBalanceRequest
-	50, // 28: arkwallet.v1.WalletService.LockConnectorUtxos:input_type -> arkwallet.v1.LockConnectorUtxosRequest
-	52, // 29: arkwallet.v1.WalletService.GetDustAmount:input_type -> arkwallet.v1.GetDustAmountRequest
-	58, // 30: arkwallet.v1.WalletService.GetTransaction:input_type -> arkwallet.v1.GetTransactionRequest
-	60, // 31: arkwallet.v1.WalletService.SignMessage:input_type -> arkwallet.v1.SignMessageRequest
-	62, // 32: arkwallet.v1.WalletService.VerifyMessageSignature:input_type -> arkwallet.v1.VerifyMessageSignatureRequest
-	64, // 33: arkwallet.v1.WalletService.GetCurrentBlockTime:input_type -> arkwallet.v1.GetCurrentBlockTimeRequest
-	68, // 34: arkwallet.v1.WalletService.Withdraw:input_type -> arkwallet.v1.WithdrawRequest
-	54, // 35: arkwallet.v1.WalletService.WatchScripts:input_type -> arkwallet.v1.WatchScriptsRequest
-	56, // 36: arkwallet.v1.WalletService.UnwatchScripts:input_type -> arkwallet.v1.UnwatchScriptsRequest
-	6,  // 37: arkwallet.v1.WalletService.NotificationStream:input_type -> arkwallet.v1.NotificationStreamRequest
-	70, // 38: arkwallet.v1.WalletService.LoadSignerKey:input_type -> arkwallet.v1.LoadSignerKeyRequest
-	66, // 39: arkwallet.v1.WalletService.RescanUtxos:input_type -> arkwallet.v1.RescanUtxosRequest
-	11, // 40: arkwallet.v1.WalletService.GenSeed:output_type -> arkwallet.v1.GenSeedResponse
-	13, // 41: arkwallet.v1.WalletService.Create:output_type -> arkwallet.v1.CreateResponse
-	15, // 42: arkwallet.v1.WalletService.Restore:output_type -> arkwallet.v1.RestoreResponse
-	17, // 43: arkwallet.v1.WalletService.Unlock:output_type -> arkwallet.v1.UnlockResponse
-	19, // 44: arkwallet.v1.WalletService.Lock:output_type -> arkwallet.v1.LockResponse
-	21, // 45: arkwallet.v1.WalletService.Status:output_type -> arkwallet.v1.StatusResponse
-	23, // 46: arkwallet.v1.WalletService.GetNetwork:output_type -> arkwallet.v1.GetNetworkResponse
-	25, // 47: arkwallet.v1.WalletService.GetForfeitPubkey:output_type -> arkwallet.v1.GetForfeitPubkeyResponse
-	27, // 48: arkwallet.v1.WalletService.DeriveConnectorAddress:output_type -> arkwallet.v1.DeriveConnectorAddressResponse
-	29, // 49: arkwallet.v1.WalletService.DeriveAddresses:output_type -> arkwallet.v1.DeriveAddressesResponse
-	31, // 50: arkwallet.v1.WalletService.SignTransaction:output_type -> arkwallet.v1.SignTransactionResponse
-	33, // 51: arkwallet.v1.WalletService.SignTransactionTapscript:output_type -> arkwallet.v1.SignTransactionTapscriptResponse
-	35, // 52: arkwallet.v1.WalletService.SelectUtxos:output_type -> arkwallet.v1.SelectUtxosResponse
-	37, // 53: arkwallet.v1.WalletService.BroadcastTransaction:output_type -> arkwallet.v1.BroadcastTransactionResponse
-	1,  // 54: arkwallet.v1.WalletService.GetReadyUpdate:output_type -> arkwallet.v1.GetReadyUpdateResponse
-	3,  // 55: arkwallet.v1.WalletService.IsTransactionConfirmed:output_type -> arkwallet.v1.IsTransactionConfirmedResponse
-	5,  // 56: arkwallet.v1.WalletService.GetOutpointStatus:output_type -> arkwallet.v1.GetOutpointStatusResponse
-	41, // 57: arkwallet.v1.WalletService.EstimateFees:output_type -> arkwallet.v1.EstimateFeesResponse
-	43, // 58: arkwallet.v1.WalletService.FeeRate:output_type -> arkwallet.v1.FeeRateResponse
-	45, // 59: arkwallet.v1.WalletService.ListConnectorUtxos:output_type -> arkwallet.v1.ListConnectorUtxosResponse
-	47, // 60: arkwallet.v1.WalletService.MainAccountBalance:output_type -> arkwallet.v1.MainAccountBalanceResponse
-	49, // 61: arkwallet.v1.WalletService.ConnectorsAccountBalance:output_type -> arkwallet.v1.ConnectorsAccountBalanceResponse
-	51, // 62: arkwallet.v1.WalletService.LockConnectorUtxos:output_type -> arkwallet.v1.LockConnectorUtxosResponse
-	53, // 63: arkwallet.v1.WalletService.GetDustAmount:output_type -> arkwallet.v1.GetDustAmountResponse
-	59, // 64: arkwallet.v1.WalletService.GetTransaction:output_type -> arkwallet.v1.GetTransactionResponse
-	61, // 65: arkwallet.v1.WalletService.SignMessage:output_type -> arkwallet.v1.SignMessageResponse
-	63, // 66: arkwallet.v1.WalletService.VerifyMessageSignature:output_type -> arkwallet.v1.VerifyMessageSignatureResponse
-	65, // 67: arkwallet.v1.WalletService.GetCurrentBlockTime:output_type -> arkwallet.v1.GetCurrentBlockTimeResponse
-	69, // 68: arkwallet.v1.WalletService.Withdraw:output_type -> arkwallet.v1.WithdrawResponse
-	55, // 69: arkwallet.v1.WalletService.WatchScripts:output_type -> arkwallet.v1.WatchScriptsResponse
-	57, // 70: arkwallet.v1.WalletService.UnwatchScripts:output_type -> arkwallet.v1.UnwatchScriptsResponse
-	7,  // 71: arkwallet.v1.WalletService.NotificationStream:output_type -> arkwallet.v1.NotificationStreamResponse
-	71, // 72: arkwallet.v1.WalletService.LoadSignerKey:output_type -> arkwallet.v1.LoadSignerKeyResponse
-	67, // 73: arkwallet.v1.WalletService.RescanUtxos:output_type -> arkwallet.v1.RescanUtxosResponse
-	40, // [40:74] is the sub-list for method output_type
-	6,  // [6:40] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	74, // 2: arkwallet.v1.SelectUtxosResponse.utxos:type_name -> arkwallet.v1.TxInput
+	74, // 3: arkwallet.v1.ListConnectorUtxosResponse.utxos:type_name -> arkwallet.v1.TxInput
+	75, // 4: arkwallet.v1.GetMainAccountUtxosResponse.utxos:type_name -> arkwallet.v1.WalletUtxo
+	76, // 5: arkwallet.v1.LockConnectorUtxosRequest.utxos:type_name -> arkwallet.v1.TxOutpoint
+	77, // 6: arkwallet.v1.GetCurrentBlockTimeResponse.timestamp:type_name -> arkwallet.v1.BlockTimestamp
+	10, // 7: arkwallet.v1.WalletService.GenSeed:input_type -> arkwallet.v1.GenSeedRequest
+	12, // 8: arkwallet.v1.WalletService.Create:input_type -> arkwallet.v1.CreateRequest
+	14, // 9: arkwallet.v1.WalletService.Restore:input_type -> arkwallet.v1.RestoreRequest
+	16, // 10: arkwallet.v1.WalletService.Unlock:input_type -> arkwallet.v1.UnlockRequest
+	18, // 11: arkwallet.v1.WalletService.Lock:input_type -> arkwallet.v1.LockRequest
+	20, // 12: arkwallet.v1.WalletService.Status:input_type -> arkwallet.v1.StatusRequest
+	22, // 13: arkwallet.v1.WalletService.GetNetwork:input_type -> arkwallet.v1.GetNetworkRequest
+	24, // 14: arkwallet.v1.WalletService.GetForfeitPubkey:input_type -> arkwallet.v1.GetForfeitPubkeyRequest
+	26, // 15: arkwallet.v1.WalletService.DeriveConnectorAddress:input_type -> arkwallet.v1.DeriveConnectorAddressRequest
+	28, // 16: arkwallet.v1.WalletService.DeriveAddresses:input_type -> arkwallet.v1.DeriveAddressesRequest
+	30, // 17: arkwallet.v1.WalletService.SignTransaction:input_type -> arkwallet.v1.SignTransactionRequest
+	32, // 18: arkwallet.v1.WalletService.SignTransactionTapscript:input_type -> arkwallet.v1.SignTransactionTapscriptRequest
+	34, // 19: arkwallet.v1.WalletService.SelectUtxos:input_type -> arkwallet.v1.SelectUtxosRequest
+	36, // 20: arkwallet.v1.WalletService.BroadcastTransaction:input_type -> arkwallet.v1.BroadcastTransactionRequest
+	0,  // 21: arkwallet.v1.WalletService.GetReadyUpdate:input_type -> arkwallet.v1.GetReadyUpdateRequest
+	2,  // 22: arkwallet.v1.WalletService.IsTransactionConfirmed:input_type -> arkwallet.v1.IsTransactionConfirmedRequest
+	4,  // 23: arkwallet.v1.WalletService.GetOutpointStatus:input_type -> arkwallet.v1.GetOutpointStatusRequest
+	40, // 24: arkwallet.v1.WalletService.EstimateFees:input_type -> arkwallet.v1.EstimateFeesRequest
+	42, // 25: arkwallet.v1.WalletService.FeeRate:input_type -> arkwallet.v1.FeeRateRequest
+	44, // 26: arkwallet.v1.WalletService.ListConnectorUtxos:input_type -> arkwallet.v1.ListConnectorUtxosRequest
+	46, // 27: arkwallet.v1.WalletService.GetMainAccountUtxos:input_type -> arkwallet.v1.GetMainAccountUtxosRequest
+	48, // 28: arkwallet.v1.WalletService.MainAccountBalance:input_type -> arkwallet.v1.MainAccountBalanceRequest
+	50, // 29: arkwallet.v1.WalletService.ConnectorsAccountBalance:input_type -> arkwallet.v1.ConnectorsAccountBalanceRequest
+	52, // 30: arkwallet.v1.WalletService.LockConnectorUtxos:input_type -> arkwallet.v1.LockConnectorUtxosRequest
+	54, // 31: arkwallet.v1.WalletService.GetDustAmount:input_type -> arkwallet.v1.GetDustAmountRequest
+	60, // 32: arkwallet.v1.WalletService.GetTransaction:input_type -> arkwallet.v1.GetTransactionRequest
+	62, // 33: arkwallet.v1.WalletService.SignMessage:input_type -> arkwallet.v1.SignMessageRequest
+	64, // 34: arkwallet.v1.WalletService.VerifyMessageSignature:input_type -> arkwallet.v1.VerifyMessageSignatureRequest
+	66, // 35: arkwallet.v1.WalletService.GetCurrentBlockTime:input_type -> arkwallet.v1.GetCurrentBlockTimeRequest
+	70, // 36: arkwallet.v1.WalletService.Withdraw:input_type -> arkwallet.v1.WithdrawRequest
+	56, // 37: arkwallet.v1.WalletService.WatchScripts:input_type -> arkwallet.v1.WatchScriptsRequest
+	58, // 38: arkwallet.v1.WalletService.UnwatchScripts:input_type -> arkwallet.v1.UnwatchScriptsRequest
+	6,  // 39: arkwallet.v1.WalletService.NotificationStream:input_type -> arkwallet.v1.NotificationStreamRequest
+	72, // 40: arkwallet.v1.WalletService.LoadSignerKey:input_type -> arkwallet.v1.LoadSignerKeyRequest
+	68, // 41: arkwallet.v1.WalletService.RescanUtxos:input_type -> arkwallet.v1.RescanUtxosRequest
+	11, // 42: arkwallet.v1.WalletService.GenSeed:output_type -> arkwallet.v1.GenSeedResponse
+	13, // 43: arkwallet.v1.WalletService.Create:output_type -> arkwallet.v1.CreateResponse
+	15, // 44: arkwallet.v1.WalletService.Restore:output_type -> arkwallet.v1.RestoreResponse
+	17, // 45: arkwallet.v1.WalletService.Unlock:output_type -> arkwallet.v1.UnlockResponse
+	19, // 46: arkwallet.v1.WalletService.Lock:output_type -> arkwallet.v1.LockResponse
+	21, // 47: arkwallet.v1.WalletService.Status:output_type -> arkwallet.v1.StatusResponse
+	23, // 48: arkwallet.v1.WalletService.GetNetwork:output_type -> arkwallet.v1.GetNetworkResponse
+	25, // 49: arkwallet.v1.WalletService.GetForfeitPubkey:output_type -> arkwallet.v1.GetForfeitPubkeyResponse
+	27, // 50: arkwallet.v1.WalletService.DeriveConnectorAddress:output_type -> arkwallet.v1.DeriveConnectorAddressResponse
+	29, // 51: arkwallet.v1.WalletService.DeriveAddresses:output_type -> arkwallet.v1.DeriveAddressesResponse
+	31, // 52: arkwallet.v1.WalletService.SignTransaction:output_type -> arkwallet.v1.SignTransactionResponse
+	33, // 53: arkwallet.v1.WalletService.SignTransactionTapscript:output_type -> arkwallet.v1.SignTransactionTapscriptResponse
+	35, // 54: arkwallet.v1.WalletService.SelectUtxos:output_type -> arkwallet.v1.SelectUtxosResponse
+	37, // 55: arkwallet.v1.WalletService.BroadcastTransaction:output_type -> arkwallet.v1.BroadcastTransactionResponse
+	1,  // 56: arkwallet.v1.WalletService.GetReadyUpdate:output_type -> arkwallet.v1.GetReadyUpdateResponse
+	3,  // 57: arkwallet.v1.WalletService.IsTransactionConfirmed:output_type -> arkwallet.v1.IsTransactionConfirmedResponse
+	5,  // 58: arkwallet.v1.WalletService.GetOutpointStatus:output_type -> arkwallet.v1.GetOutpointStatusResponse
+	41, // 59: arkwallet.v1.WalletService.EstimateFees:output_type -> arkwallet.v1.EstimateFeesResponse
+	43, // 60: arkwallet.v1.WalletService.FeeRate:output_type -> arkwallet.v1.FeeRateResponse
+	45, // 61: arkwallet.v1.WalletService.ListConnectorUtxos:output_type -> arkwallet.v1.ListConnectorUtxosResponse
+	47, // 62: arkwallet.v1.WalletService.GetMainAccountUtxos:output_type -> arkwallet.v1.GetMainAccountUtxosResponse
+	49, // 63: arkwallet.v1.WalletService.MainAccountBalance:output_type -> arkwallet.v1.MainAccountBalanceResponse
+	51, // 64: arkwallet.v1.WalletService.ConnectorsAccountBalance:output_type -> arkwallet.v1.ConnectorsAccountBalanceResponse
+	53, // 65: arkwallet.v1.WalletService.LockConnectorUtxos:output_type -> arkwallet.v1.LockConnectorUtxosResponse
+	55, // 66: arkwallet.v1.WalletService.GetDustAmount:output_type -> arkwallet.v1.GetDustAmountResponse
+	61, // 67: arkwallet.v1.WalletService.GetTransaction:output_type -> arkwallet.v1.GetTransactionResponse
+	63, // 68: arkwallet.v1.WalletService.SignMessage:output_type -> arkwallet.v1.SignMessageResponse
+	65, // 69: arkwallet.v1.WalletService.VerifyMessageSignature:output_type -> arkwallet.v1.VerifyMessageSignatureResponse
+	67, // 70: arkwallet.v1.WalletService.GetCurrentBlockTime:output_type -> arkwallet.v1.GetCurrentBlockTimeResponse
+	71, // 71: arkwallet.v1.WalletService.Withdraw:output_type -> arkwallet.v1.WithdrawResponse
+	57, // 72: arkwallet.v1.WalletService.WatchScripts:output_type -> arkwallet.v1.WatchScriptsResponse
+	59, // 73: arkwallet.v1.WalletService.UnwatchScripts:output_type -> arkwallet.v1.UnwatchScriptsResponse
+	7,  // 74: arkwallet.v1.WalletService.NotificationStream:output_type -> arkwallet.v1.NotificationStreamResponse
+	73, // 75: arkwallet.v1.WalletService.LoadSignerKey:output_type -> arkwallet.v1.LoadSignerKeyResponse
+	69, // 76: arkwallet.v1.WalletService.RescanUtxos:output_type -> arkwallet.v1.RescanUtxosResponse
+	42, // [42:77] is the sub-list for method output_type
+	7,  // [7:42] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_arkwallet_v1_bitcoin_wallet_proto_init() }
@@ -3724,7 +3915,7 @@ func file_arkwallet_v1_bitcoin_wallet_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_arkwallet_v1_bitcoin_wallet_proto_rawDesc), len(file_arkwallet_v1_bitcoin_wallet_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   75,
+			NumMessages:   78,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api-spec/protobuf/gen/arkwallet/v1/bitcoin_wallet.pb.rgw.go
+++ b/api-spec/protobuf/gen/arkwallet/v1/bitcoin_wallet.pb.rgw.go
@@ -327,6 +327,15 @@ func request_WalletService_ListConnectorUtxos_0(ctx context.Context, marshaler g
 
 }
 
+func request_WalletService_GetMainAccountUtxos_0(ctx context.Context, marshaler gateway.Marshaler, mux *gateway.ServeMux, client WalletServiceClient, req *http.Request, pathParams gateway.Params) (proto.Message, gateway.ServerMetadata, error) {
+	var protoReq GetMainAccountUtxosRequest
+	var metadata gateway.ServerMetadata
+
+	msg, err := client.GetMainAccountUtxos(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
 func request_WalletService_MainAccountBalance_0(ctx context.Context, marshaler gateway.Marshaler, mux *gateway.ServeMux, client WalletServiceClient, req *http.Request, pathParams gateway.Params) (proto.Message, gateway.ServerMetadata, error) {
 	var protoReq MainAccountBalanceRequest
 	var metadata gateway.ServerMetadata
@@ -1027,6 +1036,28 @@ func RegisterWalletServiceHandlerClient(ctx context.Context, mux *gateway.ServeM
 		}
 
 		resp, md, err := request_WalletService_ListConnectorUtxos_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
+		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)
+			return
+		}
+
+		mux.ForwardResponseMessage(annotatedContext, outboundMarshaler, w, req, resp)
+	})
+
+	mux.HandleWithParams("GET", "/v1/wallet/main-account-utxos", func(w http.ResponseWriter, req *http.Request, pathParams gateway.Params) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := mux.MarshalerForRequest(req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = gateway.AnnotateContext(ctx, mux, req, "/arkwallet.v1.WalletService/GetMainAccountUtxos", gateway.WithHTTPPathPattern("/v1/wallet/main-account-utxos"))
+		if err != nil {
+			mux.HTTPError(ctx, outboundMarshaler, w, req, err)
+			return
+		}
+
+		resp, md, err := request_WalletService_GetMainAccountUtxos_0(annotatedContext, inboundMarshaler, mux, client, req, pathParams)
 		annotatedContext = gateway.NewServerMetadataContext(annotatedContext, md)
 		if err != nil {
 			mux.HTTPError(annotatedContext, outboundMarshaler, w, req, err)

--- a/api-spec/protobuf/gen/arkwallet/v1/bitcoin_wallet_grpc.pb.go
+++ b/api-spec/protobuf/gen/arkwallet/v1/bitcoin_wallet_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	WalletService_EstimateFees_FullMethodName             = "/arkwallet.v1.WalletService/EstimateFees"
 	WalletService_FeeRate_FullMethodName                  = "/arkwallet.v1.WalletService/FeeRate"
 	WalletService_ListConnectorUtxos_FullMethodName       = "/arkwallet.v1.WalletService/ListConnectorUtxos"
+	WalletService_GetMainAccountUtxos_FullMethodName      = "/arkwallet.v1.WalletService/GetMainAccountUtxos"
 	WalletService_MainAccountBalance_FullMethodName       = "/arkwallet.v1.WalletService/MainAccountBalance"
 	WalletService_ConnectorsAccountBalance_FullMethodName = "/arkwallet.v1.WalletService/ConnectorsAccountBalance"
 	WalletService_LockConnectorUtxos_FullMethodName       = "/arkwallet.v1.WalletService/LockConnectorUtxos"
@@ -81,6 +82,7 @@ type WalletServiceClient interface {
 	EstimateFees(ctx context.Context, in *EstimateFeesRequest, opts ...grpc.CallOption) (*EstimateFeesResponse, error)
 	FeeRate(ctx context.Context, in *FeeRateRequest, opts ...grpc.CallOption) (*FeeRateResponse, error)
 	ListConnectorUtxos(ctx context.Context, in *ListConnectorUtxosRequest, opts ...grpc.CallOption) (*ListConnectorUtxosResponse, error)
+	GetMainAccountUtxos(ctx context.Context, in *GetMainAccountUtxosRequest, opts ...grpc.CallOption) (*GetMainAccountUtxosResponse, error)
 	MainAccountBalance(ctx context.Context, in *MainAccountBalanceRequest, opts ...grpc.CallOption) (*MainAccountBalanceResponse, error)
 	ConnectorsAccountBalance(ctx context.Context, in *ConnectorsAccountBalanceRequest, opts ...grpc.CallOption) (*ConnectorsAccountBalanceResponse, error)
 	LockConnectorUtxos(ctx context.Context, in *LockConnectorUtxosRequest, opts ...grpc.CallOption) (*LockConnectorUtxosResponse, error)
@@ -314,6 +316,16 @@ func (c *walletServiceClient) ListConnectorUtxos(ctx context.Context, in *ListCo
 	return out, nil
 }
 
+func (c *walletServiceClient) GetMainAccountUtxos(ctx context.Context, in *GetMainAccountUtxosRequest, opts ...grpc.CallOption) (*GetMainAccountUtxosResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetMainAccountUtxosResponse)
+	err := c.cc.Invoke(ctx, WalletService_GetMainAccountUtxos_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *walletServiceClient) MainAccountBalance(ctx context.Context, in *MainAccountBalanceRequest, opts ...grpc.CallOption) (*MainAccountBalanceResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(MainAccountBalanceResponse)
@@ -489,6 +501,7 @@ type WalletServiceServer interface {
 	EstimateFees(context.Context, *EstimateFeesRequest) (*EstimateFeesResponse, error)
 	FeeRate(context.Context, *FeeRateRequest) (*FeeRateResponse, error)
 	ListConnectorUtxos(context.Context, *ListConnectorUtxosRequest) (*ListConnectorUtxosResponse, error)
+	GetMainAccountUtxos(context.Context, *GetMainAccountUtxosRequest) (*GetMainAccountUtxosResponse, error)
 	MainAccountBalance(context.Context, *MainAccountBalanceRequest) (*MainAccountBalanceResponse, error)
 	ConnectorsAccountBalance(context.Context, *ConnectorsAccountBalanceRequest) (*ConnectorsAccountBalanceResponse, error)
 	LockConnectorUtxos(context.Context, *LockConnectorUtxosRequest) (*LockConnectorUtxosResponse, error)
@@ -571,6 +584,9 @@ func (UnimplementedWalletServiceServer) FeeRate(context.Context, *FeeRateRequest
 }
 func (UnimplementedWalletServiceServer) ListConnectorUtxos(context.Context, *ListConnectorUtxosRequest) (*ListConnectorUtxosResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ListConnectorUtxos not implemented")
+}
+func (UnimplementedWalletServiceServer) GetMainAccountUtxos(context.Context, *GetMainAccountUtxosRequest) (*GetMainAccountUtxosResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetMainAccountUtxos not implemented")
 }
 func (UnimplementedWalletServiceServer) MainAccountBalance(context.Context, *MainAccountBalanceRequest) (*MainAccountBalanceResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method MainAccountBalance not implemented")
@@ -987,6 +1003,24 @@ func _WalletService_ListConnectorUtxos_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WalletService_GetMainAccountUtxos_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMainAccountUtxosRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WalletServiceServer).GetMainAccountUtxos(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WalletService_GetMainAccountUtxos_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WalletServiceServer).GetMainAccountUtxos(ctx, req.(*GetMainAccountUtxosRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _WalletService_MainAccountBalance_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(MainAccountBalanceRequest)
 	if err := dec(in); err != nil {
@@ -1314,6 +1348,10 @@ var WalletService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListConnectorUtxos",
 			Handler:    _WalletService_ListConnectorUtxos_Handler,
+		},
+		{
+			MethodName: "GetMainAccountUtxos",
+			Handler:    _WalletService_GetMainAccountUtxos_Handler,
 		},
 		{
 			MethodName: "MainAccountBalance",

--- a/cmd/arkd/commands.go
+++ b/cmd/arkd/commands.go
@@ -125,6 +125,11 @@ var (
 		Flags:  []cli.Flag{sweepConnectorsFlag, sweepCommitmentTxidsFlag},
 		Action: sweepAction,
 	}
+	walletUtxosCmd = &cli.Command{
+		Name:   "wallet-utxos",
+		Usage:  "List the UTXO set of the wallet main account",
+		Action: walletUtxosAction,
+	}
 	roundInfoCmd = &cli.Command{
 		Name:   "round-info",
 		Usage:  "Get round info",
@@ -563,6 +568,28 @@ func scheduledSweepAction(ctx *cli.Context) error {
 	url := fmt.Sprintf("%s/v1/admin/sweeps", baseURL)
 
 	resp, err := get[[]map[string]any](url, "sweeps", macaroon, tlsConfig)
+	if err != nil {
+		return err
+	}
+
+	respJson, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to json encode response: %s", err)
+	}
+	fmt.Println(string(respJson))
+	return nil
+}
+
+func walletUtxosAction(ctx *cli.Context) error {
+	baseURL := ctx.String(urlFlagName)
+	macaroon, tlsConfig, err := getCredentials(ctx)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/v1/admin/wallet/utxos", baseURL)
+
+	resp, err := get[[]map[string]any](url, "utxos", macaroon, tlsConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/arkd/main.go
+++ b/cmd/arkd/main.go
@@ -91,6 +91,7 @@ func main() {
 		intentsCmd,
 		scheduledSweepCmd,
 		sweepCmd,
+		walletUtxosCmd,
 		roundInfoCmd,
 		roundsInTimeRangeCmd,
 		scheduledSessionCmd,

--- a/internal/core/application/admin.go
+++ b/internal/core/application/admin.go
@@ -26,6 +26,7 @@ type AdminService interface {
 	) ([]string, error)
 	GetWalletAddress(ctx context.Context) (string, error)
 	GetWalletStatus(ctx context.Context) (*WalletStatus, error)
+	GetMainAccountUtxos(ctx context.Context) ([]ports.WalletUtxo, error)
 	CreateNotes(ctx context.Context, amount uint32, quantity int) ([]string, error)
 	GetScheduledSessionConfig(ctx context.Context) (*domain.ScheduledSession, error)
 	UpdateScheduledSessionConfig(
@@ -89,6 +90,10 @@ func NewAdminService(
 
 func (a *adminService) Wallet() ports.WalletService {
 	return a.walletSvc
+}
+
+func (a *adminService) GetMainAccountUtxos(ctx context.Context) ([]ports.WalletUtxo, error) {
+	return a.walletSvc.GetMainAccountUtxos(ctx)
 }
 
 func (a *adminService) GetRoundDetails(

--- a/internal/core/ports/wallet.go
+++ b/internal/core/ports/wallet.go
@@ -38,6 +38,9 @@ type WalletService interface {
 	EstimateFees(ctx context.Context, psbt string) (uint64, error)
 	FeeRate(ctx context.Context) (uint64, error)
 	ListConnectorUtxos(ctx context.Context, connectorAddress string) ([]TxInput, error)
+	// GetMainAccountUtxos lists the whole UTXO set of the main account,
+	// including locked and unconfirmed UTXOs, each flagged accordingly.
+	GetMainAccountUtxos(ctx context.Context) ([]WalletUtxo, error)
 	MainAccountBalance(ctx context.Context) (uint64, uint64, error)
 	ConnectorsAccountBalance(ctx context.Context) (uint64, uint64, error)
 	LockConnectorUtxos(ctx context.Context, utxos []domain.Outpoint) error
@@ -68,6 +71,18 @@ type Tapscript struct {
 	InternalKey  string // hex encoded
 	ControlBlock string // hex encoded
 	Tapscript    string // hex encoded
+}
+
+// WalletUtxo describes a single UTXO of the main account, including its
+// confirmation count and whether it is currently locked by a pending operation.
+type WalletUtxo struct {
+	Txid          string
+	Vout          uint32
+	Value         uint64
+	Script        string // hex encoded
+	Address       string
+	Confirmations uint32
+	Locked        bool
 }
 
 type BlockTimestamp struct {

--- a/internal/infrastructure/tx-builder/covenantless/mocks_test.go
+++ b/internal/infrastructure/tx-builder/covenantless/mocks_test.go
@@ -274,6 +274,17 @@ func (m *mockedWallet) ListConnectorUtxos(
 	return res, args.Error(1)
 }
 
+func (m *mockedWallet) GetMainAccountUtxos(ctx context.Context) ([]ports.WalletUtxo, error) {
+	args := m.Called(ctx)
+
+	var res []ports.WalletUtxo
+	if a := args.Get(0); a != nil {
+		res = a.([]ports.WalletUtxo)
+	}
+
+	return res, args.Error(1)
+}
+
 func (m *mockedWallet) LockConnectorUtxos(ctx context.Context, utxos []domain.Outpoint) error {
 	args := m.Called(ctx, utxos)
 	return args.Error(0)

--- a/internal/infrastructure/wallet/wallet_client.go
+++ b/internal/infrastructure/wallet/wallet_client.go
@@ -438,6 +438,26 @@ func (w *walletDaemonClient) ListConnectorUtxos(
 	return inputs, nil
 }
 
+func (w *walletDaemonClient) GetMainAccountUtxos(ctx context.Context) ([]ports.WalletUtxo, error) {
+	resp, err := w.client.GetMainAccountUtxos(ctx, &arkwalletv1.GetMainAccountUtxosRequest{})
+	if err != nil {
+		return nil, err
+	}
+	utxos := make([]ports.WalletUtxo, len(resp.GetUtxos()))
+	for i, utxo := range resp.GetUtxos() {
+		utxos[i] = ports.WalletUtxo{
+			Txid:          utxo.GetTxid(),
+			Vout:          utxo.GetVout(),
+			Value:         utxo.GetValue(),
+			Script:        utxo.GetScript(),
+			Address:       utxo.GetAddress(),
+			Confirmations: utxo.GetConfirmations(),
+			Locked:        utxo.GetLocked(),
+		}
+	}
+	return utxos, nil
+}
+
 func (w *walletDaemonClient) MainAccountBalance(ctx context.Context) (uint64, uint64, error) {
 	resp, err := w.client.MainAccountBalance(ctx, &arkwalletv1.MainAccountBalanceRequest{})
 	if err != nil {

--- a/internal/interface/grpc/handlers/adminservice.go
+++ b/internal/interface/grpc/handlers/adminservice.go
@@ -498,6 +498,30 @@ func (a *adminHandler) Sweep(
 	}, nil
 }
 
+func (a *adminHandler) GetMainAccountUtxos(
+	ctx context.Context, _ *arkv1.GetMainAccountUtxosRequest,
+) (*arkv1.GetMainAccountUtxosResponse, error) {
+	utxos, err := a.adminService.GetMainAccountUtxos(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "%s", err.Error())
+	}
+
+	resp := make([]*arkv1.WalletUtxo, 0, len(utxos))
+	for _, u := range utxos {
+		resp = append(resp, &arkv1.WalletUtxo{
+			Txid:          u.Txid,
+			Vout:          u.Vout,
+			Value:         u.Value,
+			Script:        u.Script,
+			Address:       u.Address,
+			Confirmations: u.Confirmations,
+			Locked:        u.Locked,
+		})
+	}
+
+	return &arkv1.GetMainAccountUtxosResponse{Utxos: resp}, nil
+}
+
 func (a *adminHandler) RevokeAuth(
 	ctx context.Context, req *arkv1.RevokeAuthRequest,
 ) (*arkv1.RevokeAuthResponse, error) {

--- a/internal/interface/grpc/permissions/permissions.go
+++ b/internal/interface/grpc/permissions/permissions.go
@@ -316,6 +316,10 @@ func AllPermissionsByMethod() map[string][]bakery.Op {
 			Entity: EntityManager,
 			Action: "read",
 		}},
+		fmt.Sprintf("/%s/GetMainAccountUtxos", arkv1.AdminService_ServiceDesc.ServiceName): {{
+			Entity: EntityManager,
+			Action: "read",
+		}},
 		fmt.Sprintf("/%s/CreateNote", arkv1.AdminService_ServiceDesc.ServiceName): {{
 			Entity: EntityNote,
 			Action: "write",

--- a/pkg/arkd-wallet/core/application/types.go
+++ b/pkg/arkd-wallet/core/application/types.go
@@ -35,6 +35,9 @@ type WalletService interface {
 	EstimateFees(ctx context.Context, psbt string) (uint64, error)
 	FeeRate(ctx context.Context) (chainfee.SatPerKVByte, error)
 	ListConnectorUtxos(ctx context.Context, connectorAddress string) ([]Utxo, error)
+	// GetMainAccountUtxos lists the whole UTXO set of the main account,
+	// including locked and unconfirmed UTXOs, each flagged accordingly.
+	GetMainAccountUtxos(ctx context.Context) ([]MainAccountUtxo, error)
 	MainAccountBalance(ctx context.Context) (uint64, uint64, error)
 	ConnectorsAccountBalance(ctx context.Context) (uint64, uint64, error)
 	LockConnectorUtxos(ctx context.Context, utxos []wire.OutPoint) error
@@ -72,6 +75,18 @@ type Utxo struct {
 	Index  uint32
 	Script string
 	Value  uint64
+}
+
+// MainAccountUtxo describes a single UTXO of the main account, including its
+// confirmation count and whether it is currently locked by a pending operation.
+type MainAccountUtxo struct {
+	Txid          string
+	Vout          uint32
+	Value         uint64
+	Script        string
+	Address       string
+	Confirmations uint32
+	Locked        bool
 }
 
 type BlockTimestamp struct {

--- a/pkg/arkd-wallet/core/application/wallet/coinselect.go
+++ b/pkg/arkd-wallet/core/application/wallet/coinselect.go
@@ -62,3 +62,17 @@ func (u coin) Index() uint32 {
 func (u coin) NumConfs() int64 {
 	return int64(u.utxo.Confirmations)
 }
+
+// effectiveValueCoin wraps a coin so the selector ranks and accumulates it by
+// its effective value (real value minus the fee to spend it as an input), while
+// still exposing the real outpoint/script/value for tx building. Selecting by
+// effective value against a target of amount+baseFee guarantees the chosen
+// UTXOs cover the amount plus the fee for their actual input count.
+type effectiveValueCoin struct {
+	coin
+	effectiveValue btcutil.Amount
+}
+
+func (c effectiveValueCoin) Value() btcutil.Amount {
+	return c.effectiveValue
+}

--- a/pkg/arkd-wallet/core/application/wallet/coinselect.go
+++ b/pkg/arkd-wallet/core/application/wallet/coinselect.go
@@ -9,9 +9,25 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
-var coinSelector = coinset.MinNumberCoinSelector{
-	MaxInputs:       50,
-	MinChangeAmount: 800,
+const (
+	// maxSelectionInputs caps the number of inputs a single selection may use.
+	maxSelectionInputs = 50
+	// defaultMinChangeAmount is the min change a selection must leave to be
+	// accepted (roughly the P2TR/P2WSH dust limit). It avoids producing dust
+	// change outputs for general-purpose selections.
+	defaultMinChangeAmount = 330
+)
+
+// newCoinSelector builds a coin selector that prefers the fewest inputs.
+// minChangeAmount controls the minimum change a selection must leave behind:
+// any selection whose total is in (target, target+minChangeAmount) is rejected.
+// Pass 0 to accept any total >= target (useful when sub-dust change is folded
+// into the fee instead of becoming an output).
+func newCoinSelector(minChangeAmount btcutil.Amount) coinset.MinNumberCoinSelector {
+	return coinset.MinNumberCoinSelector{
+		MaxInputs:       maxSelectionInputs,
+		MinChangeAmount: minChangeAmount,
+	}
 }
 
 // coin implements coinset.Coin interface

--- a/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
+++ b/pkg/arkd-wallet/core/application/wallet/outpoint_locker.go
@@ -52,6 +52,21 @@ func (l *outpointLocker) lock(ctx context.Context, outpoints ...wire.OutPoint) e
 	return nil
 }
 
+// unlock releases the given outpoints so they can be selected again. Unlocking
+// an outpoint that isn't locked is a no-op.
+func (l *outpointLocker) unlock(_ context.Context, outpoints ...wire.OutPoint) {
+	if len(outpoints) == 0 {
+		return
+	}
+
+	l.locker.Lock()
+	defer l.locker.Unlock()
+
+	for _, outpoint := range outpoints {
+		delete(l.lockedOutpoints, outpoint)
+	}
+}
+
 func (l *outpointLocker) get(_ context.Context) (map[wire.OutPoint]struct{}, error) {
 	l.locker.Lock()
 	defer l.locker.Unlock()

--- a/pkg/arkd-wallet/core/application/wallet/service.go
+++ b/pkg/arkd-wallet/core/application/wallet/service.go
@@ -380,6 +380,23 @@ func (w *wallet) GetCurrentBlockTime(ctx context.Context) (*application.BlockTim
 }
 
 func (w *wallet) SelectUtxos(ctx context.Context, amount uint64, confirmedOnly bool) ([]application.Utxo, uint64, error) {
+	selectedUtxos, totalValue, err := w.selectCoins(ctx, amount, confirmedOnly, defaultMinChangeAmount)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if err := w.lockUtxos(ctx, selectedUtxos); err != nil {
+		log.Error("failed to lock utxos", err)
+		// ignore error
+	}
+
+	return selectedUtxos, totalValue - amount, nil
+}
+
+// selectCoins picks a subset of the main account UTXOs covering amount
+func (w *wallet) selectCoins(
+	ctx context.Context, amount uint64, confirmedOnly bool, minChangeAmount btcutil.Amount,
+) ([]application.Utxo, uint64, error) {
 	if w.keyMgr == nil {
 		return nil, 0, ErrWalletLocked
 	}
@@ -406,14 +423,13 @@ func (w *wallet) SelectUtxos(ctx context.Context, amount uint64, confirmedOnly b
 		availableUtxos = append(availableUtxos, coin{utxo})
 	}
 
-	coins, err := coinSelector.CoinSelect(btcutil.Amount(amount), availableUtxos)
+	coins, err := newCoinSelector(minChangeAmount).CoinSelect(btcutil.Amount(amount), availableUtxos)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	selected := coins.Coins()
 	selectedUtxos := make([]application.Utxo, 0, len(selected))
-	toLock := make([]wire.OutPoint, 0, len(selected))
 	totalValue := uint64(0)
 
 	for _, coin := range selected {
@@ -424,21 +440,39 @@ func (w *wallet) SelectUtxos(ctx context.Context, amount uint64, confirmedOnly b
 			Script: hex.EncodeToString(coin.PkScript()),
 			Value:  value,
 		})
-		toLock = append(toLock, wire.OutPoint{
-			Hash:  *coin.Hash(),
-			Index: coin.Index(),
-		})
 		totalValue += value
 	}
 
-	if err := w.locker.lock(ctx, toLock...); err != nil {
-		log.Error("failed to lock utxos", err)
-		// ignore error
+	return selectedUtxos, totalValue, nil
+}
+
+// lockUtxos locks the given UTXOs so concurrent operations don't double-spend them.
+func (w *wallet) lockUtxos(ctx context.Context, utxos []application.Utxo) error {
+	toLock := make([]wire.OutPoint, 0, len(utxos))
+	for _, utxo := range utxos {
+		hash, err := chainhash.NewHashFromStr(utxo.Txid)
+		if err != nil {
+			return fmt.Errorf("failed to parse txid: %w", err)
+		}
+		toLock = append(toLock, wire.OutPoint{Hash: *hash, Index: utxo.Index})
 	}
 
-	change := totalValue - amount
+	return w.locker.lock(ctx, toLock...)
+}
 
-	return selectedUtxos, change, nil
+// unlockUtxos releases UTXOs previously locked by lockUtxos, e.g. when the tx
+// they were selected for ends up not being broadcast.
+func (w *wallet) unlockUtxos(ctx context.Context, utxos []application.Utxo) {
+	toUnlock := make([]wire.OutPoint, 0, len(utxos))
+	for _, utxo := range utxos {
+		hash, err := chainhash.NewHashFromStr(utxo.Txid)
+		if err != nil {
+			continue
+		}
+		toUnlock = append(toUnlock, wire.OutPoint{Hash: *hash, Index: utxo.Index})
+	}
+
+	w.locker.unlock(ctx, toUnlock...)
 }
 
 func (w *wallet) GetTransaction(ctx context.Context, txid string) (string, error) {
@@ -710,6 +744,20 @@ func (w *wallet) Withdraw(ctx context.Context, destinationAddress string, amount
 		}
 	}
 
+	// If signing or broadcasting fails, release the locks held on the inputs so
+	// the funds become spendable again instead of waiting for the lock expiry.
+	// (withdrawAll inputs aren't locked, so this is a no-op for that path.)
+	broadcasted := false
+	defer func() {
+		if !broadcasted {
+			outpoints := make([]wire.OutPoint, 0, len(ptx.UnsignedTx.TxIn))
+			for _, in := range ptx.UnsignedTx.TxIn {
+				outpoints = append(outpoints, in.PreviousOutPoint)
+			}
+			w.locker.unlock(ctx, outpoints...)
+		}
+	}()
+
 	psbtB64, err := ptx.B64Encode()
 	if err != nil {
 		return "", fmt.Errorf("failed to encode PSBT: %w", err)
@@ -721,7 +769,13 @@ func (w *wallet) Withdraw(ctx context.Context, destinationAddress string, amount
 		return "", fmt.Errorf("failed to sign transaction: %w", err)
 	}
 
-	return w.BroadcastTransaction(ctx, signedTx)
+	txid, err := w.BroadcastTransaction(ctx, signedTx)
+	if err != nil {
+		return "", err
+	}
+
+	broadcasted = true
+	return txid, nil
 }
 
 func (w *wallet) LoadSignerKey(ctx context.Context, prvkey *btcec.PrivateKey) error {
@@ -746,15 +800,31 @@ func (w *wallet) withdrawPartially(ctx context.Context, feeRate chainfee.SatPerK
 	// estimate fees for a typical 2-input withdraw
 	estimatedFee := w.estimateWithdrawFee(feeRate, 2, destPkScript)
 
-	selectedUtxos, _, err := w.SelectUtxos(ctx, amount+estimatedFee, false)
+	// Select with a zero min-change so selection never fails when the wallet
+	// holds just slightly more than amount+fee: any sub-dust change is folded
+	// into the fee below instead of becoming an output.
+	selectedUtxos, totalInputValue, err := w.selectCoins(ctx, amount+estimatedFee, false, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select UTXOs: %w", err)
 	}
 
-	totalInputValue := uint64(0)
-	inputs := make([]*wire.OutPoint, 0)
+	if err := w.lockUtxos(ctx, selectedUtxos); err != nil {
+		log.Error("failed to lock utxos", err)
+		// ignore error
+	}
+
+	// Release the locked UTXOs if we fail to build the tx, so they don't stay
+	// locked until the lock expiry for nothing.
+	built := false
+	defer func() {
+		if !built {
+			w.unlockUtxos(ctx, selectedUtxos)
+		}
+	}()
+
+	inputs := make([]*wire.OutPoint, 0, len(selectedUtxos))
 	outputs := make([]*wire.TxOut, 0)
-	nSequences := make([]uint32, 0)
+	nSequences := make([]uint32, 0, len(selectedUtxos))
 
 	for _, utxo := range selectedUtxos {
 		hash, err := chainhash.NewHashFromStr(utxo.Txid)
@@ -762,12 +832,16 @@ func (w *wallet) withdrawPartially(ctx context.Context, feeRate chainfee.SatPerK
 			return nil, fmt.Errorf("failed to parse txid: %w", err)
 		}
 		inputs = append(inputs, &wire.OutPoint{Hash: *hash, Index: utxo.Index})
-		totalInputValue += utxo.Value
 		nSequences = append(nSequences, wire.MaxTxInSequenceNum)
 	}
 
 	actualFee := w.estimateWithdrawFee(feeRate, len(selectedUtxos), destPkScript) // 2 outputs: destination + change
-	changeAmount := totalInputValue - amount - actualFee
+
+	surplus := totalInputValue - amount
+	changeAmount := uint64(0)
+	if surplus > actualFee {
+		changeAmount = surplus - actualFee
+	}
 
 	outputs = append(outputs, &wire.TxOut{
 		Value:    int64(amount),
@@ -822,6 +896,7 @@ func (w *wallet) withdrawPartially(ctx context.Context, feeRate chainfee.SatPerK
 		}
 	}
 
+	built = true
 	return ptx, nil
 }
 

--- a/pkg/arkd-wallet/core/application/wallet/service.go
+++ b/pkg/arkd-wallet/core/application/wallet/service.go
@@ -367,6 +367,40 @@ func (w *wallet) ListConnectorUtxos(ctx context.Context, connectorAddress string
 	return connectorUtxos, nil
 }
 
+// GetMainAccountUtxos lists the whole UTXO set of the main account, including
+// locked and unconfirmed UTXOs, each flagged with its lock status.
+func (w *wallet) GetMainAccountUtxos(ctx context.Context) ([]application.MainAccountUtxo, error) {
+	if w.keyMgr == nil {
+		return nil, ErrWalletLocked
+	}
+
+	mainAccountUtxos, err := w.Nbxplorer.GetUtxos(ctx, w.keyMgr.mainAccountDerivationScheme)
+	if err != nil {
+		return nil, err
+	}
+
+	lockedOutpoints, err := w.locker.get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	utxos := make([]application.MainAccountUtxo, 0, len(mainAccountUtxos))
+	for _, utxo := range mainAccountUtxos {
+		_, locked := lockedOutpoints[utxo.OutPoint]
+		utxos = append(utxos, application.MainAccountUtxo{
+			Txid:          utxo.OutPoint.Hash.String(),
+			Vout:          utxo.OutPoint.Index,
+			Value:         utxo.Value,
+			Script:        utxo.Script,
+			Address:       utxo.Address,
+			Confirmations: utxo.Confirmations,
+			Locked:        locked,
+		})
+	}
+
+	return utxos, nil
+}
+
 func (w *wallet) GetCurrentBlockTime(ctx context.Context) (*application.BlockTimestamp, error) {
 	status, err := w.Nbxplorer.GetBitcoinStatus(ctx)
 	if err != nil {
@@ -441,6 +475,68 @@ func (w *wallet) selectCoins(
 			Value:  value,
 		})
 		totalValue += value
+	}
+
+	return selectedUtxos, totalValue, nil
+}
+
+// selectCoinsForWithdraw selects main-account UTXOs to fund a withdrawal of
+// `amount` in a tx paying `feeRate`.
+func (w *wallet) selectCoinsForWithdraw(
+	ctx context.Context, amount uint64, feeRate chainfee.SatPerKVByte, destPkScript []byte,
+) ([]application.Utxo, uint64, error) {
+	if w.keyMgr == nil {
+		return nil, 0, ErrWalletLocked
+	}
+
+	mainAccountUtxos, err := w.Nbxplorer.GetUtxos(ctx, w.keyMgr.mainAccountDerivationScheme)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	lockedOutpoints, err := w.locker.get(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// fee(n) = base + perInput*n, derived from the weight estimator.
+	feeOneInput := w.estimateWithdrawFee(feeRate, 1, destPkScript)
+	feeTwoInputs := w.estimateWithdrawFee(feeRate, 2, destPkScript)
+	perInput := feeTwoInputs - feeOneInput
+	base := feeOneInput - perInput
+
+	availableUtxos := make([]coinset.Coin, 0, len(mainAccountUtxos))
+	for _, utxo := range mainAccountUtxos {
+		if _, isLocked := lockedOutpoints[utxo.OutPoint]; isLocked {
+			continue
+		}
+		// skip UTXOs that cost at least as much to spend as they are worth
+		if utxo.Value <= perInput {
+			continue
+		}
+		availableUtxos = append(availableUtxos, effectiveValueCoin{
+			coin:           coin{utxo},
+			effectiveValue: btcutil.Amount(utxo.Value - perInput),
+		})
+	}
+
+	coins, err := newCoinSelector(0).CoinSelect(btcutil.Amount(amount+base), availableUtxos)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	selected := coins.Coins()
+	selectedUtxos := make([]application.Utxo, 0, len(selected))
+	totalValue := uint64(0)
+	for _, c := range selected {
+		utxo := c.(effectiveValueCoin).coin.utxo
+		selectedUtxos = append(selectedUtxos, application.Utxo{
+			Txid:   utxo.OutPoint.Hash.String(),
+			Index:  utxo.OutPoint.Index,
+			Script: utxo.Script,
+			Value:  utxo.Value,
+		})
+		totalValue += utxo.Value
 	}
 
 	return selectedUtxos, totalValue, nil
@@ -797,13 +893,10 @@ func (w *wallet) Close() {
 }
 
 func (w *wallet) withdrawPartially(ctx context.Context, feeRate chainfee.SatPerKVByte, amount uint64, destPkScript []byte) (*psbt.Packet, error) {
-	// estimate fees for a typical 2-input withdraw
-	estimatedFee := w.estimateWithdrawFee(feeRate, 2, destPkScript)
-
-	// Select with a zero min-change so selection never fails when the wallet
-	// holds just slightly more than amount+fee: any sub-dust change is folded
-	// into the fee below instead of becoming an output.
-	selectedUtxos, totalInputValue, err := w.selectCoins(ctx, amount+estimatedFee, false, 0)
+	// Effective-value selection: the chosen UTXOs always cover amount + the fee
+	// for their actual input count, whatever that count is. This makes any
+	// fundable withdraw succeed without a re-selection loop.
+	selectedUtxos, totalInputValue, err := w.selectCoinsForWithdraw(ctx, amount, feeRate, destPkScript)
 	if err != nil {
 		return nil, fmt.Errorf("failed to select UTXOs: %w", err)
 	}

--- a/pkg/arkd-wallet/interface/grpc/handlers/wallet_handler.go
+++ b/pkg/arkd-wallet/interface/grpc/handlers/wallet_handler.go
@@ -231,6 +231,28 @@ func (h *walletHandler) ListConnectorUtxos(
 	return &arkwalletv1.ListConnectorUtxosResponse{Utxos: respUtxos}, nil
 }
 
+func (h *walletHandler) GetMainAccountUtxos(
+	ctx context.Context, _ *arkwalletv1.GetMainAccountUtxosRequest,
+) (*arkwalletv1.GetMainAccountUtxosResponse, error) {
+	utxos, err := h.wallet.GetMainAccountUtxos(ctx)
+	if err != nil {
+		return nil, err
+	}
+	respUtxos := make([]*arkwalletv1.WalletUtxo, 0, len(utxos))
+	for _, u := range utxos {
+		respUtxos = append(respUtxos, &arkwalletv1.WalletUtxo{
+			Txid:          u.Txid,
+			Vout:          u.Vout,
+			Value:         u.Value,
+			Script:        u.Script,
+			Address:       u.Address,
+			Confirmations: u.Confirmations,
+			Locked:        u.Locked,
+		})
+	}
+	return &arkwalletv1.GetMainAccountUtxosResponse{Utxos: respUtxos}, nil
+}
+
 func (h *walletHandler) MainAccountBalance(
 	ctx context.Context, _ *arkwalletv1.MainAccountBalanceRequest,
 ) (*arkwalletv1.MainAccountBalanceResponse, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query main-account UTXOs via new API/gRPC endpoint with detailed per-UTXO info (txid, vout, value, address/script, confirmations, locked).
  * New CLI command to fetch and print wallet UTXO details.

* **Improvements**
  * Coin selection updated to use effective-value logic accounting for input costs.
  * UTXO locking/unlocking improved with automatic unlock on transaction/build/broadcast failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->