### PR TITLE
fix(guards): validate version and digest headers when provided

### DIFF
--- a/internal/interface/grpc/interceptors/digest.go
+++ b/internal/interface/grpc/interceptors/digest.go
@@ -33,15 +33,17 @@ func unaryDigestHandler(getDigest func() (string, bool, error)) grpc.UnaryServer
 					"failed to verify digest header, retry later",
 				)
 			}
-			if guardEnabled {
-				digest := digestHeaderValue(ctx)
-				if digest != expectedDigest {
-					return nil, errors.DIGEST_MISMATCH.
-						New("invalid digest header").WithMetadata(errors.DigestMetadata{
-						ExpectedDigest: expectedDigest,
-						GotDigest:      digest,
-					})
-				}
+			// A present digest is always validated against the expected one;
+			// an absent (empty) digest is rejected only when the header is
+			// required. guardEnabled therefore governs only the missing-header
+			// case, not whether a provided digest is checked.
+			digest := digestHeaderValue(ctx)
+			if digest != expectedDigest && (guardEnabled || digest != "") {
+				return nil, errors.DIGEST_MISMATCH.
+					New("invalid digest header").WithMetadata(errors.DigestMetadata{
+					ExpectedDigest: expectedDigest,
+					GotDigest:      digest,
+				})
 			}
 		}
 		return handler(ctx, req)
@@ -60,15 +62,17 @@ func streamDigestHandler(
 			if err != nil {
 				return errors.INTERNAL_ERROR.New("failed to verify digest header, retry later")
 			}
-			if guardEnabled {
-				digest := digestHeaderValue(ss.Context())
-				if digest != expectedDigest {
-					return errors.DIGEST_MISMATCH.
-						New("invalid digest header").WithMetadata(errors.DigestMetadata{
-						ExpectedDigest: expectedDigest,
-						GotDigest:      digest,
-					})
-				}
+			// A present digest is always validated against the expected one;
+			// an absent (empty) digest is rejected only when the header is
+			// required. guardEnabled therefore governs only the missing-header
+			// case, not whether a provided digest is checked.
+			digest := digestHeaderValue(ss.Context())
+			if digest != expectedDigest && (guardEnabled || digest != "") {
+				return errors.DIGEST_MISMATCH.
+					New("invalid digest header").WithMetadata(errors.DigestMetadata{
+					ExpectedDigest: expectedDigest,
+					GotDigest:      digest,
+				})
 			}
 		}
 		return handler(srv, ss)

--- a/internal/interface/grpc/interceptors/digest_test.go
+++ b/internal/interface/grpc/interceptors/digest_test.go
@@ -86,18 +86,34 @@ func TestDigestCompat(t *testing.T) {
 			wantGot:        "abc123",
 		},
 
-		// --- Guard disabled: every request passes regardless of the header ---
+		// --- Guard disabled: a missing header passes, but a present digest is
+		// still validated against the expected one ---
 		{
-			description:    "disabled guard passes despite mismatch",
+			description:    "disabled guard rejects present mismatching digest",
 			guardEnabled:   false,
 			expectedDigest: "abc123",
 			ctx:            ctxWithDigest("deadbeef"),
+			wantReject:     true,
+			wantExpected:   "abc123",
+			wantGot:        "deadbeef",
+		},
+		{
+			description:    "disabled guard passes with matching digest",
+			guardEnabled:   false,
+			expectedDigest: "abc123",
+			ctx:            ctxWithDigest("abc123"),
 		},
 		{
 			description:    "disabled guard passes with no header",
 			guardEnabled:   false,
 			expectedDigest: "abc123",
 			ctx:            context.Background(),
+		},
+		{
+			description:    "disabled guard passes with empty header value",
+			guardEnabled:   false,
+			expectedDigest: "abc123",
+			ctx:            ctxWithDigest(""),
 		},
 	}
 

--- a/internal/interface/grpc/interceptors/version.go
+++ b/internal/interface/grpc/interceptors/version.go
@@ -123,14 +123,14 @@ func buildVersionTooOld(clientVersion string, guard VersionGuard) error {
 }
 
 func checkVersionCompat(ctx context.Context, fullMethod string, guard VersionGuard) error {
-	if !guard.RequireHeader || !strings.Contains(
-		fullMethod, arkv1.ArkService_ServiceDesc.ServiceName,
-	) {
+	// The guard only applies to the public ArkService.
+	if !strings.Contains(fullMethod, arkv1.ArkService_ServiceDesc.ServiceName) {
 		return nil
 	}
 
 	headerVal, present := versionHeaderValue(ctx)
 	if !present || headerVal == "" {
+		// A missing or empty header is rejected only when the header is required.
 		if guard.RequireHeader {
 			return buildVersionTooOld("", guard)
 		}
@@ -139,9 +139,16 @@ func checkVersionCompat(ctx context.Context, fullMethod string, guard VersionGua
 
 	clientMajor, clientMinor, clientPatch, err := parseVersion(headerVal)
 	if err != nil {
-		return buildVersionTooOld(headerVal, guard)
+		// An unparseable header cannot be compared to the minimum: reject it only
+		// when the header is required, otherwise let it through.
+		if guard.RequireHeader {
+			return buildVersionTooOld(headerVal, guard)
+		}
+		return nil
 	}
 
+	// A present, parseable version is always held to the minimum, regardless of
+	// whether the header is required.
 	if isBehind(guard, clientMajor, clientMinor, clientPatch) {
 		return buildVersionTooOld(headerVal, guard)
 	}

--- a/internal/interface/grpc/interceptors/version_test.go
+++ b/internal/interface/grpc/interceptors/version_test.go
@@ -71,10 +71,11 @@ type versionCompatCase struct {
 
 func TestVersionCompat(t *testing.T) {
 	testCases := []versionCompatCase{
-		// The guard enforces the version policy only when requireHeader is true.
-		// When it is false the guard is bypassed entirely (see the
-		// "header not required" group below), so every version-comparison case
-		// here sets requireHeader: true.
+		// A present, parseable version is always held to the minimum,
+		// regardless of requireHeader (see the "header not required" group
+		// below). requireHeader only governs whether a missing/empty/unparseable
+		// header is rejected. The comparison cases here set requireHeader: true,
+		// but their parseable-and-below-min verdicts hold either way.
 
 		// --- Client below the minimum is rejected ---
 		{
@@ -206,8 +207,9 @@ func TestVersionCompat(t *testing.T) {
 			ctx:           ctxWithVersion("2.3.4"),
 		},
 
-		// --- Header not required (requireHeader=false): the guard is bypassed,
-		// so even a missing/invalid/below-min header passes ---
+		// --- Header not required (requireHeader=false): a missing, empty or
+		// unparseable header passes, but a present parseable version is still
+		// held to the minimum ---
 		{
 			description: "not required: missing header passes",
 			minVersion:  "2.3.4",
@@ -224,9 +226,22 @@ func TestVersionCompat(t *testing.T) {
 			ctx:         ctxWithVersion("not-a-version"),
 		},
 		{
-			description: "not required: below-min client passes (no enforcement)",
+			description:       "not required: below-min client rejected",
+			minVersion:        "2.3.4",
+			ctx:               ctxWithVersion("1.0.0"),
+			wantReject:        true,
+			wantClientVersion: "1.0.0",
+			wantMinVersion:    "2.3.4",
+		},
+		{
+			description: "not required: client equal to min passes",
 			minVersion:  "2.3.4",
-			ctx:         ctxWithVersion("1.0.0"),
+			ctx:         ctxWithVersion("2.3.4"),
+		},
+		{
+			description: "not required: client above min passes",
+			minVersion:  "2.3.4",
+			ctx:         ctxWithVersion("2.4.0"),
 		},
 
 		// --- Configured min version unparseable/empty: the header is still


### PR DESCRIPTION
## Problem

Both header-compatibility interceptors skip **all** validation when their "required" flag is false, so a client that *advertises* a bad value is accepted:

- **Version guard** (`version.go`): when `BuildVersionHeaderRequired` is false, an `x-build-version` below the configured minimum was accepted.
- **Digest guard** (`digest.go`): when `DigestHeaderRequired` is false, a wrong `x-digest` was accepted (the comparison was gated behind `guardEnabled`).

This conflates two independent questions:

- **Is the header mandatory?** → the `*Required` flag
- **If a value is provided, is it valid?** → should always be enforced

Observed: with `MIN_BUILD_VERSION_HEADER=0.9.10` but `MIN_BUILD_VERSION_HEADER_REQUIRED` unset (default false), a client sending `x-build-version: 0.9.9` was not rejected.

## Change

The `*Required` flag now governs only the **absent / empty** header case. A **present** value is always validated, regardless of the flag.

### Version guard
`RequireHeader` gates only absent/empty/unparseable headers. A present, parseable version is always held to the minimum — still a **minimum** check (strict `<` via `isBehind`): `>= min` passes, only `< min` is rejected.

| | header absent | present & `< min` | present & `>= min` | present & unparseable |
|---|---|---|---|---|
| required = true | reject | reject | pass | reject |
| required = false (before) | pass | **pass** | pass | pass |
| required = false (after) | pass | **reject** | pass | pass |

Unparseable-when-not-required stays allowed: an unparseable string can't be proven below the minimum.

### Digest guard
A present digest is always compared to the expected one; an absent/empty header is rejected only when `DigestHeaderRequired` is true. Expressed as: reject iff `digest != expected && (guardEnabled || digest != "")`.

| | header absent | present & matches | present & mismatches |
|---|---|---|---|
| required = true | reject* | pass | reject |
| required = false (before) | pass | pass | **pass** |
| required = false (after) | pass | pass | **reject** |

\* except when no digest is configured (empty expected): a missing header still passes, since there is nothing to match. GetInfo remains exempt (it's how clients learn the digest).

## Tests

- `version_test.go`: the former "not required: below-min client passes" case now expects rejection; added "not required: equal/above min passes" cases.
- `digest_test.go`: the former "disabled guard passes despite mismatch" case now expects rejection; added "disabled guard passes with matching digest / empty header" cases. The empty-expected-digest and GetInfo-exemption cases are unchanged.

## Verification

⚠️ **Not run locally** — no Go toolchain in this environment, and `ci_unit` only triggers on `pull_request` to base branches matching `'*'`, which does not match the slashed base `feat/deprecated-keys`, so unit CI will not run on this PR. Both changes were verified by manually tracing every case in `version_test.go` and `digest_test.go` against the new logic. **Please run `go test ./internal/interface/grpc/interceptors/...` before merging** — that's the claim most likely to need confirmation.

## Notes / out of scope

- `VersionGuard` still names its parsed threshold fields `serverMajor/serverMinor/serverPatch` and a comment calls it "the server's own build version," but the value is actually the configured minimum (`settings.BuildVersionHeader`). Left as-is to keep the diff minimal; renaming is a reasonable follow-up.
