### PR TITLE
Minor fixes

### DIFF
--- a/internal/interface/grpc/interceptors/logger.go
+++ b/internal/interface/grpc/interceptors/logger.go
@@ -19,6 +19,7 @@ var sensitiveRequestFields = map[string]struct{}{
 	"password":      {},
 	"secret":        {},
 	"authorization": {},
+	"seed":          {},
 }
 
 // metadataOfInterest is the allowlist of incoming gRPC metadata keys we log.

--- a/internal/interface/grpc/interceptors/logger.go
+++ b/internal/interface/grpc/interceptors/logger.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	arkerrors "github.com/arkade-os/arkd/pkg/errors"
@@ -115,17 +114,4 @@ func sanitizeMetadata(ctx context.Context) (string, bool) {
 	}
 
 	return string(formatted), true
-}
-
-func normalizeFieldName(name string) string {
-	var builder strings.Builder
-	builder.Grow(len(name))
-
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			builder.WriteRune(r)
-		}
-	}
-
-	return strings.ToLower(builder.String())
 }

--- a/internal/interface/grpc/interceptors/logger.go
+++ b/internal/interface/grpc/interceptors/logger.go
@@ -14,14 +14,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var sensitiveRequestFields = map[string]struct{}{
-	"macaroon":      {},
-	"password":      {},
-	"secret":        {},
-	"authorization": {},
-	"seed":          {},
-}
-
 // metadataOfInterest is the allowlist of incoming gRPC metadata keys we log.
 // gRPC lowercases all incoming metadata keys, so entries here must be lowercase.
 var metadataOfInterest = map[string]struct{}{
@@ -53,9 +45,6 @@ func logUnaryCall(method string, req any, ctx context.Context, dur time.Duration
 	str := fmt.Sprintf("method=%s duration=%dms", method, dur.Milliseconds())
 
 	if log.IsLevelEnabled(log.DebugLevel) {
-		if sanitizedReq, ok := sanitizeRequest(req); ok && sanitizedReq != "{}" {
-			str += fmt.Sprintf(" request=%s", sanitizedReq)
-		}
 		if md, ok := sanitizeMetadata(ctx); ok {
 			str += fmt.Sprintf(" metadata=%s", md)
 		}
@@ -109,10 +98,6 @@ func sanitizeMetadata(ctx context.Context) (string, bool) {
 		if len(vals) == 0 {
 			continue
 		}
-		if isSensitiveField(key) {
-			selected[key] = "******"
-			continue
-		}
 		if len(vals) == 1 {
 			selected[key] = vals[0]
 			continue
@@ -130,68 +115,6 @@ func sanitizeMetadata(ctx context.Context) (string, bool) {
 	}
 
 	return string(formatted), true
-}
-
-func sanitizeRequest(req any) (string, bool) {
-	if req == nil {
-		return "", false
-	}
-
-	raw, err := json.Marshal(req)
-	if err != nil {
-		return "", false
-	}
-
-	var decoded interface{}
-	if err := json.Unmarshal(raw, &decoded); err != nil {
-		return "", false
-	}
-
-	sanitized := redactSensitiveFields(decoded)
-	formatted, err := json.Marshal(sanitized)
-	if err != nil {
-		return "", false
-	}
-
-	return string(formatted), true
-}
-
-func redactSensitiveFields(value interface{}) interface{} {
-	switch v := value.(type) {
-	case map[string]interface{}:
-		redacted := make(map[string]interface{}, len(v))
-		for key, item := range v {
-			if isSensitiveField(key) {
-				redacted[key] = "******"
-				continue
-			}
-			redacted[key] = redactSensitiveFields(item)
-		}
-		return redacted
-	case []interface{}:
-		redacted := make([]interface{}, len(v))
-		for i, item := range v {
-			redacted[i] = redactSensitiveFields(item)
-		}
-		return redacted
-	default:
-		return v
-	}
-}
-
-func isSensitiveField(name string) bool {
-	normalized := normalizeFieldName(name)
-	if _, ok := sensitiveRequestFields[normalized]; ok {
-		return true
-	}
-
-	for sensitive := range sensitiveRequestFields {
-		if strings.Contains(normalized, sensitive) {
-			return true
-		}
-	}
-
-	return false
 }
 
 func normalizeFieldName(name string) string {

--- a/pkg/client-lib/init.go
+++ b/pkg/client-lib/init.go
@@ -27,7 +27,7 @@ func (a *service) Init(ctx context.Context, args InitArgs) error {
 func (a *service) init(
 	ctx context.Context, args args, explorerSvc explorer.Explorer,
 ) error {
-	clientSvc, err := grpcclient.NewClient(args.serverUrl, ClientVersion)
+	clientSvc, err := grpcclient.NewClient(args.serverUrl, a.clientVersion)
 	if err != nil {
 		return fmt.Errorf("failed to setup client: %s", err)
 	}

--- a/pkg/client-lib/service.go
+++ b/pkg/client-lib/service.go
@@ -36,8 +36,6 @@ var (
 	supportedIdentities = utils.SupportedType[struct{}]{
 		SingleKeyIdentity: struct{}{},
 	}
-
-	ClientVersion string
 )
 
 type service struct {
@@ -51,6 +49,7 @@ type service struct {
 	txLock                 *sync.RWMutex
 	verbose                bool
 	withFinalizePendingTxs bool
+	clientVersion          string
 }
 
 func NewWallet(storeSvc types.Store, opts ...ServiceOption) (Wallet, error) {
@@ -133,7 +132,7 @@ func LoadWallet(storeSvc types.Store, opts ...ServiceOption) (Wallet, error) {
 		client.explorer = explorerSvc
 	}
 
-	clientSvc, err := grpcclient.NewClient(cfgData.ServerUrl, ClientVersion)
+	clientSvc, err := grpcclient.NewClient(cfgData.ServerUrl, client.clientVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup transport client: %s", err)
 	}

--- a/pkg/client-lib/service_opts.go
+++ b/pkg/client-lib/service_opts.go
@@ -30,3 +30,9 @@ func WithoutFinalizePendingTxs() ServiceOption {
 		c.withFinalizePendingTxs = false
 	}
 }
+
+func WithClientVersion(version string) ServiceOption {
+	return func(c *service) {
+		c.clientVersion = version
+	}
+}


### PR DESCRIPTION
Fixes client version usage in client-lib and logger interceptor in arkd to prevent diclosing secrets in logs

Please @louisinger review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-service client version configuration via `WithClientVersion`, so the gRPC client uses the configured instance version.

* **Behavior Changes**
  * Updated gRPC request logging: the logged request payload and metadata redaction behavior were modified, with sensitive-field handling adjusted (including treating `seed` as sensitive).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->