### PR TITLE
fix:  convert guard errors to gRPC status before they reach the client

### DIFF
--- a/internal/interface/grpc/interceptors/digest_test.go
+++ b/internal/interface/grpc/interceptors/digest_test.go
@@ -5,14 +5,10 @@ import (
 	"errors"
 	"testing"
 
-	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
 	arkerrors "github.com/arkade-os/arkd/pkg/errors"
-	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 // guardedMethod is an ArkService method that is NOT digest-exempt, used to
@@ -239,36 +235,6 @@ func assertDigestCompat(t *testing.T, tc digestCompatCase, called bool, err erro
 	require.Equal(t, tc.wantExpected, meta["expected_digest"])
 	require.Equal(t, tc.wantGot, meta["got_digest"])
 	require.Contains(t, err.Error(), "invalid digest header")
-}
-
-// TestDigestMismatchReachesClient checks the client receives a proper status with details, not a bare Unknown. Chain mirrors UnaryInterceptor and must stay in sync.
-func TestDigestMismatchReachesClient(t *testing.T) {
-	chain := middleware.ChainUnaryServer(
-		unaryPanicRecoveryInterceptor(),
-		errorConverter,
-		unaryLogger,
-		unaryDigestHandler(staticDigest("server-digest", true)),
-	)
-
-	_, err := chain(
-		ctxWithDigest("stale-digest"),
-		nil,
-		&grpc.UnaryServerInfo{FullMethod: guardedMethod},
-		func(ctx context.Context, req any) (any, error) { return "ok", nil },
-	)
-	require.Error(t, err)
-
-	st := status.Convert(err)
-	require.Equal(t, codes.FailedPrecondition, st.Code())
-
-	details := st.Details()
-	require.NotEmpty(t, details, "client should receive structured error details")
-
-	errDetails, ok := details[0].(*arkv1.ErrorDetails)
-	require.True(t, ok)
-	require.Equal(t, arkerrors.DIGEST_MISMATCH.Name, errDetails.GetName())
-	require.Equal(t, "server-digest", errDetails.GetMetadata()["expected_digest"])
-	require.Equal(t, "stale-digest", errDetails.GetMetadata()["got_digest"])
 }
 
 // runUnaryDigest runs the unary digest interceptor and reports whether the

--- a/internal/interface/grpc/interceptors/digest_test.go
+++ b/internal/interface/grpc/interceptors/digest_test.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 	"testing"
 
+	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
 	arkerrors "github.com/arkade-os/arkd/pkg/errors"
+	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // guardedMethod is an ArkService method that is NOT digest-exempt, used to
@@ -235,6 +239,36 @@ func assertDigestCompat(t *testing.T, tc digestCompatCase, called bool, err erro
 	require.Equal(t, tc.wantExpected, meta["expected_digest"])
 	require.Equal(t, tc.wantGot, meta["got_digest"])
 	require.Contains(t, err.Error(), "invalid digest header")
+}
+
+// TestDigestMismatchReachesClient checks the client receives a proper status with details, not a bare Unknown. Chain mirrors UnaryInterceptor and must stay in sync.
+func TestDigestMismatchReachesClient(t *testing.T) {
+	chain := middleware.ChainUnaryServer(
+		unaryPanicRecoveryInterceptor(),
+		errorConverter,
+		unaryLogger,
+		unaryDigestHandler(staticDigest("server-digest", true)),
+	)
+
+	_, err := chain(
+		ctxWithDigest("stale-digest"),
+		nil,
+		&grpc.UnaryServerInfo{FullMethod: guardedMethod},
+		func(ctx context.Context, req any) (any, error) { return "ok", nil },
+	)
+	require.Error(t, err)
+
+	st := status.Convert(err)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	details := st.Details()
+	require.NotEmpty(t, details, "client should receive structured error details")
+
+	errDetails, ok := details[0].(*arkv1.ErrorDetails)
+	require.True(t, ok)
+	require.Equal(t, arkerrors.DIGEST_MISMATCH.Name, errDetails.GetName())
+	require.Equal(t, "server-digest", errDetails.GetMetadata()["expected_digest"])
+	require.Equal(t, "stale-digest", errDetails.GetMetadata()["got_digest"])
 }
 
 // runUnaryDigest runs the unary digest interceptor and reports whether the

--- a/internal/interface/grpc/interceptors/error_converter.go
+++ b/internal/interface/grpc/interceptors/error_converter.go
@@ -49,3 +49,16 @@ func errorConverter(
 	}
 	return resp, err
 }
+
+func streamErrorConverter(
+	srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
+) error {
+	err := handler(srv, ss)
+	if err != nil {
+		var structuredErr arkerrors.Error
+		if errors.As(err, &structuredErr) {
+			return gRPCError{structuredErr}
+		}
+	}
+	return err
+}

--- a/internal/interface/grpc/interceptors/interceptor.go
+++ b/internal/interface/grpc/interceptors/interceptor.go
@@ -29,6 +29,7 @@ func StreamInterceptor(
 ) grpc.ServerOption {
 	return grpc.StreamInterceptor(middleware.ChainStreamServer(
 		streamPanicRecoveryInterceptor(),
+		streamErrorConverter,
 		streamLogger,
 		streamVersionCompatHandler(getVersionGuard),
 		streamDigestHandler(getDigest),

--- a/internal/interface/grpc/interceptors/interceptor.go
+++ b/internal/interface/grpc/interceptors/interceptor.go
@@ -13,12 +13,12 @@ func UnaryInterceptor(
 ) grpc.ServerOption {
 	return grpc.UnaryInterceptor(middleware.ChainUnaryServer(
 		unaryPanicRecoveryInterceptor(),
+		errorConverter,
 		unaryLogger,
 		unaryVersionCompatHandler(getVersionGuard),
 		unaryDigestHandler(getDigest),
 		unaryMacaroonAuthHandler(svc),
 		unaryReadinessHandler(readiness),
-		errorConverter,
 	))
 }
 

--- a/internal/interface/grpc/interceptors/interceptor_test.go
+++ b/internal/interface/grpc/interceptors/interceptor_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// TestDigestMismatchReachesClient checks the client receives a proper status with details, not a bare Unknown. Chain mirrors UnaryInterceptor and must stay in sync.
+// TestDigestMismatchReachesClient checks the client receives a proper status with details
 func TestDigestMismatchReachesClient(t *testing.T) {
 	chain := middleware.ChainUnaryServer(
 		unaryPanicRecoveryInterceptor(),
@@ -43,7 +43,7 @@ func TestDigestMismatchReachesClient(t *testing.T) {
 	require.Equal(t, "stale-digest", errDetails.GetMetadata()["got_digest"])
 }
 
-// TestStreamDigestMismatchReachesClient is the stream counterpart: the stream chain has no converter by default, so streamErrorConverter must be wired in. Chain mirrors StreamInterceptor and must stay in sync.
+// TestStreamDigestMismatchReachesClient is the stream counterpart
 func TestStreamDigestMismatchReachesClient(t *testing.T) {
 	chain := middleware.ChainStreamServer(
 		streamPanicRecoveryInterceptor(),

--- a/internal/interface/grpc/interceptors/interceptor_test.go
+++ b/internal/interface/grpc/interceptors/interceptor_test.go
@@ -42,3 +42,33 @@ func TestDigestMismatchReachesClient(t *testing.T) {
 	require.Equal(t, "server-digest", errDetails.GetMetadata()["expected_digest"])
 	require.Equal(t, "stale-digest", errDetails.GetMetadata()["got_digest"])
 }
+
+// TestStreamDigestMismatchReachesClient is the stream counterpart: the stream chain has no converter by default, so streamErrorConverter must be wired in. Chain mirrors StreamInterceptor and must stay in sync.
+func TestStreamDigestMismatchReachesClient(t *testing.T) {
+	chain := middleware.ChainStreamServer(
+		streamPanicRecoveryInterceptor(),
+		streamErrorConverter,
+		streamLogger,
+		streamDigestHandler(staticDigest("server-digest", true)),
+	)
+
+	err := chain(
+		nil,
+		&testServerStream{ctx: ctxWithDigest("stale-digest")},
+		&grpc.StreamServerInfo{FullMethod: guardedMethod},
+		func(srv any, ss grpc.ServerStream) error { return nil },
+	)
+	require.Error(t, err)
+
+	st := status.Convert(err)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	details := st.Details()
+	require.NotEmpty(t, details, "client should receive structured error details")
+
+	errDetails, ok := details[0].(*arkv1.ErrorDetails)
+	require.True(t, ok)
+	require.Equal(t, arkerrors.DIGEST_MISMATCH.Name, errDetails.GetName())
+	require.Equal(t, "server-digest", errDetails.GetMetadata()["expected_digest"])
+	require.Equal(t, "stale-digest", errDetails.GetMetadata()["got_digest"])
+}

--- a/internal/interface/grpc/interceptors/interceptor_test.go
+++ b/internal/interface/grpc/interceptors/interceptor_test.go
@@ -1,0 +1,44 @@
+package interceptors
+
+import (
+	"context"
+	"testing"
+
+	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
+	arkerrors "github.com/arkade-os/arkd/pkg/errors"
+	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestDigestMismatchReachesClient checks the client receives a proper status with details, not a bare Unknown. Chain mirrors UnaryInterceptor and must stay in sync.
+func TestDigestMismatchReachesClient(t *testing.T) {
+	chain := middleware.ChainUnaryServer(
+		unaryPanicRecoveryInterceptor(),
+		errorConverter,
+		unaryLogger,
+		unaryDigestHandler(staticDigest("server-digest", true)),
+	)
+
+	_, err := chain(
+		ctxWithDigest("stale-digest"),
+		nil,
+		&grpc.UnaryServerInfo{FullMethod: guardedMethod},
+		func(ctx context.Context, req any) (any, error) { return "ok", nil },
+	)
+	require.Error(t, err)
+
+	st := status.Convert(err)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	details := st.Details()
+	require.NotEmpty(t, details, "client should receive structured error details")
+
+	errDetails, ok := details[0].(*arkv1.ErrorDetails)
+	require.True(t, ok)
+	require.Equal(t, arkerrors.DIGEST_MISMATCH.Name, errDetails.GetName())
+	require.Equal(t, "server-digest", errDetails.GetMetadata()["expected_digest"])
+	require.Equal(t, "stale-digest", errDetails.GetMetadata()["got_digest"])
+}

--- a/pkg/client-lib/client/grpc/digest_header.go
+++ b/pkg/client-lib/client/grpc/digest_header.go
@@ -2,11 +2,12 @@ package grpcclient
 
 import (
 	"context"
-	"strings"
 
+	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
 	"github.com/arkade-os/arkd/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -49,11 +50,23 @@ func streamDigestInterceptor(getDigest func() string) grpc.StreamClientIntercept
 
 // isDigestMismatch reports whether err is the server's DIGEST_MISMATCH error.
 //
-// TODO: decode the gRPC status details (arkv1.ErrorDetails) instead of matching
-// the error message, once that path works end to end. Until then this matches the
-// structured error's name in the message.
+// The server attaches a structured arkv1.ErrorDetails to the gRPC status, so we
+// match on its name rather than the raw error message.
 func isDigestMismatch(err error) bool {
-	return err != nil && strings.Contains(err.Error(), errors.DIGEST_MISMATCH.Name)
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	for _, detail := range st.Details() {
+		if d, ok := detail.(*arkv1.ErrorDetails); ok &&
+			d.GetName() == errors.DIGEST_MISMATCH.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // withDigestRefresh runs call and, if it fails with the server's DIGEST_MISMATCH

--- a/pkg/client-lib/client/grpc/digest_header_test.go
+++ b/pkg/client-lib/client/grpc/digest_header_test.go
@@ -1,0 +1,65 @@
+package grpcclient
+
+import (
+	stderrors "errors"
+	"testing"
+
+	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
+	"github.com/arkade-os/arkd/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsDigestMismatch(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain non-status error",
+			err:  stderrors.New(errors.DIGEST_MISMATCH.Name),
+			want: false,
+		},
+		{
+			name: "status with DIGEST_MISMATCH details",
+			err:  statusWithDetails(t, codes.FailedPrecondition, errors.DIGEST_MISMATCH.Name),
+			want: true,
+		},
+		{
+			name: "status with different error details",
+			err: statusWithDetails(
+				t, codes.FailedPrecondition, errors.BUILD_VERSION_TOO_OLD.Name,
+			),
+			want: false,
+		},
+		{
+			name: "status without details but name in message",
+			err:  status.Error(codes.FailedPrecondition, errors.DIGEST_MISMATCH.Name),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isDigestMismatch(tt.err))
+		})
+	}
+}
+
+// statusWithDetails builds a gRPC status error carrying an arkv1.ErrorDetails,
+// mirroring what the server's errorConverter attaches to guard errors.
+func statusWithDetails(t *testing.T, code codes.Code, name string) error {
+	t.Helper()
+	st, err := status.New(code, name).WithDetails(&arkv1.ErrorDetails{
+		Name: name,
+	})
+	require.NoError(t, err)
+	return st.Err()
+}


### PR DESCRIPTION
fixes #1107

errorConverter sat at the bottom of the unary interceptor chain (innermost), so it only wrapped errors from the request handler. 

Errors returned by the digest and version guards ran above it and skipped conversion, reaching the client as a bare Unknown status with no details,  including the expected digest a stale client needs to recover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gRPC interceptor error handling so digest-mismatch failures are converted earlier in both unary and streaming middleware, ensuring clients receive structured gRPC errors with diagnostic details (expected vs. actual digest).
* **Tests**
  * Added coverage for unary and streaming digest-mismatch propagation, validating the presence and contents of gRPC error details and digest metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->