### PR TITLE
client-lib: Add optional x-sdk-version header to arkade grpc client

### DIFF
--- a/internal/interface/grpc/interceptors/logger.go
+++ b/internal/interface/grpc/interceptors/logger.go
@@ -25,6 +25,7 @@ var sensitiveRequestFields = map[string]struct{}{
 // gRPC lowercases all incoming metadata keys, so entries here must be lowercase.
 var metadataOfInterest = map[string]struct{}{
 	"x-build-version": {},
+	"x-sdk-version":   {},
 	"x-digest":        {},
 }
 

--- a/internal/interface/grpc/service.go
+++ b/internal/interface/grpc/service.go
@@ -449,6 +449,8 @@ func (s *service) newServer(tlsConfig *tls.Config, withPprof bool) error {
 			return "macaroon", true
 		case "X-Build-Version":
 			return "x-build-version", true
+		case "X-Sdk-Version":
+			return "x-sdk-version", true
 		case "X-Digest":
 			return "x-digest", true
 		default:

--- a/internal/test/e2e/e2e_test.go
+++ b/internal/test/e2e/e2e_test.go
@@ -6081,7 +6081,7 @@ func TestTxListenerChurn(t *testing.T) {
 		go func(workerID int) {
 			defer wg.Done()
 
-			streamClient, err := grpcclient.NewClient(serverUrl)
+			streamClient, err := grpcclient.NewClient(serverUrl, "")
 			if err != nil {
 				if stressCtx.Err() != nil {
 					return
@@ -6110,7 +6110,7 @@ func TestTxListenerChurn(t *testing.T) {
 				// Reconnect if the previous iteration tore down the client
 				// due to a transient error.
 				if streamClient == nil {
-					streamClient, err = grpcclient.NewClient(serverUrl)
+					streamClient, err = grpcclient.NewClient(serverUrl, "")
 					if err != nil {
 						if stressCtx.Err() != nil {
 							return
@@ -6369,7 +6369,7 @@ func TestEventListenerChurn(t *testing.T) {
 		go func(workerID int) {
 			defer wg.Done()
 
-			streamClient, err := grpcclient.NewClient(serverUrl)
+			streamClient, err := grpcclient.NewClient(serverUrl, "")
 			if err != nil {
 				if stressCtx.Err() != nil {
 					return
@@ -6397,7 +6397,7 @@ func TestEventListenerChurn(t *testing.T) {
 
 				// Reconnect after a transient error tore down the client.
 				if streamClient == nil {
-					streamClient, err = grpcclient.NewClient(serverUrl)
+					streamClient, err = grpcclient.NewClient(serverUrl, "")
 					if err != nil {
 						if stressCtx.Err() != nil {
 							return

--- a/pkg/client-lib/client/grpc/client.go
+++ b/pkg/client-lib/client/grpc/client.go
@@ -37,7 +37,7 @@ type grpcClient struct {
 	digest     string
 }
 
-func NewClient(serverUrl string) (client.Client, error) {
+func NewClient(serverUrl, clientVersion string) (client.Client, error) {
 	if len(serverUrl) <= 0 {
 		return nil, fmt.Errorf("missing server url")
 	}
@@ -60,6 +60,17 @@ func NewClient(serverUrl string) (client.Client, error) {
 		infoMu:     &sync.RWMutex{},
 	}
 
+	unaryInterceptors := []grpc.UnaryClientInterceptor{
+		unaryVersionInterceptor(), unaryDigestInterceptor(client.getDigest),
+	}
+	streamInterceptors := []grpc.StreamClientInterceptor{
+		streamVersionInterceptor(), streamDigestInterceptor(client.getDigest),
+	}
+	if len(clientVersion) > 0 {
+		unaryInterceptors = append(unaryInterceptors, unaryClientVersionInterceptor(clientVersion))
+		streamInterceptors = append(streamInterceptors, streamClientVersionInterceptor(clientVersion))
+	}
+
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDisableServiceConfig(),
@@ -73,12 +84,8 @@ func NewClient(serverUrl string) (client.Client, error) {
 			},
 			MinConnectTimeout: 3 * time.Second,
 		}),
-		grpc.WithChainUnaryInterceptor(
-			unaryVersionInterceptor(), unaryDigestInterceptor(client.getDigest),
-		),
-		grpc.WithChainStreamInterceptor(
-			streamVersionInterceptor(), streamDigestInterceptor(client.getDigest),
-		),
+		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
+		grpc.WithChainStreamInterceptor(streamInterceptors...),
 	}
 	options = append(options, testDialOptions...)
 

--- a/pkg/client-lib/client/grpc/client_version_header.go
+++ b/pkg/client-lib/client/grpc/client_version_header.go
@@ -8,39 +8,38 @@ import (
 )
 
 const (
-	// buildVersionHeader is the gRPC metadata key carrying the client build version.
+	// clientVersionHeader is the gRPC metadata key carrying the client build version.
 	// It must match the key the arkd server reads via md.Get on the version interceptor
 	// (internal/interface/grpc/interceptors/version.go).
 	// gRPC normalises all metadata keys to lowercase.
-	buildVersionHeader = "x-build-version"
-	buildVersion       = "0.9.9"
+	clientVersionHeader = "x-sdk-version"
 )
 
-// unaryVersionInterceptor returns a gRPC unary client interceptor that sets
-// buildVersionHeader=buildVersion to the outgoing metadata of every unary RPC.
-func unaryVersionInterceptor() grpc.UnaryClientInterceptor {
+// unaryClientVersionInterceptor returns a gRPC unary client interceptor that sets
+// clientVersionHeader=version to the outgoing metadata of every unary RPC.
+func unaryClientVersionInterceptor(version string) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context, method string, req, reply interface{},
 		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
 		md, _ := metadata.FromOutgoingContext(ctx)
 		md = md.Copy()
-		md.Set(buildVersionHeader, buildVersion)
+		md.Set(clientVersionHeader, version)
 		ctx = metadata.NewOutgoingContext(ctx, md)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 
-// streamVersionInterceptor returns a gRPC stream client interceptor that sets
-// buildVersionHeader=buildVersion to the outgoing metadata of every streaming RPC
-func streamVersionInterceptor() grpc.StreamClientInterceptor {
+// streamClientVersionInterceptor returns a gRPC stream client interceptor that sets
+// clientVersionHeader=version to the outgoing metadata of every streaming RPC
+func streamClientVersionInterceptor(version string) grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
 		method string, streamer grpc.Streamer, opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
 		md, _ := metadata.FromOutgoingContext(ctx)
 		md = md.Copy()
-		md.Set(buildVersionHeader, buildVersion)
+		md.Set(clientVersionHeader, version)
 		ctx = metadata.NewOutgoingContext(ctx, md)
 		return streamer(ctx, desc, cc, method, opts...)
 	}

--- a/pkg/client-lib/client/grpc/client_version_header_test.go
+++ b/pkg/client-lib/client/grpc/client_version_header_test.go
@@ -1,0 +1,274 @@
+package grpcclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestClientVersionHeaderInjected_Unary verifies that a unary RPC issued through
+// the real NewClient constructor carries the x-sdk-version header server-side
+// when a client version is configured.
+func TestClientVersionHeaderInjected_Unary(t *testing.T) {
+	const clientVersion = "9.9.9"
+
+	capture := &headerCapture{key: clientVersionHeader}
+	dialer := startArkHeaderServer(t, capture)
+
+	// Drive the REAL NewClient path; the bufconn dialer is injected via the
+	// test-only seam so the production interceptors registered in NewClient
+	// are exercised end to end.
+	prev := testDialOptions
+	testDialOptions = []grpc.DialOption{grpc.WithContextDialer(dialer)}
+	t.Cleanup(func() { testDialOptions = prev })
+
+	c, err := NewClient("passthrough:///bufconn", clientVersion)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// GetInfo returns Unimplemented from the stub server; that is expected.
+	// The server-side interceptor still captures the header before the handler.
+	_, _ = c.GetInfo(ctx)
+
+	value, seen := capture.get()
+	require.True(t, seen, "server did not receive x-sdk-version header on unary call")
+	require.Equal(t, clientVersion, value)
+}
+
+// TestClientVersionHeaderInjected_Stream verifies that a streaming RPC issued
+// through the real NewClient constructor carries the x-sdk-version header
+// server-side when a client version is configured.
+func TestClientVersionHeaderInjected_Stream(t *testing.T) {
+	const clientVersion = "9.9.9"
+
+	capture := &headerCapture{key: clientVersionHeader}
+	dialer := startArkHeaderServer(t, capture)
+
+	prev := testDialOptions
+	testDialOptions = []grpc.DialOption{grpc.WithContextDialer(dialer)}
+	t.Cleanup(func() { testDialOptions = prev })
+
+	c, err := NewClient("passthrough:///bufconn", clientVersion)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// GetTransactionsStream opens a server-streaming RPC. The stream
+	// interceptor on the server captures the header as the stream is
+	// established, regardless of the Unimplemented handler outcome.
+	_, closeFn, err := c.GetTransactionsStream(ctx)
+	if closeFn != nil {
+		defer closeFn()
+	}
+	// An error is acceptable (Unimplemented); we only require that the stream
+	// reached the server and the header was captured.
+	_ = err
+
+	require.Eventually(t, func() bool {
+		_, seen := capture.get()
+		return seen
+	}, 5*time.Second, 20*time.Millisecond,
+		"server did not receive x-sdk-version header on streaming call")
+
+	value, _ := capture.get()
+	require.Equal(t, clientVersion, value)
+}
+
+// TestClientVersionHeaderOmitted_Unary verifies that no x-sdk-version header is
+// sent when NewClient is constructed without a client version, mirroring the
+// conditional wiring in NewClient.
+func TestClientVersionHeaderOmitted_Unary(t *testing.T) {
+	capture := &headerCapture{key: clientVersionHeader}
+	dialer := startArkHeaderServer(t, capture)
+
+	prev := testDialOptions
+	testDialOptions = []grpc.DialOption{grpc.WithContextDialer(dialer)}
+	t.Cleanup(func() { testDialOptions = prev })
+
+	c, err := NewClient("passthrough:///bufconn", "")
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, _ = c.GetInfo(ctx)
+
+	_, seen := capture.get()
+	require.False(t, seen, "x-sdk-version header should be absent without a client version")
+}
+
+// TestUnaryClientVersionInterceptor drives the unary interceptor directly and
+// asserts on the outgoing metadata it hands to the invoker.
+func TestUnaryClientVersionInterceptor(t *testing.T) {
+	const version = "1.2.3"
+
+	t.Run("sets header", func(t *testing.T) {
+		var got metadata.MD
+		invoker := func(
+			ctx context.Context, _ string, _, _ interface{},
+			_ *grpc.ClientConn, _ ...grpc.CallOption,
+		) error {
+			got, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		}
+
+		err := unaryClientVersionInterceptor(version)(
+			context.Background(), "/ark.v1.ArkService/GetInfo",
+			nil, nil, nil, invoker,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{version}, got.Get(clientVersionHeader))
+	})
+
+	t.Run("preserves existing metadata", func(t *testing.T) {
+		var got metadata.MD
+		invoker := func(
+			ctx context.Context, _ string, _, _ interface{},
+			_ *grpc.ClientConn, _ ...grpc.CallOption,
+		) error {
+			got, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		}
+
+		ctx := metadata.NewOutgoingContext(
+			context.Background(), metadata.Pairs("x-other", "keep-me"),
+		)
+		err := unaryClientVersionInterceptor(version)(
+			ctx, "/ark.v1.ArkService/GetInfo", nil, nil, nil, invoker,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{version}, got.Get(clientVersionHeader))
+		require.Equal(t, []string{"keep-me"}, got.Get("x-other"))
+	})
+
+	t.Run("overwrites stale header and leaves caller context untouched", func(t *testing.T) {
+		var got metadata.MD
+		invoker := func(
+			ctx context.Context, _ string, _, _ interface{},
+			_ *grpc.ClientConn, _ ...grpc.CallOption,
+		) error {
+			got, _ = metadata.FromOutgoingContext(ctx)
+			return nil
+		}
+
+		caller := metadata.Pairs(clientVersionHeader, "0.0.1")
+		ctx := metadata.NewOutgoingContext(context.Background(), caller)
+		err := unaryClientVersionInterceptor(version)(
+			ctx, "/ark.v1.ArkService/GetInfo", nil, nil, nil, invoker,
+		)
+		require.NoError(t, err)
+		// The invoker sees the fresh version, not the stale one.
+		require.Equal(t, []string{version}, got.Get(clientVersionHeader))
+		// The caller's own metadata was copied, not mutated in place.
+		require.Equal(t, []string{"0.0.1"}, caller.Get(clientVersionHeader))
+	})
+
+	t.Run("propagates invoker error", func(t *testing.T) {
+		wantErr := context.Canceled
+		invoker := func(
+			_ context.Context, _ string, _, _ interface{},
+			_ *grpc.ClientConn, _ ...grpc.CallOption,
+		) error {
+			return wantErr
+		}
+
+		err := unaryClientVersionInterceptor(version)(
+			context.Background(), "/ark.v1.ArkService/GetInfo",
+			nil, nil, nil, invoker,
+		)
+		require.ErrorIs(t, err, wantErr)
+	})
+}
+
+// TestStreamClientVersionInterceptor drives the stream interceptor directly and
+// asserts on the outgoing metadata it hands to the streamer.
+func TestStreamClientVersionInterceptor(t *testing.T) {
+	const version = "1.2.3"
+
+	t.Run("sets header", func(t *testing.T) {
+		var got metadata.MD
+		streamer := func(
+			ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn,
+			_ string, _ ...grpc.CallOption,
+		) (grpc.ClientStream, error) {
+			got, _ = metadata.FromOutgoingContext(ctx)
+			return nil, nil
+		}
+
+		_, err := streamClientVersionInterceptor(version)(
+			context.Background(), &grpc.StreamDesc{}, nil,
+			"/ark.v1.ArkService/GetEventStream", streamer,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{version}, got.Get(clientVersionHeader))
+	})
+
+	t.Run("preserves existing metadata", func(t *testing.T) {
+		var got metadata.MD
+		streamer := func(
+			ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn,
+			_ string, _ ...grpc.CallOption,
+		) (grpc.ClientStream, error) {
+			got, _ = metadata.FromOutgoingContext(ctx)
+			return nil, nil
+		}
+
+		ctx := metadata.NewOutgoingContext(
+			context.Background(), metadata.Pairs("x-other", "keep-me"),
+		)
+		_, err := streamClientVersionInterceptor(version)(
+			ctx, &grpc.StreamDesc{}, nil,
+			"/ark.v1.ArkService/GetEventStream", streamer,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{version}, got.Get(clientVersionHeader))
+		require.Equal(t, []string{"keep-me"}, got.Get("x-other"))
+	})
+
+	t.Run("overwrites stale header and leaves caller context untouched", func(t *testing.T) {
+		var got metadata.MD
+		streamer := func(
+			ctx context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn,
+			_ string, _ ...grpc.CallOption,
+		) (grpc.ClientStream, error) {
+			got, _ = metadata.FromOutgoingContext(ctx)
+			return nil, nil
+		}
+
+		caller := metadata.Pairs(clientVersionHeader, "0.0.1")
+		ctx := metadata.NewOutgoingContext(context.Background(), caller)
+		_, err := streamClientVersionInterceptor(version)(
+			ctx, &grpc.StreamDesc{}, nil,
+			"/ark.v1.ArkService/GetEventStream", streamer,
+		)
+		require.NoError(t, err)
+		require.Equal(t, []string{version}, got.Get(clientVersionHeader))
+		require.Equal(t, []string{"0.0.1"}, caller.Get(clientVersionHeader))
+	})
+
+	t.Run("propagates streamer error", func(t *testing.T) {
+		wantErr := context.Canceled
+		streamer := func(
+			_ context.Context, _ *grpc.StreamDesc, _ *grpc.ClientConn,
+			_ string, _ ...grpc.CallOption,
+		) (grpc.ClientStream, error) {
+			return nil, wantErr
+		}
+
+		_, err := streamClientVersionInterceptor(version)(
+			context.Background(), &grpc.StreamDesc{}, nil,
+			"/ark.v1.ArkService/GetEventStream", streamer,
+		)
+		require.ErrorIs(t, err, wantErr)
+	})
+}

--- a/pkg/client-lib/client/grpc/version_header_test.go
+++ b/pkg/client-lib/client/grpc/version_header_test.go
@@ -17,7 +17,7 @@ import (
 // TestBuildVersionHeaderInjected_Unary verifies that a unary RPC issued through
 // the real NewClient constructor carries the x-build-version header server-side.
 func TestBuildVersionHeaderInjected_Unary(t *testing.T) {
-	capture := &headerCapture{}
+	capture := &headerCapture{key: buildVersionHeader}
 	dialer := startArkHeaderServer(t, capture)
 
 	// Drive the REAL NewClient path; the bufconn dialer is injected via the
@@ -27,7 +27,7 @@ func TestBuildVersionHeaderInjected_Unary(t *testing.T) {
 	testDialOptions = []grpc.DialOption{grpc.WithContextDialer(dialer)}
 	t.Cleanup(func() { testDialOptions = prev })
 
-	c, err := NewClient("passthrough:///bufconn")
+	c, err := NewClient("passthrough:///bufconn", "")
 	require.NoError(t, err)
 	t.Cleanup(c.Close)
 
@@ -47,14 +47,14 @@ func TestBuildVersionHeaderInjected_Unary(t *testing.T) {
 // through the real NewClient constructor carries the x-build-version header
 // server-side.
 func TestBuildVersionHeaderInjected_Stream(t *testing.T) {
-	capture := &headerCapture{}
+	capture := &headerCapture{key: buildVersionHeader}
 	dialer := startArkHeaderServer(t, capture)
 
 	prev := testDialOptions
 	testDialOptions = []grpc.DialOption{grpc.WithContextDialer(dialer)}
 	t.Cleanup(func() { testDialOptions = prev })
 
-	c, err := NewClient("passthrough:///bufconn")
+	c, err := NewClient("passthrough:///bufconn", "")
 	require.NoError(t, err)
 	t.Cleanup(c.Close)
 
@@ -82,9 +82,11 @@ func TestBuildVersionHeaderInjected_Stream(t *testing.T) {
 	require.Equal(t, buildVersion, value)
 }
 
-// headerCapture records the x-build-version metadata value seen by the server.
+// headerCapture records the value of the metadata key it is configured for, as
+// seen by the server on incoming calls.
 type headerCapture struct {
 	mu    sync.Mutex
+	key   string
 	value string
 	seen  bool
 }
@@ -93,7 +95,7 @@ func (h *headerCapture) record(ctx context.Context) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if vals := md.Get(buildVersionHeader); len(vals) > 0 {
+		if vals := md.Get(h.key); len(vals) > 0 {
 			h.value = vals[0]
 			h.seen = true
 		}

--- a/pkg/client-lib/init.go
+++ b/pkg/client-lib/init.go
@@ -27,7 +27,7 @@ func (a *service) Init(ctx context.Context, args InitArgs) error {
 func (a *service) init(
 	ctx context.Context, args args, explorerSvc explorer.Explorer,
 ) error {
-	clientSvc, err := grpcclient.NewClient(args.serverUrl)
+	clientSvc, err := grpcclient.NewClient(args.serverUrl, ClientVersion)
 	if err != nil {
 		return fmt.Errorf("failed to setup client: %s", err)
 	}

--- a/pkg/client-lib/service.go
+++ b/pkg/client-lib/service.go
@@ -36,6 +36,8 @@ var (
 	supportedIdentities = utils.SupportedType[struct{}]{
 		SingleKeyIdentity: struct{}{},
 	}
+
+	ClientVersion string
 )
 
 type service struct {
@@ -131,7 +133,7 @@ func LoadWallet(storeSvc types.Store, opts ...ServiceOption) (Wallet, error) {
 		client.explorer = explorerSvc
 	}
 
-	clientSvc, err := grpcclient.NewClient(cfgData.ServerUrl)
+	clientSvc, err := grpcclient.NewClient(cfgData.ServerUrl, ClientVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup transport client: %s", err)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SDK now automatically includes version information in gRPC requests, enabling improved debugging, monitoring, and server-side tracking of SDK usage.

* **Tests**
  * Added comprehensive test coverage for version header functionality, including validation for both unary and streaming RPC calls and behavior verification when version information is present or absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->