### PR TITLE
Harden deprecated signer key handling

### DIFF
--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -6395,4 +6395,32 @@ func TestDeprecatedSignerKey(t *testing.T) {
 		_, err = dave.Settle(ctx)
 		require.ErrorContains(t, err, "is a deprecated key since")
 	})
+
+	t.Run("recover_after_cutoff", func(t *testing.T) {
+		// the other half of the design: once an old-key VTXO has expired and been swept it
+		// must still be recoverable even though its signer key is past the cutoff, because a
+		// swept VTXO no longer requires a forfeit and so skips the signer-key validation. The
+		// past-cutoff rotation from the previous subtest is still in effect here.
+		bobVtxos, _, err := bob.ListVtxos(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, bobVtxos)
+
+		// expire the batch and wait for the server to sweep bob's old-key VTXO
+		require.NoError(t, generateBlocks(50))
+		require.Eventually(t, func() bool {
+			vtxos, _, err := bob.ListVtxos(ctx)
+			if err != nil || len(vtxos) == 0 {
+				return false
+			}
+			return vtxos[0].Swept
+		}, 60*time.Second, 2*time.Second)
+
+		// recovery must succeed despite the past cutoff
+		_, err = bob.Settle(ctx, wallet.WithRecoverableVtxos())
+		require.NoError(t, err)
+
+		_, spent, err := bob.ListVtxos(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, spent)
+	})
 }

--- a/pkg/arkd-wallet/config/config.go
+++ b/pkg/arkd-wallet/config/config.go
@@ -225,6 +225,13 @@ func parseDeprecatedSignerKeys(raw string) ([]wallet.DeprecatedSignerKey, error)
 		if err != nil {
 			return nil, fmt.Errorf("invalid signer key format, must be hex: %s", keyPart)
 		}
+		// btcec.PrivKeyFromBytes silently reduces any byte length mod N, so a truncated or
+		// padded key would yield the wrong private key and strand every coin locked to it.
+		if len(buf) != 32 {
+			return nil, fmt.Errorf(
+				"invalid signer key, must be 32 bytes, got %d: %s", len(buf), keyPart,
+			)
+		}
 		key, _ := btcec.PrivKeyFromBytes(buf)
 
 		var cutoffDate int64

--- a/pkg/arkd-wallet/core/application/wallet/service.go
+++ b/pkg/arkd-wallet/core/application/wallet/service.go
@@ -662,9 +662,14 @@ func (w *wallet) SignTransaction(
 		}
 
 		if len(input.TaprootLeafScript) > 0 {
-			signingKey := w.signerKeyForLeaf(input.TaprootLeafScript[0].Script)
+			var signingKey *btcec.PrivateKey
 			if signMode == application.SignModeLiquidityProvider {
 				signingKey = w.keyMgr.forfeitPrvkey
+			} else {
+				signingKey, err = w.signerKeyForLeaf(input.TaprootLeafScript[0].Script)
+				if err != nil {
+					return "", err
+				}
 			}
 
 			tapLeaf := txscript.NewBaseTapLeaf(input.TaprootLeafScript[0].Script)
@@ -779,38 +784,59 @@ func (w *wallet) SignTransaction(
 	return ptx.B64Encode()
 }
 
-// signerKeyForLeaf returns the deprecated signer key referenced by the leaf, or the current SignerKey.
-func (w *wallet) signerKeyForLeaf(leafScript []byte) *btcec.PrivateKey {
+// signerKeyForLeaf returns the signer key the leaf commits to: a deprecated key when the leaf
+// references one, otherwise the current SignerKey. It refuses to sign (returns an error) when
+// the leaf commits to a deprecated key whose cutoff date has already passed, as a last-resort
+// guard on top of the validation arkd performs at intent registration.
+func (w *wallet) signerKeyForLeaf(leafScript []byte) (*btcec.PrivateKey, error) {
 	if len(w.DeprecatedSignerKeys) == 0 {
-		return w.SignerKey
+		return w.SignerKey, nil
 	}
 
 	closure, err := script.DecodeClosure(leafScript)
 	if err != nil {
-		return w.SignerKey
+		return w.SignerKey, nil
 	}
 
-	leafKeys := make([]*btcec.PublicKey, 0)
+	// every closure type embeds MultisigClosure, so they all expose the leaf pubkeys.
+	var leafKeys []*btcec.PublicKey
 	switch c := closure.(type) {
 	case *script.MultisigClosure:
+		leafKeys = c.PubKeys
+	case *script.CSVMultisigClosure:
 		leafKeys = c.PubKeys
 	case *script.CLTVMultisigClosure:
 		leafKeys = c.PubKeys
 	case *script.ConditionMultisigClosure:
 		leafKeys = c.PubKeys
+	case *script.ConditionCSVMultisigClosure:
+		leafKeys = c.PubKeys
 	default:
-		return nil
+		return w.SignerKey, nil
 	}
-	
+
 	for _, k := range w.DeprecatedSignerKeys {
 		want := schnorr.SerializePubKey(k.Key.PubKey())
 		for _, pubkey := range leafKeys {
-			if bytes.Equal(schnorr.SerializePubKey(pubkey), want) {
-				return k.Key
+			if !bytes.Equal(schnorr.SerializePubKey(pubkey), want) {
+				continue
 			}
+			if k.isPastCutoff(time.Now()) {
+				return nil, fmt.Errorf(
+					"refusing to sign with deprecated signer key %x: cutoff date %s has passed",
+					k.Key.PubKey().SerializeCompressed(),
+					time.Unix(k.CutoffDate, 0).UTC().Format(time.RFC3339),
+				)
+			}
+			return k.Key, nil
 		}
 	}
-	return w.SignerKey
+	return w.SignerKey, nil
+}
+
+// isPastCutoff reports whether the deprecated key's cutoff date is set and has passed.
+func (k DeprecatedSignerKey) isPastCutoff(now time.Time) bool {
+	return k.CutoffDate > 0 && now.After(time.Unix(k.CutoffDate, 0))
 }
 
 // WithdrawAll withdraws all available balance including connectors account funds

--- a/pkg/arkd-wallet/core/application/wallet/signer_keys_test.go
+++ b/pkg/arkd-wallet/core/application/wallet/signer_keys_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/script"
 	"github.com/arkade-os/arkd/pkg/arkd-wallet/core/application"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -18,10 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSignTransaction makes sure SignTransaction signs taproot script-path inputs
-// with the key referenced by the leaf, including deprecated signer keys. From the
-// wallet's point of view the cutoff date is purely informational: it always signs
-// with the deprecated key whether or not the cutoff has passed.
+// TestSignTransaction makes sure SignTransaction signs taproot script-path inputs with the
+// key referenced by the leaf, including deprecated signer keys within their cutoff, and that
+// it refuses to sign with a deprecated key whose cutoff date has already passed.
 func TestSignTransaction(t *testing.T) {
 	owner, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
@@ -37,6 +37,7 @@ func TestSignTransaction(t *testing.T) {
 		w          *wallet
 		leafSigner *btcec.PublicKey
 		wantSigner *btcec.PublicKey
+		wantErr    string
 	}{
 		{
 			name:       "sign with current key",
@@ -54,13 +55,13 @@ func TestSignTransaction(t *testing.T) {
 			wantSigner: old.PubKey(),
 		},
 		{
-			name: "sign with deprecated key where cutoff passed",
+			name: "refuse deprecated key where cutoff passed",
 			w: &wallet{WalletOptions: WalletOptions{
 				SignerKey:            current,
 				DeprecatedSignerKeys: []DeprecatedSignerKey{{Key: old, CutoffDate: now - 3600}},
 			}},
 			leafSigner: old.PubKey(),
-			wantSigner: old.PubKey(),
+			wantErr:    "cutoff date",
 		},
 	}
 
@@ -70,6 +71,10 @@ func TestSignTransaction(t *testing.T) {
 
 			signed, err := tt.w.SignTransaction(
 				context.Background(), application.SignModeSigner, b64, false, nil)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
 			require.NoError(t, err)
 
 			out, err := psbt.NewFromRawBytes(strings.NewReader(signed), true)
@@ -129,6 +134,124 @@ func leafScript(t *testing.T, owner, signer *btcec.PublicKey) []byte {
 		Type:    script.MultisigTypeChecksig,
 	}
 	s, err := closure.Script()
+	require.NoError(t, err)
+	return s
+}
+
+// TestSignerKeyForLeaf makes sure signerKeyForLeaf resolves a signing key for every closure
+// type the server may be asked to sign — not only the multisig forfeit closures — never
+// returning a nil key for a recognised closure, and refuses to sign when the matched
+// deprecated key is past its cutoff.
+func TestSignerKeyForLeaf(t *testing.T) {
+	owner, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	current, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	old, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	now := time.Now()
+	withinCutoff := []DeprecatedSignerKey{{Key: old, CutoffDate: now.Add(time.Hour).Unix()}}
+	pastCutoff := []DeprecatedSignerKey{{Key: old, CutoffDate: now.Add(-time.Hour).Unix()}}
+
+	walletWith := func(deprecated []DeprecatedSignerKey) *wallet {
+		return &wallet{WalletOptions: WalletOptions{
+			SignerKey:            current,
+			DeprecatedSignerKeys: deprecated,
+		}}
+	}
+
+	leafBuilders := []struct {
+		name  string
+		build func(t *testing.T, owner, signer *btcec.PublicKey) []byte
+	}{
+		{"multisig", leafScript},
+		{"csv multisig", csvMultisigLeaf},
+		{"cltv multisig", cltvMultisigLeaf},
+		{"condition multisig", conditionMultisigLeaf},
+		{"condition csv multisig", conditionCSVMultisigLeaf},
+	}
+
+	for _, lb := range leafBuilders {
+		t.Run(lb.name, func(t *testing.T) {
+			t.Run("current key", func(t *testing.T) {
+				leaf := lb.build(t, owner.PubKey(), current.PubKey())
+				key, err := walletWith(withinCutoff).signerKeyForLeaf(leaf)
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				want := current.PubKey().SerializeCompressed()
+				require.Equal(t, want, key.PubKey().SerializeCompressed())
+			})
+
+			t.Run("deprecated key within cutoff", func(t *testing.T) {
+				leaf := lb.build(t, owner.PubKey(), old.PubKey())
+				key, err := walletWith(withinCutoff).signerKeyForLeaf(leaf)
+				require.NoError(t, err)
+				require.NotNil(t, key)
+				want := old.PubKey().SerializeCompressed()
+				require.Equal(t, want, key.PubKey().SerializeCompressed())
+			})
+
+			t.Run("deprecated key past cutoff", func(t *testing.T) {
+				leaf := lb.build(t, owner.PubKey(), old.PubKey())
+				_, err := walletWith(pastCutoff).signerKeyForLeaf(leaf)
+				require.ErrorContains(t, err, "cutoff date")
+			})
+		})
+	}
+}
+
+func csvMultisigLeaf(t *testing.T, owner, signer *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := (&script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{owner, signer},
+			Type:    script.MultisigTypeChecksig,
+		},
+		Locktime: arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
+	}).Script()
+	require.NoError(t, err)
+	return s
+}
+
+func cltvMultisigLeaf(t *testing.T, owner, signer *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := (&script.CLTVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{owner, signer},
+			Type:    script.MultisigTypeChecksig,
+		},
+		Locktime: arklib.AbsoluteLocktime(1_700_000_000),
+	}).Script()
+	require.NoError(t, err)
+	return s
+}
+
+func conditionMultisigLeaf(t *testing.T, owner, signer *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := (&script.ConditionMultisigClosure{
+		MultisigClosure: script.MultisigClosure{
+			PubKeys: []*btcec.PublicKey{owner, signer},
+			Type:    script.MultisigTypeChecksig,
+		},
+		Condition: []byte{txscript.OP_TRUE},
+	}).Script()
+	require.NoError(t, err)
+	return s
+}
+
+func conditionCSVMultisigLeaf(t *testing.T, owner, signer *btcec.PublicKey) []byte {
+	t.Helper()
+	s, err := (&script.ConditionCSVMultisigClosure{
+		CSVMultisigClosure: script.CSVMultisigClosure{
+			MultisigClosure: script.MultisigClosure{
+				PubKeys: []*btcec.PublicKey{owner, signer},
+				Type:    script.MultisigTypeChecksig,
+			},
+			Locktime: arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
+		},
+		Condition: []byte{txscript.OP_TRUE},
+	}).Script()
 	require.NoError(t, err)
 	return s
 }


### PR DESCRIPTION
Follow-up to #1097, targeting its branch (`feat/deprecated-keys`). Addresses the actionable review findings from that PR; the broad output-taptree-reveal enforcement is intentionally left for a later PR.

## Changes

- **`signerKeyForLeaf` nil-deref (latent crash).** The two exit closures (`CSVMultisigClosure`, `ConditionCSVMultisigClosure`) fell through to `default: return nil`, contradicting the function's doc contract and the pre-change behaviour. Under `SignModeSigner` the caller dereferences the returned key, so any future signer-mode signing of a CSV-based closure would panic — and with deprecated keys configured it returned `nil` even for the current signer key. Now handles all five closure types (they all embed `MultisigClosure`) and defaults to the current `SignerKey`.
- **Cutoff defense-in-depth.** The wallet now refuses to sign with a deprecated key whose cutoff has passed, rather than relying solely on arkd's intent-registration validation. Recovery is unaffected: swept/expired vtxos don't require a forfeit, so the deprecated key is never asked to sign them.
- **Deprecated key length validation.** Reject keys that aren't 32 bytes at parse time instead of letting `btcec.PrivKeyFromBytes` silently reduce a truncated/padded value into the wrong key (which would strand every coin locked to the intended key).
- **Recovery e2e.** Asserts that a swept old-key vtxo is still recoverable after its cutoff has passed — the `RequiresForfeit() == false` path that bypasses signer-key validation.

## Test plan

- `go test ./pkg/arkd-wallet/...` — new `TestSignerKeyForLeaf` covers all five closure types for current/deprecated keys plus past-cutoff refusal; `TestSignTransaction` updated to expect refusal once the cutoff has passed.
- e2e `TestDeprecatedSignerKey/recover_after_cutoff`.
