### PR TITLE
client-lib: support deprecated signer verification

### DIFF
--- a/pkg/client-lib/asset.go
+++ b/pkg/client-lib/asset.go
@@ -27,6 +27,11 @@ func (a *service) IssueAsset(
 		}
 	}
 
+	cfgData, err := a.GetConfigData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if amount == 0 {
 		return nil, fmt.Errorf("amount must be > 0")
 	}
@@ -156,12 +161,13 @@ func (a *service) IssueAsset(
 		return nil, err
 	}
 
+	signers := cfgData.AllSigners()
 	// validate and verify transactions returned by the server
-	if err := verifySignedArk(arkTx, signedArkTx, a.SignerPubKey); err != nil {
+	if err := verifySignedArk(arkTx, signedArkTx, signers); err != nil {
 		return nil, err
 	}
 
-	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, a.SignerPubKey); err != nil {
+	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, signers); err != nil {
 		return nil, err
 	}
 
@@ -242,6 +248,11 @@ func (a *service) ReissueAsset(
 		if err := opt.applySend(o); err != nil {
 			return nil, err
 		}
+	}
+
+	cfgData, err := a.GetConfigData(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	if amount == 0 {
@@ -361,12 +372,13 @@ func (a *service) ReissueAsset(
 		return nil, err
 	}
 
+	signers := cfgData.AllSigners()
 	// validate and verify transactions returned by the server
-	if err := verifySignedArk(arkTx, signedArkTx, a.SignerPubKey); err != nil {
+	if err := verifySignedArk(arkTx, signedArkTx, signers); err != nil {
 		return nil, err
 	}
 
-	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, a.SignerPubKey); err != nil {
+	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, signers); err != nil {
 		return nil, err
 	}
 
@@ -423,6 +435,11 @@ func (a *service) BurnAsset(
 		if err := opt.applySend(o); err != nil {
 			return nil, err
 		}
+	}
+
+	cfgData, err := a.GetConfigData(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	addr, err := a.getReceiver(ctx, o.receiver)
@@ -492,12 +509,13 @@ func (a *service) BurnAsset(
 		return nil, err
 	}
 
+	signers := cfgData.AllSigners()
 	// validate and verify transactions returned by the server
-	if err := verifySignedArk(arkTx, signedArkTx, a.SignerPubKey); err != nil {
+	if err := verifySignedArk(arkTx, signedArkTx, signers); err != nil {
 		return nil, err
 	}
 
-	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, a.SignerPubKey); err != nil {
+	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, signers); err != nil {
 		return nil, err
 	}
 

--- a/pkg/client-lib/send.go
+++ b/pkg/client-lib/send.go
@@ -40,6 +40,11 @@ func (a *service) SendOffChain(
 	a.txLock.Lock()
 	defer a.txLock.Unlock()
 
+	cfgData, err := a.GetConfigData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	baseArkTx, checkpointTxs, selectedCoins, changeReceiver, err := a.createOffchainTx(
 		ctx, receivers, o,
 	)
@@ -84,12 +89,13 @@ func (a *service) SendOffChain(
 		return nil, err
 	}
 
+	signers := cfgData.AllSigners()
 	// validate and verify transactions returned by the server
-	if err := verifySignedArk(arkTx, signedArkTx, a.SignerPubKey); err != nil {
+	if err := verifySignedArk(arkTx, signedArkTx, signers); err != nil {
 		return nil, err
 	}
 
-	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, a.SignerPubKey); err != nil {
+	if err := verifySignedCheckpoints(checkpointTxs, signedCheckpointTxs, signers); err != nil {
 		return nil, err
 	}
 

--- a/pkg/client-lib/store/file/config_store.go
+++ b/pkg/client-lib/store/file/config_store.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/arkade-os/arkd/pkg/client-lib/types"
 )
@@ -50,6 +51,13 @@ func (s *configStore) GetDatadir() string {
 }
 
 func (s *configStore) AddData(ctx context.Context, data types.Config) error {
+	deprecatedSigners := make([]deprecatedSignerData, 0, len(data.DeprecatedSigners))
+	for _, ds := range data.DeprecatedSigners {
+		deprecatedSigners = append(deprecatedSigners, deprecatedSignerData{
+			Pubkey:     hex.EncodeToString(ds.PubKey.SerializeCompressed()),
+			CutoffDate: ds.CutoffDate.Format(time.RFC3339),
+		})
+	}
 	sd := &storeData{
 		ServerUrl:           data.ServerUrl,
 		SignerPubKey:        hex.EncodeToString(data.SignerPubKey.SerializeCompressed()),
@@ -75,6 +83,7 @@ func (s *configStore) AddData(ctx context.Context, data types.Config) error {
 				OnchainOutput:  data.Fees.IntentFees.IntentOnchainOutputProgram,
 			},
 		},
+		DeprecatedSigners: deprecatedSigners,
 	}
 
 	if err := s.write(sd); err != nil {

--- a/pkg/client-lib/store/file/types.go
+++ b/pkg/client-lib/store/file/types.go
@@ -3,6 +3,7 @@ package filestore
 import (
 	"encoding/hex"
 	"strconv"
+	"time"
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/ark-lib/arkfee"
@@ -23,23 +24,29 @@ type intentFeeData struct {
 	OnchainOutput  string `json:"onchain_output"`
 }
 
+type deprecatedSignerData struct {
+	Pubkey     string `json:"pubkey"`
+	CutoffDate string `json:"cutoff_date"`
+}
+
 type storeData struct {
-	ServerUrl           string  `json:"server_url"`
-	SignerPubKey        string  `json:"signer_pubkey"`
-	ForfeitPubKey       string  `json:"forfeit_pubkey"`
-	Network             string  `json:"network"`
-	SessionDuration     string  `json:"session_duration"`
-	UnilateralExitDelay string  `json:"unilateral_exit_delay"`
-	Dust                string  `json:"dust"`
-	BoardingExitDelay   string  `json:"boarding_exit_delay"`
-	ExplorerURL         string  `json:"explorer_url"`
-	ForfeitAddress      string  `json:"forfeit_address"`
-	UtxoMinAmount       string  `json:"utxo_min_amount"`
-	UtxoMaxAmount       string  `json:"utxo_max_amount"`
-	VtxoMinAmount       string  `json:"vtxo_min_amount"`
-	VtxoMaxAmount       string  `json:"vtxo_max_amount"`
-	CheckpointTapscript string  `json:"checkpoint_tapscript"`
-	Fees                feeData `json:"fees"`
+	ServerUrl           string                 `json:"server_url"`
+	SignerPubKey        string                 `json:"signer_pubkey"`
+	ForfeitPubKey       string                 `json:"forfeit_pubkey"`
+	Network             string                 `json:"network"`
+	SessionDuration     string                 `json:"session_duration"`
+	UnilateralExitDelay string                 `json:"unilateral_exit_delay"`
+	Dust                string                 `json:"dust"`
+	BoardingExitDelay   string                 `json:"boarding_exit_delay"`
+	ExplorerURL         string                 `json:"explorer_url"`
+	ForfeitAddress      string                 `json:"forfeit_address"`
+	UtxoMinAmount       string                 `json:"utxo_min_amount"`
+	UtxoMaxAmount       string                 `json:"utxo_max_amount"`
+	VtxoMinAmount       string                 `json:"vtxo_min_amount"`
+	VtxoMaxAmount       string                 `json:"vtxo_max_amount"`
+	CheckpointTapscript string                 `json:"checkpoint_tapscript"`
+	Fees                feeData                `json:"fees"`
+	DeprecatedSigners   []deprecatedSignerData `json:"deprecated_signers"`
 }
 
 func (d storeData) isEmpty() bool {
@@ -88,6 +95,17 @@ func (d storeData) decode() types.Config {
 		},
 	}
 
+	deprecatedSigners := make([]types.DeprecatedSigner, 0, len(d.DeprecatedSigners))
+	for _, ds := range d.DeprecatedSigners {
+		buf, _ := hex.DecodeString(ds.Pubkey)
+		pubkey, _ := btcec.ParsePubKey(buf)
+		cutoff, _ := time.Parse(time.RFC3339, ds.CutoffDate)
+		deprecatedSigners = append(deprecatedSigners, types.DeprecatedSigner{
+			PubKey:     pubkey,
+			CutoffDate: cutoff,
+		})
+	}
+
 	return types.Config{
 		ServerUrl:     d.ServerUrl,
 		SignerPubKey:  signerPubkey,
@@ -111,6 +129,7 @@ func (d storeData) decode() types.Config {
 		VtxoMaxAmount:       int64(vtxoMaxAmount),
 		CheckpointTapscript: d.CheckpointTapscript,
 		Fees:                fees,
+		DeprecatedSigners:   deprecatedSigners,
 	}
 }
 
@@ -140,5 +159,6 @@ func (d storeData) asMap() map[string]any {
 				"onchain_output":  d.Fees.IntentFees.OnchainOutput,
 			},
 		},
+		"deprecated_signers": d.DeprecatedSigners,
 	}
 }

--- a/pkg/client-lib/store/service_test.go
+++ b/pkg/client-lib/store/service_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
 	"github.com/arkade-os/arkd/pkg/client-lib/store"
@@ -12,9 +13,11 @@ import (
 )
 
 var (
-	key, _         = btcec.NewPrivateKey()
-	forfeitkKey, _ = btcec.NewPrivateKey()
-	testConfigData = types.Config{
+	key, _           = btcec.NewPrivateKey()
+	forfeitkKey, _   = btcec.NewPrivateKey()
+	deprecatedKey, _ = btcec.NewPrivateKey()
+	cutoffDate       = time.Date(2026, 6, 17, 12, 0, 0, 0, time.UTC)
+	testConfigData   = types.Config{
 		ServerUrl:           "127.0.0.1:7070",
 		SignerPubKey:        key.PubKey(),
 		ForfeitPubKey:       forfeitkKey.PubKey(),
@@ -25,6 +28,7 @@ var (
 		BoardingExitDelay:   arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
 		ForfeitAddress:      "bcrt1qzvqj",
 		CheckpointTapscript: "abcdefghijklmnopqrtuvxyz",
+		DeprecatedSigners:   []types.DeprecatedSigner{},
 	}
 )
 
@@ -79,6 +83,21 @@ func testConfigStore(t *testing.T, storeSvc types.ConfigStore) {
 	data, err = storeSvc.GetData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, testConfigData, *data)
+
+	// Check deprecated signers are persisted and restored.
+	configWithDeprecatedSigners := testConfigData
+	configWithDeprecatedSigners.DeprecatedSigners = []types.DeprecatedSigner{
+		{
+			PubKey:     deprecatedKey.PubKey(),
+			CutoffDate: cutoffDate,
+		},
+	}
+	err = storeSvc.AddData(ctx, configWithDeprecatedSigners)
+	require.NoError(t, err)
+
+	data, err = storeSvc.GetData(ctx)
+	require.NoError(t, err)
+	require.Equal(t, configWithDeprecatedSigners, *data)
 
 	// Check clean and retrieve data.
 	err = storeSvc.CleanData(ctx)

--- a/pkg/client-lib/types/types.go
+++ b/pkg/client-lib/types/types.go
@@ -41,12 +41,23 @@ type Config struct {
 	VtxoMaxAmount       int64
 	CheckpointTapscript string
 	Fees                FeeInfo
+	DeprecatedSigners   []DeprecatedSigner
 }
 
 func (c Config) CheckpointExitPath() []byte {
 	// nolint
 	buf, _ := hex.DecodeString(c.CheckpointTapscript)
 	return buf
+}
+
+func (c Config) AllSigners() map[string]*btcec.PublicKey {
+	m := map[string]*btcec.PublicKey{
+		hex.EncodeToString(schnorr.SerializePubKey(c.SignerPubKey)): c.SignerPubKey,
+	}
+	for _, signer := range c.DeprecatedSigners {
+		m[hex.EncodeToString(schnorr.SerializePubKey(signer.PubKey))] = signer.PubKey
+	}
+	return m
 }
 
 type StreamConnectionState string

--- a/pkg/client-lib/types/types_test.go
+++ b/pkg/client-lib/types/types_test.go
@@ -1,0 +1,34 @@
+package types
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigAllSigners(t *testing.T) {
+	current, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	deprecated, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	cfg := Config{
+		SignerPubKey: current.PubKey(),
+		DeprecatedSigners: []DeprecatedSigner{
+			{PubKey: deprecated.PubKey()},
+			{PubKey: current.PubKey()},
+		},
+	}
+
+	signers := cfg.AllSigners()
+
+	currentKey := hex.EncodeToString(schnorr.SerializePubKey(current.PubKey()))
+	deprecatedKey := hex.EncodeToString(schnorr.SerializePubKey(deprecated.PubKey()))
+
+	require.Len(t, signers, 2)
+	require.True(t, signers[currentKey].IsEqual(current.PubKey()))
+	require.True(t, signers[deprecatedKey].IsEqual(deprecated.PubKey()))
+}

--- a/pkg/client-lib/utils.go
+++ b/pkg/client-lib/utils.go
@@ -916,7 +916,7 @@ func toOutputScript(onchainAddress string, network arklib.Network) ([]byte, erro
 }
 
 func verifySignedCheckpoints(
-	originalCheckpoints, signedCheckpoints []string, signerpubkey *btcec.PublicKey,
+	originalCheckpoints, signedCheckpoints []string, signers map[string]*btcec.PublicKey,
 ) error {
 	// index by txid
 	indexedOriginalCheckpoints := make(map[string]*psbt.Packet)
@@ -943,7 +943,7 @@ func verifySignedCheckpoints(
 		if !ok {
 			return fmt.Errorf("signed checkpoint %s not found", txid)
 		}
-		if err := verifyOffchainPsbt(originalPtx, signedPtx, signerpubkey); err != nil {
+		if err := verifyOffchainPsbt(originalPtx, signedPtx, signers); err != nil {
 			return err
 		}
 	}
@@ -951,7 +951,7 @@ func verifySignedCheckpoints(
 	return nil
 }
 
-func verifySignedArk(original, signed string, signerPubKey *btcec.PublicKey) error {
+func verifySignedArk(original, signed string, signers map[string]*btcec.PublicKey) error {
 	originalPtx, err := psbt.NewFromRawBytes(strings.NewReader(original), true)
 	if err != nil {
 		return err
@@ -962,12 +962,10 @@ func verifySignedArk(original, signed string, signerPubKey *btcec.PublicKey) err
 		return err
 	}
 
-	return verifyOffchainPsbt(originalPtx, signedPtx, signerPubKey)
+	return verifyOffchainPsbt(originalPtx, signedPtx, signers)
 }
 
-func verifyOffchainPsbt(original, signed *psbt.Packet, signerpubkey *btcec.PublicKey) error {
-	xonlySigner := schnorr.SerializePubKey(signerpubkey)
-
+func verifyOffchainPsbt(original, signed *psbt.Packet, signers map[string]*btcec.PublicKey) error {
 	if original.UnsignedTx.TxID() != signed.UnsignedTx.TxID() {
 		return fmt.Errorf("invalid offchain tx : txids mismatch")
 	}
@@ -1016,10 +1014,12 @@ func verifyOffchainPsbt(original, signed *psbt.Packet, signerpubkey *btcec.Publi
 
 		// check that every input has the signer's signature
 		var signerSig *psbt.TaprootScriptSpendSig
-
+		var signerPubkey *btcec.PublicKey
 		for _, sig := range signedInput.TaprootScriptSpendSig {
-			if bytes.Equal(sig.XOnlyPubKey, xonlySigner) {
+			pubkey, ok := signers[hex.EncodeToString(sig.XOnlyPubKey)]
+			if ok {
 				signerSig = sig
+				signerPubkey = pubkey
 				break
 			}
 		}
@@ -1046,7 +1046,7 @@ func verifyOffchainPsbt(original, signed *psbt.Packet, signerpubkey *btcec.Publi
 			return err
 		}
 
-		if !sig.Verify(message, signerpubkey) {
+		if !sig.Verify(message, signerPubkey) {
 			return fmt.Errorf("invalid signer signature for input %d", inputIndex)
 		}
 	}


### PR DESCRIPTION
## Summary

Backports deprecated signer support onto the current client-lib layout.

- store deprecated signer keys in client-lib config/state
- expose `Config.AllSigners()` for current + deprecated signer verification
- verify signed ark/checkpoint transactions against all configured signers
- add coverage for config persistence and signer set construction

## Why

During signer rotation, old VTXOs may still require server signatures from the deprecated signer while new outputs use the active signer. Verifying returned transactions against only `SignerPubKey` rejects valid migration transactions with `signer signature not found for input 0`.

@altafan please review.