### PR TITLE
client-lib: Handle sending digest header

### DIFF
--- a/pkg/client-lib/client/grpc/client.go
+++ b/pkg/client-lib/client/grpc/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/client"
 	"github.com/arkade-os/arkd/pkg/client-lib/internal/utils"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
+	"github.com/arkade-os/arkd/pkg/errors"
 	"github.com/btcsuite/btcd/wire"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -29,9 +30,12 @@ var testDialOptions []grpc.DialOption
 
 type grpcClient struct {
 	conn       *grpc.ClientConn
-	connMu     *sync.RWMutex
+	connMu     *sync.Mutex
+	svc        arkv1.ArkServiceClient
 	listenerMu *sync.RWMutex
 	listenerId string
+	infoMu     *sync.RWMutex
+	digest     string
 }
 
 func NewClient(serverUrl string) (client.Client, error) {
@@ -51,6 +55,12 @@ func NewClient(serverUrl string) (client.Client, error) {
 		serverUrl = fmt.Sprintf("%s:%d", serverUrl, port)
 	}
 
+	client := &grpcClient{
+		connMu:     &sync.Mutex{},
+		listenerMu: &sync.RWMutex{},
+		infoMu:     &sync.RWMutex{},
+	}
+
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDisableServiceConfig(),
@@ -65,10 +75,10 @@ func NewClient(serverUrl string) (client.Client, error) {
 			MinConnectTimeout: 3 * time.Second,
 		}),
 		grpc.WithChainUnaryInterceptor(
-			unaryVersionInterceptor(),
+			unaryVersionInterceptor(), unaryDigestInterceptor(client.getDigest),
 		),
 		grpc.WithChainStreamInterceptor(
-			streamVersionInterceptor(),
+			streamVersionInterceptor(), streamDigestInterceptor(client.getDigest),
 		),
 	}
 	options = append(options, testDialOptions...)
@@ -77,20 +87,15 @@ func NewClient(serverUrl string) (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	client := &grpcClient{
-		conn:       conn,
-		connMu:     &sync.RWMutex{},
-		listenerMu: &sync.RWMutex{},
-		listenerId: "",
-	}
+	client.conn = conn
+	client.svc = arkv1.NewArkServiceClient(conn)
 
 	return client, nil
 }
 
 func (a *grpcClient) GetInfo(ctx context.Context) (*client.Info, error) {
 	req := &arkv1.GetInfoRequest{}
-	resp, err := a.svc().GetInfo(ctx, req)
+	resp, err := a.svc.GetInfo(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +127,13 @@ func (a *grpcClient) GetInfo(ctx context.Context) (*client.Info, error) {
 			CutoffDate: s.GetCutoffDate(),
 		})
 	}
+	// Cache the latest digest under the lock. This must NOT wrap the RPC above:
+	// the digest interceptor reads a.digest under the same mutex, so holding it
+	// across the call would self-deadlock the RWMutex.
+	a.infoMu.Lock()
+	a.digest = resp.GetDigest()
+	a.infoMu.Unlock()
+
 	return &client.Info{
 		SignerPubKey:              resp.GetSignerPubkey(),
 		ForfeitPubKey:             resp.GetForfeitPubkey(),
@@ -151,10 +163,7 @@ func (a *grpcClient) GetInfo(ctx context.Context) (*client.Info, error) {
 	}, nil
 }
 
-func (a *grpcClient) RegisterIntent(
-	ctx context.Context,
-	proof, message string,
-) (string, error) {
+func (a *grpcClient) RegisterIntent(ctx context.Context, proof, message string) (string, error) {
 	req := &arkv1.RegisterIntentRequest{
 		Intent: &arkv1.Intent{
 			Message: message,
@@ -162,11 +171,19 @@ func (a *grpcClient) RegisterIntent(
 		},
 	}
 
-	resp, err := a.svc().RegisterIntent(ctx, req)
-	if err != nil {
-		return "", err
+	for {
+		resp, err := a.svc.RegisterIntent(ctx, req)
+		if err != nil {
+			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+					return "", err
+				}
+				continue
+			}
+			return "", err
+		}
+		return resp.GetIntentId(), nil
 	}
-	return resp.GetIntentId(), nil
 }
 
 func (a *grpcClient) DeleteIntent(ctx context.Context, proof, message string) error {
@@ -176,11 +193,19 @@ func (a *grpcClient) DeleteIntent(ctx context.Context, proof, message string) er
 			Proof:   proof,
 		},
 	}
-	_, err := a.svc().DeleteIntent(ctx, req)
-	if err != nil {
-		return err
+	for {
+		_, err := a.svc.DeleteIntent(ctx, req)
+		if err != nil {
+			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+		return nil
 	}
-	return nil
 }
 
 func (a *grpcClient) EstimateIntentFee(ctx context.Context, proof, message string) (int64, error) {
@@ -190,18 +215,26 @@ func (a *grpcClient) EstimateIntentFee(ctx context.Context, proof, message strin
 			Proof:   proof,
 		},
 	}
-	resp, err := a.svc().EstimateIntentFee(ctx, req)
-	if err != nil {
-		return -1, err
+	for {
+		resp, err := a.svc.EstimateIntentFee(ctx, req)
+		if err != nil {
+			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+					return -1, err
+				}
+				continue
+			}
+			return -1, err
+		}
+		return resp.GetFee(), nil
 	}
-	return resp.GetFee(), nil
 }
 
 func (a *grpcClient) ConfirmRegistration(ctx context.Context, intentID string) error {
 	req := &arkv1.ConfirmRegistrationRequest{
 		IntentId: intentID,
 	}
-	_, err := a.svc().ConfirmRegistration(ctx, req)
+	_, err := a.svc.ConfirmRegistration(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -217,7 +250,7 @@ func (a *grpcClient) SubmitTreeNonces(
 		TreeNonces: nonces.ToMap(),
 	}
 
-	if _, err := a.svc().SubmitTreeNonces(ctx, req); err != nil {
+	if _, err := a.svc.SubmitTreeNonces(ctx, req); err != nil {
 		return err
 	}
 
@@ -238,7 +271,7 @@ func (a *grpcClient) SubmitTreeSignatures(
 		TreeSignatures: sigs,
 	}
 
-	if _, err := a.svc().SubmitTreeSignatures(ctx, req); err != nil {
+	if _, err := a.svc.SubmitTreeSignatures(ctx, req); err != nil {
 		return err
 	}
 
@@ -253,7 +286,7 @@ func (a *grpcClient) SubmitSignedForfeitTxs(
 		SignedCommitmentTx: signedCommitmentTx,
 	}
 
-	_, err := a.svc().SubmitSignedForfeitTxs(ctx, req)
+	_, err := a.svc.SubmitSignedForfeitTxs(ctx, req)
 	if err != nil {
 		return err
 	}
@@ -271,10 +304,10 @@ func (a *grpcClient) GetEventStream(
 		client.BatchEventChannel,
 	]{
 		Connect: func(ctx context.Context) (arkv1.ArkService_GetEventStreamClient, error) {
-			return a.svc().GetEventStream(ctx, req)
+			return a.svc.GetEventStream(ctx, req)
 		},
 		Reconnect: func(ctx context.Context) (string, arkv1.ArkService_GetEventStreamClient, error) {
-			stream, err := a.svc().GetEventStream(ctx, req)
+			stream, err := a.svc.GetEventStream(ctx, req)
 			return "", stream, err
 		},
 		Recv: func(stream arkv1.ArkService_GetEventStreamClient) (**arkv1.GetEventStreamResponse, error) {
@@ -335,12 +368,20 @@ func (a *grpcClient) SubmitTx(
 		CheckpointTxs: checkpointTxs,
 	}
 
-	resp, err := a.svc().SubmitTx(ctx, req)
-	if err != nil {
-		return "", "", nil, err
-	}
+	for {
+		resp, err := a.svc.SubmitTx(ctx, req)
+		if err != nil {
+			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+					return "", "", nil, err
+				}
+				continue
+			}
+			return "", "", nil, err
+		}
 
-	return resp.GetArkTxid(), resp.GetFinalArkTx(), resp.GetSignedCheckpointTxs(), nil
+		return resp.GetArkTxid(), resp.GetFinalArkTx(), resp.GetSignedCheckpointTxs(), nil
+	}
 }
 
 func (a *grpcClient) FinalizeTx(
@@ -351,11 +392,19 @@ func (a *grpcClient) FinalizeTx(
 		FinalCheckpointTxs: finalCheckpointTxs,
 	}
 
-	_, err := a.svc().FinalizeTx(ctx, req)
-	if err != nil {
-		return err
+	for {
+		_, err := a.svc.FinalizeTx(ctx, req)
+		if err != nil {
+			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+		return nil
 	}
-	return nil
 }
 
 func (a *grpcClient) GetPendingTx(
@@ -371,20 +420,28 @@ func (a *grpcClient) GetPendingTx(
 		},
 	}
 
-	resp, err := a.svc().GetPendingTx(ctx, req)
-	if err != nil {
-		return nil, err
-	}
+	for {
+		resp, err := a.svc.GetPendingTx(ctx, req)
+		if err != nil {
+			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
 
-	pendingTxs := make([]client.AcceptedOffchainTx, 0, len(resp.GetPendingTxs()))
-	for _, tx := range resp.GetPendingTxs() {
-		pendingTxs = append(pendingTxs, client.AcceptedOffchainTx{
-			Txid:                tx.GetArkTxid(),
-			FinalArkTx:          tx.GetFinalArkTx(),
-			SignedCheckpointTxs: tx.GetSignedCheckpointTxs(),
-		})
+		pendingTxs := make([]client.AcceptedOffchainTx, 0, len(resp.GetPendingTxs()))
+		for _, tx := range resp.GetPendingTxs() {
+			pendingTxs = append(pendingTxs, client.AcceptedOffchainTx{
+				Txid:                tx.GetArkTxid(),
+				FinalArkTx:          tx.GetFinalArkTx(),
+				SignedCheckpointTxs: tx.GetSignedCheckpointTxs(),
+			})
+		}
+		return pendingTxs, nil
 	}
-	return pendingTxs, nil
 }
 
 func (c *grpcClient) GetTransactionsStream(
@@ -398,12 +455,24 @@ func (c *grpcClient) GetTransactionsStream(
 		client.TransactionEvent,
 	]{
 		Connect: func(ctx context.Context) (arkv1.ArkService_GetTransactionsStreamClient, error) {
-			return c.svc().GetTransactionsStream(ctx, req)
+			for {
+				stream, err := c.svc.GetTransactionsStream(ctx, req)
+				if err != nil {
+					if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
+						if _, infoErr := c.GetInfo(ctx); infoErr != nil {
+							return nil, err
+						}
+						continue
+					}
+					return nil, err
+				}
+				return stream, nil
+			}
 		},
 		Reconnect: func(
 			ctx context.Context,
 		) (string, arkv1.ArkService_GetTransactionsStreamClient, error) {
-			stream, err := c.svc().GetTransactionsStream(ctx, req)
+			stream, err := c.svc.GetTransactionsStream(ctx, req)
 			return "", stream, err
 		},
 		Recv: func(
@@ -529,7 +598,7 @@ func (c *grpcClient) ModifyStreamTopics(
 			},
 		},
 	}
-	updateRes, err := c.svc().UpdateStreamTopics(ctx, req)
+	updateRes, err := c.svc.UpdateStreamTopics(ctx, req)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -553,7 +622,7 @@ func (c *grpcClient) OverwriteStreamTopics(
 			},
 		},
 	}
-	updateRes, err := c.svc().UpdateStreamTopics(ctx, req)
+	updateRes, err := c.svc.UpdateStreamTopics(ctx, req)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -568,13 +637,6 @@ func (c *grpcClient) Close() {
 	c.conn.Close()
 }
 
-func (a *grpcClient) svc() arkv1.ArkServiceClient {
-	a.connMu.RLock()
-	defer a.connMu.RUnlock()
-
-	return arkv1.NewArkServiceClient(a.conn)
-}
-
 func (a *grpcClient) getListenerID() string {
 	a.listenerMu.RLock()
 	defer a.listenerMu.RUnlock()
@@ -587,6 +649,12 @@ func (a *grpcClient) setListenerID(id string) {
 	defer a.listenerMu.Unlock()
 
 	a.listenerId = id
+}
+
+func (a *grpcClient) getDigest() string {
+	a.infoMu.RLock()
+	defer a.infoMu.RUnlock()
+	return a.digest
 }
 
 func toClientStreamConnectionState(

--- a/pkg/client-lib/client/grpc/client.go
+++ b/pkg/client-lib/client/grpc/client.go
@@ -14,7 +14,6 @@ import (
 	"github.com/arkade-os/arkd/pkg/client-lib/client"
 	"github.com/arkade-os/arkd/pkg/client-lib/internal/utils"
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
-	"github.com/arkade-os/arkd/pkg/errors"
 	"github.com/btcsuite/btcd/wire"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
@@ -171,19 +170,13 @@ func (a *grpcClient) RegisterIntent(ctx context.Context, proof, message string) 
 		},
 	}
 
-	for {
-		resp, err := a.svc.RegisterIntent(ctx, req)
-		if err != nil {
-			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
-					return "", err
-				}
-				continue
-			}
-			return "", err
-		}
-		return resp.GetIntentId(), nil
+	resp, err := withDigestRefresh(a, ctx, func() (*arkv1.RegisterIntentResponse, error) {
+		return a.svc.RegisterIntent(ctx, req)
+	})
+	if err != nil {
+		return "", err
 	}
+	return resp.GetIntentId(), nil
 }
 
 func (a *grpcClient) DeleteIntent(ctx context.Context, proof, message string) error {
@@ -193,19 +186,10 @@ func (a *grpcClient) DeleteIntent(ctx context.Context, proof, message string) er
 			Proof:   proof,
 		},
 	}
-	for {
-		_, err := a.svc.DeleteIntent(ctx, req)
-		if err != nil {
-			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
-					return err
-				}
-				continue
-			}
-			return err
-		}
-		return nil
-	}
+	_, err := withDigestRefresh(a, ctx, func() (*arkv1.DeleteIntentResponse, error) {
+		return a.svc.DeleteIntent(ctx, req)
+	})
+	return err
 }
 
 func (a *grpcClient) EstimateIntentFee(ctx context.Context, proof, message string) (int64, error) {
@@ -215,19 +199,13 @@ func (a *grpcClient) EstimateIntentFee(ctx context.Context, proof, message strin
 			Proof:   proof,
 		},
 	}
-	for {
-		resp, err := a.svc.EstimateIntentFee(ctx, req)
-		if err != nil {
-			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
-					return -1, err
-				}
-				continue
-			}
-			return -1, err
-		}
-		return resp.GetFee(), nil
+	resp, err := withDigestRefresh(a, ctx, func() (*arkv1.EstimateIntentFeeResponse, error) {
+		return a.svc.EstimateIntentFee(ctx, req)
+	})
+	if err != nil {
+		return -1, err
 	}
+	return resp.GetFee(), nil
 }
 
 func (a *grpcClient) ConfirmRegistration(ctx context.Context, intentID string) error {
@@ -304,7 +282,9 @@ func (a *grpcClient) GetEventStream(
 		client.BatchEventChannel,
 	]{
 		Connect: func(ctx context.Context) (arkv1.ArkService_GetEventStreamClient, error) {
-			return a.svc.GetEventStream(ctx, req)
+			return withDigestRefresh(a, ctx, func() (arkv1.ArkService_GetEventStreamClient, error) {
+				return a.svc.GetEventStream(ctx, req)
+			})
 		},
 		Reconnect: func(ctx context.Context) (string, arkv1.ArkService_GetEventStreamClient, error) {
 			stream, err := a.svc.GetEventStream(ctx, req)
@@ -368,20 +348,13 @@ func (a *grpcClient) SubmitTx(
 		CheckpointTxs: checkpointTxs,
 	}
 
-	for {
-		resp, err := a.svc.SubmitTx(ctx, req)
-		if err != nil {
-			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
-					return "", "", nil, err
-				}
-				continue
-			}
-			return "", "", nil, err
-		}
-
-		return resp.GetArkTxid(), resp.GetFinalArkTx(), resp.GetSignedCheckpointTxs(), nil
+	resp, err := withDigestRefresh(a, ctx, func() (*arkv1.SubmitTxResponse, error) {
+		return a.svc.SubmitTx(ctx, req)
+	})
+	if err != nil {
+		return "", "", nil, err
 	}
+	return resp.GetArkTxid(), resp.GetFinalArkTx(), resp.GetSignedCheckpointTxs(), nil
 }
 
 func (a *grpcClient) FinalizeTx(
@@ -392,19 +365,10 @@ func (a *grpcClient) FinalizeTx(
 		FinalCheckpointTxs: finalCheckpointTxs,
 	}
 
-	for {
-		_, err := a.svc.FinalizeTx(ctx, req)
-		if err != nil {
-			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
-					return err
-				}
-				continue
-			}
-			return err
-		}
-		return nil
-	}
+	_, err := withDigestRefresh(a, ctx, func() (*arkv1.FinalizeTxResponse, error) {
+		return a.svc.FinalizeTx(ctx, req)
+	})
+	return err
 }
 
 func (a *grpcClient) GetPendingTx(
@@ -420,28 +384,22 @@ func (a *grpcClient) GetPendingTx(
 		},
 	}
 
-	for {
-		resp, err := a.svc.GetPendingTx(ctx, req)
-		if err != nil {
-			if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-				if _, infoErr := a.GetInfo(ctx); infoErr != nil {
-					return nil, err
-				}
-				continue
-			}
-			return nil, err
-		}
-
-		pendingTxs := make([]client.AcceptedOffchainTx, 0, len(resp.GetPendingTxs()))
-		for _, tx := range resp.GetPendingTxs() {
-			pendingTxs = append(pendingTxs, client.AcceptedOffchainTx{
-				Txid:                tx.GetArkTxid(),
-				FinalArkTx:          tx.GetFinalArkTx(),
-				SignedCheckpointTxs: tx.GetSignedCheckpointTxs(),
-			})
-		}
-		return pendingTxs, nil
+	resp, err := withDigestRefresh(a, ctx, func() (*arkv1.GetPendingTxResponse, error) {
+		return a.svc.GetPendingTx(ctx, req)
+	})
+	if err != nil {
+		return nil, err
 	}
+
+	pendingTxs := make([]client.AcceptedOffchainTx, 0, len(resp.GetPendingTxs()))
+	for _, tx := range resp.GetPendingTxs() {
+		pendingTxs = append(pendingTxs, client.AcceptedOffchainTx{
+			Txid:                tx.GetArkTxid(),
+			FinalArkTx:          tx.GetFinalArkTx(),
+			SignedCheckpointTxs: tx.GetSignedCheckpointTxs(),
+		})
+	}
+	return pendingTxs, nil
 }
 
 func (c *grpcClient) GetTransactionsStream(
@@ -455,19 +413,9 @@ func (c *grpcClient) GetTransactionsStream(
 		client.TransactionEvent,
 	]{
 		Connect: func(ctx context.Context) (arkv1.ArkService_GetTransactionsStreamClient, error) {
-			for {
-				stream, err := c.svc.GetTransactionsStream(ctx, req)
-				if err != nil {
-					if strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name) {
-						if _, infoErr := c.GetInfo(ctx); infoErr != nil {
-							return nil, err
-						}
-						continue
-					}
-					return nil, err
-				}
-				return stream, nil
-			}
+			return withDigestRefresh(c, ctx, func() (arkv1.ArkService_GetTransactionsStreamClient, error) {
+				return c.svc.GetTransactionsStream(ctx, req)
+			})
 		},
 		Reconnect: func(
 			ctx context.Context,

--- a/pkg/client-lib/client/grpc/digest_header.go
+++ b/pkg/client-lib/client/grpc/digest_header.go
@@ -1,0 +1,46 @@
+package grpcclient
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	// digestHeader is the gRPC metadata key carrying the latest digest fetched from GetInfo.
+	// If outdated, the client receives DIGEST_MISMATCH error and so it can fetch the new config
+	// params, update the header and try again.
+	digestHeader = "x-digest"
+)
+
+// unaryDigestInterceptor returns a gRPC unary client interceptor that sets digestHeader=digest to
+// the outgoing metadata of every unary RPC.
+func unaryDigestInterceptor(getDigest func() string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context, method string, req, reply interface{},
+		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		md = md.Copy()
+		md.Set(digestHeader, getDigest())
+		ctx = metadata.NewOutgoingContext(ctx, md)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// streamVersionInterceptor returns a gRPC stream client interceptor that sets dogestHeader=version
+// to the outgoing metadata of every streaming RPC, including reconnecting streams dispatched
+// through the same connection.
+func streamDigestInterceptor(getDigest func() string) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
+		method string, streamer grpc.Streamer, opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		md, _ := metadata.FromOutgoingContext(ctx)
+		md = md.Copy()
+		md.Set(digestHeader, getDigest())
+		ctx = metadata.NewOutgoingContext(ctx, md)
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}

--- a/pkg/client-lib/client/grpc/digest_header.go
+++ b/pkg/client-lib/client/grpc/digest_header.go
@@ -2,7 +2,9 @@ package grpcclient
 
 import (
 	"context"
+	"strings"
 
+	"github.com/arkade-os/arkd/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -43,4 +45,32 @@ func streamDigestInterceptor(getDigest func() string) grpc.StreamClientIntercept
 		ctx = metadata.NewOutgoingContext(ctx, md)
 		return streamer(ctx, desc, cc, method, opts...)
 	}
+}
+
+// isDigestMismatch reports whether err is the server's DIGEST_MISMATCH error.
+//
+// TODO: decode the gRPC status details (arkv1.ErrorDetails) instead of matching
+// the error message, once that path works end to end. Until then this matches the
+// structured error's name in the message.
+func isDigestMismatch(err error) bool {
+	return err != nil && strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name)
+}
+
+// withDigestRefresh runs call and, if it fails with the server's DIGEST_MISMATCH
+// error (the client's cached digest is stale because the server's config
+// changed), refreshes the digest via GetInfo — which is exempt from the digest
+// guard — and retries once. A persisting mismatch, or a GetInfo failure, returns
+// the original error. At worst the call runs twice with a GetInfo in between.
+func withDigestRefresh[T any](
+	a *grpcClient, ctx context.Context, call func() (T, error),
+) (T, error) {
+	res, err := call()
+	if !isDigestMismatch(err) {
+		return res, err
+	}
+	if _, infoErr := a.GetInfo(ctx); infoErr != nil {
+		var zero T
+		return zero, err
+	}
+	return call()
 }

--- a/pkg/client-lib/client/grpc/reconnect_test.go
+++ b/pkg/client-lib/client/grpc/reconnect_test.go
@@ -76,8 +76,10 @@ func TestGetTransactionsStreamEmitsConnectionLifecycleEvents(t *testing.T) {
 
 	c := &grpcClient{
 		conn:       conn,
-		connMu:     &sync.RWMutex{},
+		svc:        arkv1.NewArkServiceClient(conn),
+		connMu:     &sync.Mutex{},
 		listenerMu: &sync.RWMutex{},
+		infoMu:     &sync.RWMutex{},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
@@ -157,8 +159,10 @@ func TestGetTransactionsStreamReconnectsAfterServerRestart(t *testing.T) {
 
 	c := &grpcClient{
 		conn:       conn,
-		connMu:     &sync.RWMutex{},
+		svc:        arkv1.NewArkServiceClient(conn),
+		connMu:     &sync.Mutex{},
 		listenerMu: &sync.RWMutex{},
+		infoMu:     &sync.RWMutex{},
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/pkg/client-lib/client/grpc/version_header.go
+++ b/pkg/client-lib/client/grpc/version_header.go
@@ -8,21 +8,16 @@ import (
 )
 
 const (
-	// buildVersionHeader is the gRPC metadata key carrying the client build
-	// version. It must match the key the arkd server reads via md.Get on the
-	// version interceptor (internal/interface/grpc/interceptors/version.go).
+	// buildVersionHeader is the gRPC metadata key carrying the client build version.
+	// It must match the key the arkd server reads via md.Get on the version interceptor
+	// (internal/interface/grpc/interceptors/version.go).
 	// gRPC normalises all metadata keys to lowercase.
 	buildVersionHeader = "x-build-version"
 	buildVersion       = "0.9.9"
 )
 
-// unaryVersionInterceptor returns a gRPC unary client interceptor that appends
+// unaryVersionInterceptor returns a gRPC unary client interceptor that sets
 // buildVersionHeader=buildVersion to the outgoing metadata of every unary RPC.
-// version is captured once in the closure at dial time, so there is no
-// per-call lookup cost beyond the metadata append.
-//
-// AppendToOutgoingContext (not NewOutgoingContext) is used so that any metadata already set by a
-// caller above this interceptor (e.g. auth tokens) is preserved rather than overwritten.
 func unaryVersionInterceptor() grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context, method string, req, reply interface{},
@@ -36,13 +31,9 @@ func unaryVersionInterceptor() grpc.UnaryClientInterceptor {
 	}
 }
 
-// streamVersionInterceptor returns a gRPC stream client interceptor that appends
+// streamVersionInterceptor returns a gRPC stream client interceptor that sets
 // buildVersionHeader=version to the outgoing metadata of every streaming RPC, including
-// reconnecting streams dispatched through the same connection. version is captured once in the
-// closure at dial time.
-//
-// As with the unary interceptor, AppendToOutgoingContext preserves any caller-provided outgoing
-// metadata.
+// reconnecting streams dispatched through the same connection.
 func streamVersionInterceptor() grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,

--- a/pkg/client-lib/go.mod
+++ b/pkg/client-lib/go.mod
@@ -13,6 +13,7 @@ replace github.com/btcsuite/btcd/btcec/v2 => github.com/btcsuite/btcd/btcec/v2 v
 require (
 	github.com/arkade-os/arkd/api-spec v0.0.0-00010101000000-000000000000
 	github.com/arkade-os/arkd/pkg/ark-lib v0.0.0-00010101000000-000000000000
+	github.com/arkade-os/arkd/pkg/errors v0.0.0-00010101000000-000000000000
 	github.com/btcsuite/btcd v0.24.3-0.20240921052913-67b8efd3ba53
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.5
@@ -33,7 +34,6 @@ require (
 	dario.cat/mergo v1.0.1 // indirect
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
-	github.com/arkade-os/arkd/pkg/errors v0.0.0-00010101000000-000000000000 // indirect
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f // indirect
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.3.4 // indirect
 	github.com/btcsuite/btcwallet/wallet/txrules v1.2.1 // indirect


### PR DESCRIPTION
Make grpc client fetch, cache and send digest header + handle DIGEST_MISMATCH api error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic digest-aware retry/refresh for gRPC calls so requests encountering stale-digest errors are retried after a refresh.

* **Tests**
  * Updated gRPC client reconnection tests to reflect enhanced client initialization and lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->