### PR TITLE
Watch checkpoint scripts

### DIFF
--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -1287,4 +1287,3 @@ func buildExpiredToken(t *testing.T, privkey *btcec.PrivateKey, outpoints []Outp
 
 	return base64.StdEncoding.EncodeToString(append(msg, sig.Serialize()...))
 }
-

--- a/internal/core/application/indexer_exposure_test.go
+++ b/internal/core/application/indexer_exposure_test.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -13,7 +12,6 @@ import (
 	"time"
 
 	"github.com/arkade-os/arkd/internal/core/domain"
-	"github.com/arkade-os/arkd/internal/core/ports"
 	"github.com/arkade-os/arkd/pkg/ark-lib/intent"
 	arkscript "github.com/arkade-os/arkd/pkg/ark-lib/script"
 	arktree "github.com/arkade-os/arkd/pkg/ark-lib/tree"
@@ -1290,65 +1288,3 @@ func buildExpiredToken(t *testing.T, privkey *btcec.PrivateKey, outpoints []Outp
 	return base64.StdEncoding.EncodeToString(append(msg, sig.Serialize()...))
 }
 
-type mockedRoundRepo struct {
-	mock.Mock
-	domain.RoundRepository // unimplemented methods panic on call
-}
-
-func (m *mockedRoundRepo) GetTxsWithTxids(ctx context.Context, txids []string) ([]string, error) {
-	args := m.Called(ctx, txids)
-	if v := args.Get(0); v != nil {
-		return v.([]string), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
-func (m *mockedRoundRepo) GetRoundVtxoTree(ctx context.Context, txid string) (arktree.FlatTxTree, error) {
-	args := m.Called(ctx, txid)
-	if v := args.Get(0); v != nil {
-		return v.(arktree.FlatTxTree), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
-type mockedVtxoRepo struct {
-	mock.Mock
-	domain.VtxoRepository // unimplemented methods panic on call
-}
-
-func (m *mockedVtxoRepo) GetVtxos(ctx context.Context, outpoints []domain.Outpoint) ([]domain.Vtxo, error) {
-	args := m.Called(ctx, outpoints)
-	if v := args.Get(0); v != nil {
-		return v.([]domain.Vtxo), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-
-type mockedRepoManager struct {
-	mock.Mock
-	ports.RepoManager // unimplemented methods panic on call
-}
-
-func (m *mockedRepoManager) Rounds() domain.RoundRepository {
-	if v := m.Called().Get(0); v != nil {
-		return v.(domain.RoundRepository)
-	}
-	return nil
-}
-
-func (m *mockedRepoManager) Vtxos() domain.VtxoRepository {
-	if v := m.Called().Get(0); v != nil {
-		return v.(domain.VtxoRepository)
-	}
-	return nil
-}
-
-type mockedWallet struct {
-	mock.Mock
-	ports.WalletService // unimplemented methods panic on call
-}
-
-func (m *mockedWallet) GetTransaction(ctx context.Context, txid string) (string, error) {
-	args := m.Called(ctx, txid)
-	return args.String(0), args.Error(1)
-}

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -1,0 +1,181 @@
+package application
+
+import (
+	"context"
+	"sync"
+
+	"github.com/arkade-os/arkd/internal/core/domain"
+	"github.com/arkade-os/arkd/internal/core/ports"
+	arktree "github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockedRoundRepo struct {
+	mock.Mock
+	domain.RoundRepository // unimplemented methods panic on call
+}
+
+func (m *mockedRoundRepo) GetTxsWithTxids(ctx context.Context, txids []string) ([]string, error) {
+	args := m.Called(ctx, txids)
+	if v := args.Get(0); v != nil {
+		return v.([]string), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockedRoundRepo) GetRoundVtxoTree(ctx context.Context, txid string) (arktree.FlatTxTree, error) {
+	args := m.Called(ctx, txid)
+	if v := args.Get(0); v != nil {
+		return v.(arktree.FlatTxTree), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockedRoundRepo) GetSweepableRounds(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	if v := args.Get(0); v != nil {
+		return v.([]string), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+type mockedVtxoRepo struct {
+	mock.Mock
+	domain.VtxoRepository // unimplemented methods panic on call
+}
+
+func (m *mockedVtxoRepo) GetVtxos(ctx context.Context, outpoints []domain.Outpoint) ([]domain.Vtxo, error) {
+	args := m.Called(ctx, outpoints)
+	if v := args.Get(0); v != nil {
+		return v.([]domain.Vtxo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockedVtxoRepo) GetVtxoPubKeysByCommitmentTxids(
+	ctx context.Context, commitmentTxids []string, withMinimumAmount uint64,
+) ([]string, error) {
+	args := m.Called(ctx, commitmentTxids, withMinimumAmount)
+	if v := args.Get(0); v != nil {
+		return v.([]string), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *mockedVtxoRepo) GetCheckpointTxsByVtxoPubKeys(
+	ctx context.Context, pubkeys []string,
+) ([]domain.Tx, error) {
+	args := m.Called(ctx, pubkeys)
+	if v := args.Get(0); v != nil {
+		return v.([]domain.Tx), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+type mockedRepoManager struct {
+	mock.Mock
+	ports.RepoManager // unimplemented methods panic on call
+	// offchainTxHandler captures the handler registered via
+	// RegisterOffchainTxUpdateHandler so tests can dispatch it directly
+	// to exercise the inline closure in registerEventHandlers.
+	offchainTxHandler func(domain.OffchainTx)
+}
+
+func (m *mockedRepoManager) Rounds() domain.RoundRepository {
+	if v := m.Called().Get(0); v != nil {
+		return v.(domain.RoundRepository)
+	}
+	return nil
+}
+
+func (m *mockedRepoManager) Vtxos() domain.VtxoRepository {
+	if v := m.Called().Get(0); v != nil {
+		return v.(domain.VtxoRepository)
+	}
+	return nil
+}
+
+func (m *mockedRepoManager) RegisterOffchainTxUpdateHandler(h func(domain.OffchainTx)) {
+	m.offchainTxHandler = h
+}
+
+func (m *mockedRepoManager) RegisterBatchUpdateHandler(func(domain.Round)) {}
+
+func (m *mockedRepoManager) RegisterSettingsUpdateHandler(func(domain.Settings, []string)) {
+}
+
+type mockedWallet struct {
+	mock.Mock
+	ports.WalletService // unimplemented methods panic on call
+}
+
+func (m *mockedWallet) GetTransaction(ctx context.Context, txid string) (string, error) {
+	args := m.Called(ctx, txid)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockedWallet) GetDustAmount(ctx context.Context) (uint64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+// mockedScanner records every WatchScripts/UnwatchScripts payload across
+// calls so restore/stop tests can assert the full set of scripts handed to
+// the scanner, not just the args of one call.
+type mockedScanner struct {
+	mock.Mock
+	watched   []string
+	unwatched []string
+	mu        sync.Mutex
+}
+
+func (m *mockedScanner) WatchScripts(
+	ctx context.Context, scripts []string,
+) error {
+	m.mu.Lock()
+	m.watched = append(m.watched, scripts...)
+	m.mu.Unlock()
+	return m.Called(ctx, scripts).Error(0)
+}
+
+func (m *mockedScanner) UnwatchScripts(
+	ctx context.Context, scripts []string,
+) error {
+	m.mu.Lock()
+	m.unwatched = append(m.unwatched, scripts...)
+	m.mu.Unlock()
+	return m.Called(ctx, scripts).Error(0)
+}
+
+// Watched returns a copy of all scripts handed to WatchScripts across calls,
+// synchronized so tests that poll via require.Eventually do not race with
+// the goroutines the production code launches.
+func (m *mockedScanner) Watched() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.watched...)
+}
+
+// Unwatched is the UnwatchScripts counterpart of Watched.
+func (m *mockedScanner) Unwatched() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.unwatched...)
+}
+
+func (m *mockedScanner) GetNotificationChannel(
+	_ context.Context,
+) <-chan map[string][]ports.VtxoWithValue {
+	return nil
+}
+
+func (m *mockedScanner) IsTransactionConfirmed(
+	_ context.Context, _ string,
+) (bool, *ports.BlockTimestamp, error) {
+	return false, nil, nil
+}
+
+func (m *mockedScanner) RescanUtxos(_ context.Context, _ []wire.OutPoint) error {
+	return nil
+}

--- a/internal/core/application/script_watch_test.go
+++ b/internal/core/application/script_watch_test.go
@@ -1,0 +1,535 @@
+package application
+
+import (
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/internal/core/domain"
+	arkscript "github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// randomTapKey generates a valid 32-byte x-only pubkey as 64 hex chars.
+func randomTapKey(t *testing.T) string {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	return hex.EncodeToString(schnorr.SerializePubKey(priv.PubKey()))
+}
+
+// p2trScriptBytes returns the raw P2TR script bytes for a tapkey hex string.
+func p2trScriptBytes(t *testing.T, tapKeyHex string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(tapKeyHex)
+	require.NoError(t, err)
+	pk, err := schnorr.ParsePubKey(b)
+	require.NoError(t, err)
+	s, err := arkscript.P2TRScript(pk)
+	require.NoError(t, err)
+	return s
+}
+
+// checkpointPsbtB64 builds a base64 PSBT whose first (and only) output has
+// the given pkscript, matching the shape restore/stop parses from the DB.
+func checkpointPsbtB64(t *testing.T, firstOutputPkScript []byte) string {
+	t.Helper()
+	ptx, err := psbt.New(
+		[]*wire.OutPoint{{Hash: chainhash.Hash{}, Index: 0}},
+		[]*wire.TxOut{{Value: 1000, PkScript: firstOutputPkScript}},
+		3, 0,
+		[]uint32{wire.MaxTxInSequenceNum},
+	)
+	require.NoError(t, err)
+	b64, err := ptx.B64Encode()
+	require.NoError(t, err)
+	return b64
+}
+
+// arkTxPsbtB64 builds a base64 PSBT whose outputs are the given pkscripts.
+// decodeTx extracts vtxos from these outputs (PubKey = PkScript[2:]).
+func arkTxPsbtB64(t *testing.T, outputScripts [][]byte) string {
+	t.Helper()
+	outs := make([]*wire.TxOut, 0, len(outputScripts))
+	for _, s := range outputScripts {
+		outs = append(outs, &wire.TxOut{Value: 1000000, PkScript: s})
+	}
+	ptx, err := psbt.New(
+		[]*wire.OutPoint{{Hash: chainhash.Hash{}, Index: 0}},
+		outs,
+		3, 0,
+		[]uint32{wire.MaxTxInSequenceNum},
+	)
+	require.NoError(t, err)
+	b64, err := ptx.B64Encode()
+	require.NoError(t, err)
+	return b64
+}
+
+// vtxoScriptHex matches the service's fmt.Sprintf("5120%s", key) for vtxo
+// tapkeys.
+func vtxoScriptHex(tapKeyHex string) string {
+	return fmt.Sprintf("5120%s", tapKeyHex)
+}
+
+// ckptScriptHex matches the service's hex.EncodeToString(TxOut[0].PkScript)
+// for checkpoint txs.
+func ckptScriptHex(t *testing.T, tapKeyHex string) string {
+	t.Helper()
+	return hex.EncodeToString(p2trScriptBytes(t, tapKeyHex))
+}
+
+func TestRestoreWatchingVtxos(t *testing.T) {
+	t.Run("happy_path", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k2 := randomTapKey(t)
+		k3 := randomTapKey(t)
+		k4 := randomTapKey(t)
+
+		rounds := &mockedRoundRepo{}
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rounds.On("GetSweepableRounds", mock.Anything).Return([]string{"r1"}, nil)
+		vtxos.On("GetVtxoPubKeysByCommitmentTxids", mock.Anything, []string{"r1"}, uint64(0)).
+			Return([]string{k1, k2}, nil)
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, []string{k1, k2}).
+			Return([]domain.Tx{
+				{Txid: "txA", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k3))},
+				{Txid: "txB", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k4))},
+			}, nil)
+		rm.On("Rounds").Return(rounds)
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("WatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		require.NoError(t, svc.restoreWatchingVtxos())
+
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), vtxoScriptHex(k2),
+			ckptScriptHex(t, k3), ckptScriptHex(t, k4),
+		}, scn.Watched())
+		scn.AssertNumberOfCalls(t, "WatchScripts", 1)
+		vtxos.AssertNumberOfCalls(t, "GetCheckpointTxsByVtxoPubKeys", 1)
+	})
+
+	t.Run("no_sweepable_rounds", func(t *testing.T) {
+		rounds := &mockedRoundRepo{}
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rounds.On("GetSweepableRounds", mock.Anything).Return([]string{}, nil)
+		rm.On("Rounds").Return(rounds)
+		rm.On("Vtxos").Return(vtxos)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		require.NoError(t, svc.restoreWatchingVtxos())
+
+		require.Empty(t, scn.Watched())
+		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
+		vtxos.AssertNumberOfCalls(t, "GetVtxoPubKeysByCommitmentTxids", 0)
+		vtxos.AssertNumberOfCalls(t, "GetCheckpointTxsByVtxoPubKeys", 0)
+	})
+
+	t.Run("tapkeys_empty", func(t *testing.T) {
+		rounds := &mockedRoundRepo{}
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rounds.On("GetSweepableRounds", mock.Anything).Return([]string{"r1"}, nil)
+		vtxos.On("GetVtxoPubKeysByCommitmentTxids", mock.Anything, []string{"r1"}, uint64(0)).
+			Return([]string{}, nil)
+		rm.On("Rounds").Return(rounds)
+		rm.On("Vtxos").Return(vtxos)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		require.NoError(t, svc.restoreWatchingVtxos())
+
+		require.Empty(t, scn.Watched())
+		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
+		vtxos.AssertNumberOfCalls(t, "GetCheckpointTxsByVtxoPubKeys", 0)
+	})
+
+	t.Run("ckpt_fetch_err_soft_fail", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k2 := randomTapKey(t)
+
+		rounds := &mockedRoundRepo{}
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rounds.On("GetSweepableRounds", mock.Anything).Return([]string{"r1"}, nil)
+		vtxos.On("GetVtxoPubKeysByCommitmentTxids", mock.Anything, []string{"r1"}, uint64(0)).
+			Return([]string{k1, k2}, nil)
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("db down"))
+		rm.On("Rounds").Return(rounds)
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("WatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		require.NoError(t, svc.restoreWatchingVtxos())
+
+		// vtxo scripts still watched, no checkpoint scripts.
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), vtxoScriptHex(k2),
+		}, scn.Watched())
+		scn.AssertNumberOfCalls(t, "WatchScripts", 1)
+	})
+
+	t.Run("unparseable_ckpt_psbt_skipped", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k3 := randomTapKey(t)
+
+		rounds := &mockedRoundRepo{}
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rounds.On("GetSweepableRounds", mock.Anything).Return([]string{"r1"}, nil)
+		vtxos.On("GetVtxoPubKeysByCommitmentTxids", mock.Anything, []string{"r1"}, uint64(0)).
+			Return([]string{k1}, nil)
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, mock.Anything).
+			Return([]domain.Tx{
+				{Txid: "garbage", Str: "not-a-psbt"},
+				{Txid: "good", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k3))},
+			}, nil)
+		rm.On("Rounds").Return(rounds)
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("WatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		require.NoError(t, svc.restoreWatchingVtxos())
+
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), ckptScriptHex(t, k3),
+		}, scn.Watched())
+	})
+
+	t.Run("bad_tapkey_hex_filtered", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k3 := randomTapKey(t)
+		badKey := "abcd"
+
+		rounds := &mockedRoundRepo{}
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rounds.On("GetSweepableRounds", mock.Anything).Return([]string{"r1"}, nil)
+		vtxos.On("GetVtxoPubKeysByCommitmentTxids", mock.Anything, []string{"r1"}, uint64(0)).
+			Return([]string{badKey, k1}, nil)
+		// restore passes raw tapKeys (unfiltered) to the ckpt fetch.
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, []string{badKey, k1}).
+			Return([]domain.Tx{
+				{Txid: "txA", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k3))},
+			}, nil)
+		rm.On("Rounds").Return(rounds)
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("WatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		require.NoError(t, svc.restoreWatchingVtxos())
+
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), ckptScriptHex(t, k3),
+		}, scn.Watched())
+	})
+}
+
+func TestStopWatchingVtxos(t *testing.T) {
+	t.Run("happy_path", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k2 := randomTapKey(t)
+		k3 := randomTapKey(t)
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, []string{k1, k2}).
+			Return([]domain.Tx{
+				{Txid: "txA", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k3))},
+			}, nil)
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("UnwatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		svc.stopWatchingVtxos([]string{k1, k2})
+
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), vtxoScriptHex(k2), ckptScriptHex(t, k3),
+		}, scn.Unwatched())
+		scn.AssertNumberOfCalls(t, "UnwatchScripts", 1)
+	})
+
+	t.Run("ckpt_fetch_err_soft_fail", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k2 := randomTapKey(t)
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, mock.Anything).
+			Return(nil, fmt.Errorf("db down"))
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("UnwatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		svc.stopWatchingVtxos([]string{k1, k2})
+
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), vtxoScriptHex(k2),
+		}, scn.Unwatched())
+		scn.AssertNumberOfCalls(t, "UnwatchScripts", 1)
+	})
+
+	t.Run("empty_tapkeys", func(t *testing.T) {
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rm.On("Vtxos").Return(vtxos)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		svc.stopWatchingVtxos([]string{})
+
+		require.Empty(t, scn.Unwatched())
+		scn.AssertNumberOfCalls(t, "UnwatchScripts", 0)
+		vtxos.AssertNumberOfCalls(t, "GetCheckpointTxsByVtxoPubKeys", 0)
+	})
+
+	t.Run("unparseable_ckpt_psbt_skipped", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k3 := randomTapKey(t)
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, mock.Anything).
+			Return([]domain.Tx{
+				{Txid: "garbage", Str: "not-a-psbt"},
+				{Txid: "good", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k3))},
+			}, nil)
+		rm.On("Vtxos").Return(vtxos)
+		scn.On("UnwatchScripts", mock.Anything, mock.Anything).Return(nil)
+
+		svc := &service{repoManager: rm, scanner: scn}
+		svc.stopWatchingVtxos([]string{k1})
+
+		require.ElementsMatch(t, []string{
+			vtxoScriptHex(k1), ckptScriptHex(t, k3),
+		}, scn.Unwatched())
+	})
+
+	t.Run("unwatch_retries_then_succeeds", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		k3 := randomTapKey(t)
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		vtxos.On("GetCheckpointTxsByVtxoPubKeys", mock.Anything, mock.Anything).
+			Return([]domain.Tx{
+				{Txid: "txA", Str: checkpointPsbtB64(t, p2trScriptBytes(t, k3))},
+			}, nil)
+		rm.On("Vtxos").Return(vtxos)
+		// First call fails, second succeeds — retry loop sleeps 100ms then
+		// breaks.
+		scn.On("UnwatchScripts", mock.Anything, mock.Anything).
+			Return(fmt.Errorf("transient")).Once()
+		scn.On("UnwatchScripts", mock.Anything, mock.Anything).
+			Return(nil).Once()
+
+		svc := &service{repoManager: rm, scanner: scn}
+		svc.stopWatchingVtxos([]string{k1})
+
+		scn.AssertNumberOfCalls(t, "UnwatchScripts", 2)
+	})
+}
+
+// newFinalizedOffchainTx builds a finalized OffchainTx with the given ark tx
+// and checkpoint txs, replaying the Requested→Accepted→Finalized event chain.
+func newFinalizedOffchainTx(t *testing.T, arkTxid, arkPsbt string, checkpointTxs map[string]string) domain.OffchainTx {
+	t.Helper()
+	ckptTxids := make(map[string]string, len(checkpointTxs))
+	for txid := range checkpointTxs {
+		ckptTxids[txid] = "commitment_" + txid
+	}
+	return *domain.NewOffchainTxFromEvents([]domain.Event{
+		domain.OffchainTxRequested{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxRequested,
+			},
+			ArkTx:                 arkPsbt,
+			UnsignedCheckpointTxs: checkpointTxs,
+			StartingTimestamp:     time.Now().Unix(),
+		},
+		domain.OffchainTxAccepted{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxAccepted,
+			},
+			CommitmentTxids:     ckptTxids,
+			FinalArkTx:          arkPsbt,
+			SignedCheckpointTxs: checkpointTxs,
+			RootCommitmentTxid:  "root",
+			ExpiryTimestamp:     time.Now().Add(time.Hour).Unix(),
+		},
+		domain.OffchainTxFinalized{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxFinalized,
+			},
+			FinalCheckpointTxs: checkpointTxs,
+			Timestamp:          time.Now().Unix(),
+		},
+	})
+}
+
+// newAcceptedOffchainTx builds an accepted (non-finalized) OffchainTx.
+func newAcceptedOffchainTx(t *testing.T, arkTxid, arkPsbt string, checkpointTxs map[string]string) domain.OffchainTx {
+	t.Helper()
+	ckptTxids := make(map[string]string, len(checkpointTxs))
+	for txid := range checkpointTxs {
+		ckptTxids[txid] = "commitment_" + txid
+	}
+	return *domain.NewOffchainTxFromEvents([]domain.Event{
+		domain.OffchainTxRequested{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxRequested,
+			},
+			ArkTx:                 arkPsbt,
+			UnsignedCheckpointTxs: checkpointTxs,
+			StartingTimestamp:     time.Now().Unix(),
+		},
+		domain.OffchainTxAccepted{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxAccepted,
+			},
+			CommitmentTxids:     ckptTxids,
+			FinalArkTx:          arkPsbt,
+			SignedCheckpointTxs: checkpointTxs,
+			RootCommitmentTxid:  "root",
+			ExpiryTimestamp:     time.Now().Add(time.Hour).Unix(),
+		},
+	})
+}
+
+func TestOffchainTxHandler_WatchesCheckpointScripts(t *testing.T) {
+	t.Run("finalized_tx_watches_checkpoint_and_vtxo_scripts", func(t *testing.T) {
+		k1 := randomTapKey(t) // vtxo owner (ark tx output)
+		k2 := randomTapKey(t) // checkpoint output recipient
+
+		arkPsbt := arkTxPsbtB64(t, [][]byte{p2trScriptBytes(t, k1)})
+		ckptPsbt := checkpointPsbtB64(t, p2trScriptBytes(t, k2))
+		ckptTxid := "checkpoint_txid_1"
+		arkTxid := "ark_txid_1"
+
+		offchainTx := newFinalizedOffchainTx(t, arkTxid, arkPsbt,
+			map[string]string{ckptTxid: ckptPsbt})
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+		wallet := &mockedWallet{}
+
+		vtxos.On("GetVtxos", mock.Anything, mock.Anything).
+			Return([]domain.Vtxo{}, nil)
+		wallet.On("GetDustAmount", mock.Anything).Return(uint64(330), nil)
+		scn.On("WatchScripts", mock.Anything, mock.Anything).Return(nil)
+		rm.On("Vtxos").Return(vtxos)
+
+		svc := &service{
+			repoManager:         rm,
+			scanner:             scn,
+			wallet:              wallet,
+			transactionEventsCh: make(chan TransactionEvent, 64),
+			indexerTxEventsCh:   make(chan TransactionEvent, 64),
+			wg:                  &sync.WaitGroup{},
+			offchainTxMu:        &sync.Mutex{},
+		}
+		svc.registerEventHandlers()
+		rm.offchainTxHandler(offchainTx)
+
+		expectedCkptScript := ckptScriptHex(t, k2)
+		expectedVtxoScript := vtxoScriptHex(k1)
+		require.Eventually(t, func() bool {
+			return slices.Contains(scn.Watched(), expectedCkptScript) &&
+				slices.Contains(scn.Watched(), expectedVtxoScript)
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("non_finalized_tx_early_return", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		arkPsbt := arkTxPsbtB64(t, [][]byte{p2trScriptBytes(t, k1)})
+		ckptPsbt := checkpointPsbtB64(t, p2trScriptBytes(t, randomTapKey(t)))
+
+		offchainTx := newAcceptedOffchainTx(t, "ark_txid_2", arkPsbt,
+			map[string]string{"ckpt_2": ckptPsbt})
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rm.On("Vtxos").Return(vtxos)
+
+		svc := &service{
+			repoManager:         rm,
+			scanner:             scn,
+			transactionEventsCh: make(chan TransactionEvent, 64),
+			indexerTxEventsCh:   make(chan TransactionEvent, 64),
+			wg:                  &sync.WaitGroup{},
+			offchainTxMu:        &sync.Mutex{},
+		}
+		svc.registerEventHandlers()
+		rm.offchainTxHandler(offchainTx)
+
+		require.Empty(t, scn.Watched())
+		vtxos.AssertNumberOfCalls(t, "GetVtxos", 0)
+		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
+	})
+
+	t.Run("bad_checkpoint_psbt_decode_err", func(t *testing.T) {
+		k1 := randomTapKey(t)
+		arkPsbt := arkTxPsbtB64(t, [][]byte{p2trScriptBytes(t, k1)})
+
+		offchainTx := newFinalizedOffchainTx(t, "ark_txid_3", arkPsbt,
+			map[string]string{"ckpt_3": "not-a-psbt"})
+
+		vtxos := &mockedVtxoRepo{}
+		rm := &mockedRepoManager{}
+		scn := &mockedScanner{}
+
+		rm.On("Vtxos").Return(vtxos)
+
+		svc := &service{
+			repoManager:         rm,
+			scanner:             scn,
+			transactionEventsCh: make(chan TransactionEvent, 64),
+			indexerTxEventsCh:   make(chan TransactionEvent, 64),
+			wg:                  &sync.WaitGroup{},
+			offchainTxMu:        &sync.Mutex{},
+		}
+		svc.registerEventHandlers()
+		rm.offchainTxHandler(offchainTx)
+
+		require.Empty(t, scn.Watched())
+		vtxos.AssertNumberOfCalls(t, "GetVtxos", 0)
+		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
+	})
+}

--- a/internal/core/application/script_watch_test.go
+++ b/internal/core/application/script_watch_test.go
@@ -19,75 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// randomTapKey generates a valid 32-byte x-only pubkey as 64 hex chars.
-func randomTapKey(t *testing.T) string {
-	t.Helper()
-	priv, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-	return hex.EncodeToString(schnorr.SerializePubKey(priv.PubKey()))
-}
-
-// p2trScriptBytes returns the raw P2TR script bytes for a tapkey hex string.
-func p2trScriptBytes(t *testing.T, tapKeyHex string) []byte {
-	t.Helper()
-	b, err := hex.DecodeString(tapKeyHex)
-	require.NoError(t, err)
-	pk, err := schnorr.ParsePubKey(b)
-	require.NoError(t, err)
-	s, err := arkscript.P2TRScript(pk)
-	require.NoError(t, err)
-	return s
-}
-
-// checkpointPsbtB64 builds a base64 PSBT whose first (and only) output has
-// the given pkscript, matching the shape restore/stop parses from the DB.
-func checkpointPsbtB64(t *testing.T, firstOutputPkScript []byte) string {
-	t.Helper()
-	ptx, err := psbt.New(
-		[]*wire.OutPoint{{Hash: chainhash.Hash{}, Index: 0}},
-		[]*wire.TxOut{{Value: 1000, PkScript: firstOutputPkScript}},
-		3, 0,
-		[]uint32{wire.MaxTxInSequenceNum},
-	)
-	require.NoError(t, err)
-	b64, err := ptx.B64Encode()
-	require.NoError(t, err)
-	return b64
-}
-
-// arkTxPsbtB64 builds a base64 PSBT whose outputs are the given pkscripts.
-// decodeTx extracts vtxos from these outputs (PubKey = PkScript[2:]).
-func arkTxPsbtB64(t *testing.T, outputScripts [][]byte) string {
-	t.Helper()
-	outs := make([]*wire.TxOut, 0, len(outputScripts))
-	for _, s := range outputScripts {
-		outs = append(outs, &wire.TxOut{Value: 1000000, PkScript: s})
-	}
-	ptx, err := psbt.New(
-		[]*wire.OutPoint{{Hash: chainhash.Hash{}, Index: 0}},
-		outs,
-		3, 0,
-		[]uint32{wire.MaxTxInSequenceNum},
-	)
-	require.NoError(t, err)
-	b64, err := ptx.B64Encode()
-	require.NoError(t, err)
-	return b64
-}
-
-// vtxoScriptHex matches the service's fmt.Sprintf("5120%s", key) for vtxo
-// tapkeys.
-func vtxoScriptHex(tapKeyHex string) string {
-	return fmt.Sprintf("5120%s", tapKeyHex)
-}
-
-// ckptScriptHex matches the service's hex.EncodeToString(TxOut[0].PkScript)
-// for checkpoint txs.
-func ckptScriptHex(t *testing.T, tapKeyHex string) string {
-	t.Helper()
-	return hex.EncodeToString(p2trScriptBytes(t, tapKeyHex))
-}
-
 func TestRestoreWatchingVtxos(t *testing.T) {
 	t.Run("happy_path", func(t *testing.T) {
 		k1 := randomTapKey(t)
@@ -364,72 +295,6 @@ func TestStopWatchingVtxos(t *testing.T) {
 	})
 }
 
-// newFinalizedOffchainTx builds a finalized OffchainTx with the given ark tx
-// and checkpoint txs, replaying the Requested→Accepted→Finalized event chain.
-func newFinalizedOffchainTx(t *testing.T, arkTxid, arkPsbt string, checkpointTxs map[string]string) domain.OffchainTx {
-	t.Helper()
-	ckptTxids := make(map[string]string, len(checkpointTxs))
-	for txid := range checkpointTxs {
-		ckptTxids[txid] = "commitment_" + txid
-	}
-	return *domain.NewOffchainTxFromEvents([]domain.Event{
-		domain.OffchainTxRequested{
-			OffchainTxEvent: domain.OffchainTxEvent{
-				Id: arkTxid, Type: domain.EventTypeOffchainTxRequested,
-			},
-			ArkTx:                 arkPsbt,
-			UnsignedCheckpointTxs: checkpointTxs,
-			StartingTimestamp:     time.Now().Unix(),
-		},
-		domain.OffchainTxAccepted{
-			OffchainTxEvent: domain.OffchainTxEvent{
-				Id: arkTxid, Type: domain.EventTypeOffchainTxAccepted,
-			},
-			CommitmentTxids:     ckptTxids,
-			FinalArkTx:          arkPsbt,
-			SignedCheckpointTxs: checkpointTxs,
-			RootCommitmentTxid:  "root",
-			ExpiryTimestamp:     time.Now().Add(time.Hour).Unix(),
-		},
-		domain.OffchainTxFinalized{
-			OffchainTxEvent: domain.OffchainTxEvent{
-				Id: arkTxid, Type: domain.EventTypeOffchainTxFinalized,
-			},
-			FinalCheckpointTxs: checkpointTxs,
-			Timestamp:          time.Now().Unix(),
-		},
-	})
-}
-
-// newAcceptedOffchainTx builds an accepted (non-finalized) OffchainTx.
-func newAcceptedOffchainTx(t *testing.T, arkTxid, arkPsbt string, checkpointTxs map[string]string) domain.OffchainTx {
-	t.Helper()
-	ckptTxids := make(map[string]string, len(checkpointTxs))
-	for txid := range checkpointTxs {
-		ckptTxids[txid] = "commitment_" + txid
-	}
-	return *domain.NewOffchainTxFromEvents([]domain.Event{
-		domain.OffchainTxRequested{
-			OffchainTxEvent: domain.OffchainTxEvent{
-				Id: arkTxid, Type: domain.EventTypeOffchainTxRequested,
-			},
-			ArkTx:                 arkPsbt,
-			UnsignedCheckpointTxs: checkpointTxs,
-			StartingTimestamp:     time.Now().Unix(),
-		},
-		domain.OffchainTxAccepted{
-			OffchainTxEvent: domain.OffchainTxEvent{
-				Id: arkTxid, Type: domain.EventTypeOffchainTxAccepted,
-			},
-			CommitmentTxids:     ckptTxids,
-			FinalArkTx:          arkPsbt,
-			SignedCheckpointTxs: checkpointTxs,
-			RootCommitmentTxid:  "root",
-			ExpiryTimestamp:     time.Now().Add(time.Hour).Unix(),
-		},
-	})
-}
-
 func TestOffchainTxHandler_WatchesCheckpointScripts(t *testing.T) {
 	t.Run("finalized_tx_watches_checkpoint_and_vtxo_scripts", func(t *testing.T) {
 		k1 := randomTapKey(t) // vtxo owner (ark tx output)
@@ -502,5 +367,140 @@ func TestOffchainTxHandler_WatchesCheckpointScripts(t *testing.T) {
 		require.Empty(t, scn.Watched())
 		vtxos.AssertNumberOfCalls(t, "GetVtxos", 0)
 		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
+	})
+}
+
+// randomTapKey generates a valid 32-byte x-only pubkey as 64 hex chars.
+func randomTapKey(t *testing.T) string {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	return hex.EncodeToString(schnorr.SerializePubKey(priv.PubKey()))
+}
+
+// p2trScriptBytes returns the raw P2TR script bytes for a tapkey hex string.
+func p2trScriptBytes(t *testing.T, tapKeyHex string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(tapKeyHex)
+	require.NoError(t, err)
+	pk, err := schnorr.ParsePubKey(b)
+	require.NoError(t, err)
+	s, err := arkscript.P2TRScript(pk)
+	require.NoError(t, err)
+	return s
+}
+
+// checkpointPsbtB64 builds a base64 PSBT whose first (and only) output has
+// the given pkscript, matching the shape restore/stop parses from the DB.
+func checkpointPsbtB64(t *testing.T, firstOutputPkScript []byte) string {
+	t.Helper()
+	ptx, err := psbt.New(
+		[]*wire.OutPoint{{Hash: chainhash.Hash{}, Index: 0}},
+		[]*wire.TxOut{{Value: 1000, PkScript: firstOutputPkScript}},
+		3, 0,
+		[]uint32{wire.MaxTxInSequenceNum},
+	)
+	require.NoError(t, err)
+	b64, err := ptx.B64Encode()
+	require.NoError(t, err)
+	return b64
+}
+
+// arkTxPsbtB64 builds a base64 PSBT whose outputs are the given pkscripts.
+// decodeTx extracts vtxos from these outputs (PubKey = PkScript[2:]).
+func arkTxPsbtB64(t *testing.T, outputScripts [][]byte) string {
+	t.Helper()
+	outs := make([]*wire.TxOut, 0, len(outputScripts))
+	for _, s := range outputScripts {
+		outs = append(outs, &wire.TxOut{Value: 1000000, PkScript: s})
+	}
+	ptx, err := psbt.New(
+		[]*wire.OutPoint{{Hash: chainhash.Hash{}, Index: 0}},
+		outs,
+		3, 0,
+		[]uint32{wire.MaxTxInSequenceNum},
+	)
+	require.NoError(t, err)
+	b64, err := ptx.B64Encode()
+	require.NoError(t, err)
+	return b64
+}
+
+// vtxoScriptHex matches the service's fmt.Sprintf("5120%s", key) for vtxo
+// tapkeys.
+func vtxoScriptHex(tapKeyHex string) string {
+	return fmt.Sprintf("5120%s", tapKeyHex)
+}
+
+// ckptScriptHex matches the service's hex.EncodeToString(TxOut[0].PkScript)
+// for checkpoint txs.
+func ckptScriptHex(t *testing.T, tapKeyHex string) string {
+	t.Helper()
+	return hex.EncodeToString(p2trScriptBytes(t, tapKeyHex))
+}
+
+// newFinalizedOffchainTx builds a finalized OffchainTx with the given ark tx
+// and checkpoint txs, replaying the Requested→Accepted→Finalized event chain.
+func newFinalizedOffchainTx(t *testing.T, arkTxid, arkPsbt string, checkpointTxs map[string]string) domain.OffchainTx {
+	t.Helper()
+	ckptTxids := make(map[string]string, len(checkpointTxs))
+	for txid := range checkpointTxs {
+		ckptTxids[txid] = "commitment_" + txid
+	}
+	return *domain.NewOffchainTxFromEvents([]domain.Event{
+		domain.OffchainTxRequested{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxRequested,
+			},
+			ArkTx:                 arkPsbt,
+			UnsignedCheckpointTxs: checkpointTxs,
+			StartingTimestamp:     time.Now().Unix(),
+		},
+		domain.OffchainTxAccepted{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxAccepted,
+			},
+			CommitmentTxids:     ckptTxids,
+			FinalArkTx:          arkPsbt,
+			SignedCheckpointTxs: checkpointTxs,
+			RootCommitmentTxid:  "root",
+			ExpiryTimestamp:     time.Now().Add(time.Hour).Unix(),
+		},
+		domain.OffchainTxFinalized{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxFinalized,
+			},
+			FinalCheckpointTxs: checkpointTxs,
+			Timestamp:          time.Now().Unix(),
+		},
+	})
+}
+
+// newAcceptedOffchainTx builds an accepted (non-finalized) OffchainTx.
+func newAcceptedOffchainTx(t *testing.T, arkTxid, arkPsbt string, checkpointTxs map[string]string) domain.OffchainTx {
+	t.Helper()
+	ckptTxids := make(map[string]string, len(checkpointTxs))
+	for txid := range checkpointTxs {
+		ckptTxids[txid] = "commitment_" + txid
+	}
+	return *domain.NewOffchainTxFromEvents([]domain.Event{
+		domain.OffchainTxRequested{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxRequested,
+			},
+			ArkTx:                 arkPsbt,
+			UnsignedCheckpointTxs: checkpointTxs,
+			StartingTimestamp:     time.Now().Unix(),
+		},
+		domain.OffchainTxAccepted{
+			OffchainTxEvent: domain.OffchainTxEvent{
+				Id: arkTxid, Type: domain.EventTypeOffchainTxAccepted,
+			},
+			CommitmentTxids:     ckptTxids,
+			FinalArkTx:          arkPsbt,
+			SignedCheckpointTxs: checkpointTxs,
+			RootCommitmentTxid:  "root",
+			ExpiryTimestamp:     time.Now().Add(time.Hour).Unix(),
+		},
 	})
 }

--- a/internal/core/application/script_watch_test.go
+++ b/internal/core/application/script_watch_test.go
@@ -503,33 +503,4 @@ func TestOffchainTxHandler_WatchesCheckpointScripts(t *testing.T) {
 		vtxos.AssertNumberOfCalls(t, "GetVtxos", 0)
 		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
 	})
-
-	t.Run("bad_checkpoint_psbt_decode_err", func(t *testing.T) {
-		k1 := randomTapKey(t)
-		arkPsbt := arkTxPsbtB64(t, [][]byte{p2trScriptBytes(t, k1)})
-
-		offchainTx := newFinalizedOffchainTx(t, "ark_txid_3", arkPsbt,
-			map[string]string{"ckpt_3": "not-a-psbt"})
-
-		vtxos := &mockedVtxoRepo{}
-		rm := &mockedRepoManager{}
-		scn := &mockedScanner{}
-
-		rm.On("Vtxos").Return(vtxos)
-
-		svc := &service{
-			repoManager:         rm,
-			scanner:             scn,
-			transactionEventsCh: make(chan TransactionEvent, 64),
-			indexerTxEventsCh:   make(chan TransactionEvent, 64),
-			wg:                  &sync.WaitGroup{},
-			offchainTxMu:        &sync.Mutex{},
-		}
-		svc.registerEventHandlers()
-		rm.offchainTxHandler(offchainTx)
-
-		require.Empty(t, scn.Watched())
-		vtxos.AssertNumberOfCalls(t, "GetVtxos", 0)
-		scn.AssertNumberOfCalls(t, "WatchScripts", 0)
-	})
 }

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -322,12 +322,18 @@ func (s *service) registerEventHandlers() {
 			}
 
 			checkpointTxsByOutpoint := make(map[string]TxData)
+			checkpointScripts := make([]string, 0, len(offchainTx.CheckpointTxs))
 			for txid, tx := range offchainTx.CheckpointTxs {
 				// nolint
 				ptx, _ := psbt.NewFromRawBytes(strings.NewReader(tx), true)
 				checkpointTxsByOutpoint[ptx.UnsignedTx.TxIn[0].PreviousOutPoint.String()] = TxData{
 					Tx: tx, Txid: txid,
 				}
+				script := hex.EncodeToString(ptx.UnsignedTx.TxOut[0].PkScript)
+				checkpointScripts = append(
+					checkpointScripts,
+					script,
+				)
 			}
 
 			txEvent := TransactionEvent{
@@ -343,6 +349,14 @@ func (s *service) registerEventHandlers() {
 			go func() {
 				if err := s.startWatchingVtxos(newVtxos); err != nil {
 					log.WithError(err).Warn("failed to start watching vtxos")
+				}
+			}()
+
+			go func() {
+				if err := s.scanner.WatchScripts(
+					context.Background(), checkpointScripts,
+				); err != nil {
+					log.WithError(err).Warn("failed to start watching checkpoints")
 				}
 			}()
 		},

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -3745,19 +3745,12 @@ func (s *service) restoreWatchingVtxos() error {
 	}
 
 	if len(tapKeys) > 0 {
-		// Fetch the finalized checkpoint txs that spent these sweepable
-		// vtxos and watch their first output's pkscript too, so the
-		// scanner resumes detecting onchain broadcast of those
-		// checkpoints. Soft-fail: a DB error here must not block startup,
-		// the next offchain tx event re-adds any missing checkpoint
-		// scripts via the inline handler at registerEventHandlers.
+		// Also watch finalized checkpoint txs' first output so we detect
+		// onchain broadcast. Soft-fail: a DB error must not block startup
 		checkpointTxs, err := s.repoManager.Vtxos().
 			GetCheckpointTxsByVtxoPubKeys(ctx, tapKeys)
 		if err != nil {
-			log.WithError(err).Warn(
-				"failed to fetch checkpoint txs for restore; " +
-					"checkpoint scripts re-added on next offchain tx event",
-			)
+			log.WithError(err).Warn("failed to fetch checkpoint txs for restore")
 		} else {
 			scripts = append(scripts, checkpointOutputScripts(checkpointTxs)...)
 		}
@@ -3786,11 +3779,8 @@ func (s *service) stopWatchingVtxos(tapkeys []string) {
 	}
 
 	if len(tapkeys) > 0 {
-		// Mirror restoreWatchingVtxos: also unwatch the first output of
-		// every finalized checkpoint tx that spent these sweepable
-		// vtxos. Soft-fail so a DB glitch on shutdown does not spin the
-		// retry loop forever; the wallet keeps watching those scripts
-		// until the next restart's restoreWatchingVtxos re-syncs.
+		// Also unwatch finalized checkpoint txs' first output. Soft-fail:
+		// a DB glitch on shutdown leaves the scanner watching
 		checkpointTxs, err := s.repoManager.Vtxos().
 			GetCheckpointTxsByVtxoPubKeys(context.Background(), tapkeys)
 		if err != nil {

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -3690,6 +3690,21 @@ func (s *service) startWatchingVtxos(vtxos []domain.Vtxo) error {
 	return s.scanner.WatchScripts(context.Background(), scripts)
 }
 
+// checkpointOutputScripts parses each checkpoint tx PSBT and returns the
+// hex-encoded pkscript of its first output. Corrupted rows are skipped so a
+// single bad PSBT cannot abort restore/shutdown.
+func checkpointOutputScripts(txs []domain.Tx) []string {
+	scripts := make([]string, 0, len(txs))
+	for _, tx := range txs {
+		ptx, err := psbt.NewFromRawBytes(strings.NewReader(tx.Str), true)
+		if err != nil || len(ptx.UnsignedTx.TxOut) == 0 {
+			continue
+		}
+		scripts = append(scripts, hex.EncodeToString(ptx.UnsignedTx.TxOut[0].PkScript))
+	}
+	return scripts
+}
+
 // restoreWatchingVtxos re-registers every sweepable round's vtxo pubkeys
 // with the chain scanner so we resume receiving notifications after a
 // restart. The pubkey lookup uses the bulk repo method
@@ -3729,6 +3744,25 @@ func (s *service) restoreWatchingVtxos() error {
 		scripts = append(scripts, fmt.Sprintf("5120%s", key))
 	}
 
+	if len(tapKeys) > 0 {
+		// Fetch the finalized checkpoint txs that spent these sweepable
+		// vtxos and watch their first output's pkscript too, so the
+		// scanner resumes detecting onchain broadcast of those
+		// checkpoints. Soft-fail: a DB error here must not block startup,
+		// the next offchain tx event re-adds any missing checkpoint
+		// scripts via the inline handler at registerEventHandlers.
+		checkpointTxs, err := s.repoManager.Vtxos().
+			GetCheckpointTxsByVtxoPubKeys(ctx, tapKeys)
+		if err != nil {
+			log.WithError(err).Warn(
+				"failed to fetch checkpoint txs for restore; " +
+					"checkpoint scripts re-added on next offchain tx event",
+			)
+		} else {
+			scripts = append(scripts, checkpointOutputScripts(checkpointTxs)...)
+		}
+	}
+
 	if len(scripts) == 0 {
 		return nil
 	}
@@ -3738,7 +3772,7 @@ func (s *service) restoreWatchingVtxos() error {
 	}
 
 	log.Debugf(
-		"restored watching %d vtxo scripts from %d sweepable rounds",
+		"restored watching %d scripts (vtxo + checkpoint) from %d sweepable rounds",
 		len(scripts), len(commitmentTxIds),
 	)
 	return nil
@@ -3751,6 +3785,23 @@ func (s *service) stopWatchingVtxos(tapkeys []string) {
 		scripts = append(scripts, fmt.Sprintf("5120%s", key))
 	}
 
+	if len(tapkeys) > 0 {
+		// Mirror restoreWatchingVtxos: also unwatch the first output of
+		// every finalized checkpoint tx that spent these sweepable
+		// vtxos. Soft-fail so a DB glitch on shutdown does not spin the
+		// retry loop forever; the wallet keeps watching those scripts
+		// until the next restart's restoreWatchingVtxos re-syncs.
+		checkpointTxs, err := s.repoManager.Vtxos().
+			GetCheckpointTxsByVtxoPubKeys(context.Background(), tapkeys)
+		if err != nil {
+			log.WithError(err).Warn(
+				"failed to fetch checkpoint txs for shutdown unwatch",
+			)
+		} else {
+			scripts = append(scripts, checkpointOutputScripts(checkpointTxs)...)
+		}
+	}
+
 	if len(scripts) <= 0 {
 		return
 	}
@@ -3761,7 +3812,7 @@ func (s *service) stopWatchingVtxos(tapkeys []string) {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		}
-		log.Debugf("stopped watching %d vtxo scripts", len(tapkeys))
+		log.Debugf("stopped watching %d scripts (vtxo + checkpoint)", len(scripts))
 		break
 	}
 }

--- a/internal/core/application/utils_test.go
+++ b/internal/core/application/utils_test.go
@@ -335,4 +335,3 @@ func mustEncodePSBTB64(t *testing.T, tx *wire.MsgTx) string {
 	require.NoError(t, err)
 	return b64
 }
-

--- a/internal/core/domain/vtxo_repo.go
+++ b/internal/core/domain/vtxo_repo.go
@@ -21,6 +21,7 @@ type VtxoRepository interface {
 	GetRecoverableLiquidity(ctx context.Context) (uint64, error)
 	UpdateVtxosExpiration(ctx context.Context, outpoints []Outpoint, expiresAt int64) error
 	GetLeafVtxosForBatch(ctx context.Context, txid string) ([]Vtxo, error)
+	GetCheckpointTxsByVtxoPubKeys(ctx context.Context, pubkeys []string) ([]Tx, error)
 	GetSweepableVtxosByCommitmentTxid(
 		ctx context.Context, commitmentTxid string,
 	) ([]Outpoint, error)

--- a/internal/infrastructure/db/badger/ark_repo.go
+++ b/internal/infrastructure/db/badger/ark_repo.go
@@ -22,6 +22,7 @@ type arkRepository struct {
 type ArkRepository interface {
 	domain.RoundRepository
 	domain.OffchainTxRepository
+	Store() *badgerhold.Store
 }
 
 type IntentIndex struct {
@@ -287,8 +288,12 @@ func (r *arkRepository) GetOffchainTx(
 }
 
 func (r *arkRepository) Close() {
-	// nolint
+	// nolint:all
 	r.store.Close()
+}
+
+func (r *arkRepository) Store() *badgerhold.Store {
+	return r.store
 }
 
 func (r *arkRepository) findRound(

--- a/internal/infrastructure/db/badger/vtxo_repo.go
+++ b/internal/infrastructure/db/badger/vtxo_repo.go
@@ -17,8 +17,8 @@ import (
 const vtxoStoreDir = "vtxos"
 
 type vtxoRepository struct {
-	store     *badgerhold.Store
-	arkStore  *badgerhold.Store
+	store    *badgerhold.Store
+	arkStore *badgerhold.Store
 }
 
 type vtxoDTO struct {

--- a/internal/infrastructure/db/badger/vtxo_repo.go
+++ b/internal/infrastructure/db/badger/vtxo_repo.go
@@ -17,7 +17,8 @@ import (
 const vtxoStoreDir = "vtxos"
 
 type vtxoRepository struct {
-	store *badgerhold.Store
+	store     *badgerhold.Store
+	arkStore  *badgerhold.Store
 }
 
 type vtxoDTO struct {
@@ -26,7 +27,7 @@ type vtxoDTO struct {
 }
 
 func NewVtxoRepository(config ...interface{}) (domain.VtxoRepository, error) {
-	if len(config) != 2 {
+	if len(config) != 2 && len(config) != 3 {
 		return nil, fmt.Errorf("invalid config")
 	}
 	baseDir, ok := config[0].(string)
@@ -40,6 +41,13 @@ func NewVtxoRepository(config ...interface{}) (domain.VtxoRepository, error) {
 			return nil, fmt.Errorf("invalid logger")
 		}
 	}
+	var arkStore *badgerhold.Store
+	if len(config) == 3 && config[2] != nil {
+		arkStore, ok = config[2].(*badgerhold.Store)
+		if !ok {
+			return nil, fmt.Errorf("invalid ark store")
+		}
+	}
 
 	var dir string
 	if len(baseDir) > 0 {
@@ -50,7 +58,7 @@ func NewVtxoRepository(config ...interface{}) (domain.VtxoRepository, error) {
 		return nil, fmt.Errorf("failed to open round events store: %s", err)
 	}
 
-	return &vtxoRepository{store}, nil
+	return &vtxoRepository{store: store, arkStore: arkStore}, nil
 }
 
 func (r *vtxoRepository) AddVtxos(
@@ -421,7 +429,61 @@ func (r *vtxoRepository) GetVtxoPubKeysByCommitmentTxids(
 func (r *vtxoRepository) GetCheckpointTxsByVtxoPubKeys(
 	ctx context.Context, pubkeys []string,
 ) ([]domain.Tx, error) {
-	return nil, nil
+	if len(pubkeys) == 0 {
+		return nil, nil
+	}
+	if r.arkStore == nil {
+		return nil, fmt.Errorf("ark store not configured")
+	}
+
+	idxIfaces := make([]interface{}, len(pubkeys))
+	for i, pk := range pubkeys {
+		idxIfaces[i] = pk
+	}
+
+	query := badgerhold.Where("PubKey").In(idxIfaces...).And("Swept").Eq(false)
+	vtxos, err := r.findVtxos(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	// Group vtxos by ArkTxid so each offchain tx is fetched once. Skip vtxos
+	// without a SpentBy checkpoint or an ArkTxid link; they can't join to a
+	// finalized offchain tx (mirrors SQL inner-join excludes).
+	byArkTxid := make(map[string][]domain.Vtxo)
+	for _, v := range vtxos {
+		if v.SpentBy == "" || v.ArkTxid == "" {
+			continue
+		}
+		byArkTxid[v.ArkTxid] = append(byArkTxid[v.ArkTxid], v)
+	}
+
+	dedup := make(map[string]domain.Tx)
+	for arkTxid, group := range byArkTxid {
+		var offchainTx domain.OffchainTx
+		if err := r.arkStore.Get(arkTxid, &offchainTx); err != nil {
+			if err == badgerhold.ErrNotFound {
+				continue
+			}
+			return nil, err
+		}
+		if offchainTx.Stage.Code != int(domain.OffchainTxFinalizedStage) {
+			continue
+		}
+		for _, v := range group {
+			data, ok := offchainTx.CheckpointTxs[v.SpentBy]
+			if !ok {
+				continue
+			}
+			dedup[v.SpentBy] = domain.Tx{Txid: v.SpentBy, Str: data}
+		}
+	}
+
+	txs := make([]domain.Tx, 0, len(dedup))
+	for _, tx := range dedup {
+		txs = append(txs, tx)
+	}
+	return txs, nil
 }
 
 func (r *vtxoRepository) GetPendingSpentVtxosWithPubKeys(

--- a/internal/infrastructure/db/badger/vtxo_repo.go
+++ b/internal/infrastructure/db/badger/vtxo_repo.go
@@ -418,6 +418,12 @@ func (r *vtxoRepository) GetVtxoPubKeysByCommitmentTxids(
 	return taprootKeys, nil
 }
 
+func (r *vtxoRepository) GetCheckpointTxsByVtxoPubKeys(
+	ctx context.Context, pubkeys []string,
+) ([]domain.Tx, error) {
+	return nil, nil
+}
+
 func (r *vtxoRepository) GetPendingSpentVtxosWithPubKeys(
 	ctx context.Context, pubkeys []string, after, before int64,
 ) ([]domain.Vtxo, error) {

--- a/internal/infrastructure/db/postgres/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/db/postgres/sqlc/queries/query.sql.go
@@ -325,6 +325,44 @@ func (q *Queries) SelectAssetsWithUnspentAmountsByIds(ctx context.Context, dolla
 	return items, nil
 }
 
+const selectCheckpointTxsByVtxoPubKeys = `-- name: SelectCheckpointTxsByVtxoPubKeys :many
+SELECT DISTINCT c.txid, c.tx AS data
+FROM vtxo v
+JOIN checkpoint_tx c ON c.txid = v.spent_by
+JOIN offchain_tx o ON o.txid = c.offchain_txid
+WHERE v.pubkey = ANY($1::text[])
+  AND v.swept = false
+  AND o.stage_code = 3
+`
+
+type SelectCheckpointTxsByVtxoPubKeysRow struct {
+	Txid string
+	Data string
+}
+
+func (q *Queries) SelectCheckpointTxsByVtxoPubKeys(ctx context.Context, pubkeys []string) ([]SelectCheckpointTxsByVtxoPubKeysRow, error) {
+	rows, err := q.db.QueryContext(ctx, selectCheckpointTxsByVtxoPubKeys, pq.Array(pubkeys))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectCheckpointTxsByVtxoPubKeysRow
+	for rows.Next() {
+		var i SelectCheckpointTxsByVtxoPubKeysRow
+		if err := rows.Scan(&i.Txid, &i.Data); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectControlAssetByID = `-- name: SelectControlAssetByID :one
 SELECT control_asset_id FROM asset WHERE id = $1
 `

--- a/internal/infrastructure/db/postgres/sqlc/query.sql
+++ b/internal/infrastructure/db/postgres/sqlc/query.sql
@@ -238,6 +238,15 @@ SELECT offchain_tx.txid, offchain_tx.tx AS data FROM offchain_tx WHERE offchain_
 UNION
 SELECT checkpoint_tx.txid, checkpoint_tx.tx AS data FROM checkpoint_tx WHERE checkpoint_tx.txid = ANY($1::varchar[]);
 
+-- name: SelectCheckpointTxsByVtxoPubKeys :many
+SELECT DISTINCT c.txid, c.tx AS data
+FROM vtxo v
+JOIN checkpoint_tx c ON c.txid = v.spent_by
+JOIN offchain_tx o ON o.txid = c.offchain_txid
+WHERE v.pubkey = ANY(@pubkeys::text[])
+  AND v.swept = false
+  AND o.stage_code = 3;
+
 -- name: SelectNotUnrolledVtxos :many
 SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw WHERE unrolled = false;
 

--- a/internal/infrastructure/db/postgres/vtxo_repo.go
+++ b/internal/infrastructure/db/postgres/vtxo_repo.go
@@ -252,6 +252,22 @@ func (v *vtxoRepository) GetLeafVtxosForBatch(
 	return readRows(rows)
 }
 
+func (v *vtxoRepository) GetCheckpointTxsByVtxoPubKeys(
+	ctx context.Context, pubkeys []string,
+) ([]domain.Tx, error) {
+	rows, err := v.querier.SelectCheckpointTxsByVtxoPubKeys(ctx, pubkeys)
+	if err != nil {
+		return nil, err
+	}
+
+	txs := make([]domain.Tx, 0, len(rows))
+	for _, row := range rows {
+		txs = append(txs, domain.Tx{Txid: row.Txid, Str: row.Data})
+	}
+
+	return txs, nil
+}
+
 func (v *vtxoRepository) UnrollVtxos(ctx context.Context, vtxos []domain.Outpoint) error {
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, vtxo := range vtxos {

--- a/internal/infrastructure/db/service.go
+++ b/internal/infrastructure/db/service.go
@@ -188,7 +188,9 @@ func NewService(config ServiceConfig, txDecoder ports.TxDecoder) (ports.RepoMana
 		if err != nil {
 			return nil, fmt.Errorf("failed to open round store: %s", err)
 		}
-		vtxoStore, err = vtxoStoreFactory(config.DataStoreConfig...)
+		arkStore := roundStore.(badgerdb.ArkRepository).Store()
+		vtxoStoreConfig := append(config.DataStoreConfig, arkStore)
+		vtxoStore, err = vtxoStoreFactory(vtxoStoreConfig...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open vtxo store: %s", err)
 		}

--- a/internal/infrastructure/db/service_test.go
+++ b/internal/infrastructure/db/service_test.go
@@ -1112,6 +1112,90 @@ func testVtxoRepository(t *testing.T, svc ports.RepoManager) {
 		require.NoError(t, err)
 		require.Empty(t, bulkKeys)
 
+		t.Run("test_get_checkpoint_txs_by_vtxo_pubkeys", func(t *testing.T) {
+			ctx := t.Context()
+
+			checkpointTxid1 := randomString(32)
+			checkpointTx1 := randomTx()
+			checkpointTxid2 := randomString(32)
+			checkpointTx2 := randomTx()
+			checkpointTxid3 := randomString(32)
+			checkpointTx3 := randomTx()
+			checkpointTxid4 := randomString(32)
+			checkpointTx4 := randomTx()
+
+			finalizedArkTxid := randomString(32)
+			finalizedOffchainTx := domain.NewOffchainTxFromEvents([]domain.Event{
+				domain.OffchainTxRequested{
+					OffchainTxEvent: domain.OffchainTxEvent{Id: finalizedArkTxid, Type: domain.EventTypeOffchainTxRequested},
+					ArkTx:                 randomTx(),
+					UnsignedCheckpointTxs: map[string]string{checkpointTxid1: checkpointTx1, checkpointTxid2: checkpointTx2, checkpointTxid3: checkpointTx3},
+					StartingTimestamp:     now.Unix(),
+				},
+				domain.OffchainTxAccepted{
+					OffchainTxEvent:     domain.OffchainTxEvent{Id: finalizedArkTxid, Type: domain.EventTypeOffchainTxAccepted},
+					CommitmentTxids:     map[string]string{checkpointTxid1: randomString(32), checkpointTxid2: randomString(32), checkpointTxid3: randomString(32)},
+					FinalArkTx:          randomTx(),
+					SignedCheckpointTxs: map[string]string{checkpointTxid1: checkpointTx1, checkpointTxid2: checkpointTx2, checkpointTxid3: checkpointTx3},
+					RootCommitmentTxid:  randomString(32),
+					ExpiryTimestamp:     endTimestamp,
+				},
+				domain.OffchainTxFinalized{
+					OffchainTxEvent:    domain.OffchainTxEvent{Id: finalizedArkTxid, Type: domain.EventTypeOffchainTxFinalized},
+					FinalCheckpointTxs: map[string]string{checkpointTxid1: checkpointTx1, checkpointTxid2: checkpointTx2, checkpointTxid3: checkpointTx3},
+					Timestamp:          endTimestamp,
+				},
+			})
+			err = svc.OffchainTxs().AddOrUpdateOffchainTx(ctx, finalizedOffchainTx)
+			require.NoError(t, err)
+
+			acceptedArkTxid := randomString(32)
+			acceptedOffchainTx := domain.NewOffchainTxFromEvents([]domain.Event{
+				domain.OffchainTxRequested{
+					OffchainTxEvent: domain.OffchainTxEvent{Id: acceptedArkTxid, Type: domain.EventTypeOffchainTxRequested},
+					ArkTx:                 randomTx(),
+					UnsignedCheckpointTxs: map[string]string{checkpointTxid4: checkpointTx4},
+					StartingTimestamp:     now.Unix(),
+				},
+				domain.OffchainTxAccepted{
+					OffchainTxEvent:     domain.OffchainTxEvent{Id: acceptedArkTxid, Type: domain.EventTypeOffchainTxAccepted},
+					CommitmentTxids:     map[string]string{checkpointTxid4: randomString(32)},
+					FinalArkTx:          randomTx(),
+					SignedCheckpointTxs: map[string]string{checkpointTxid4: checkpointTx4},
+					RootCommitmentTxid:  randomString(32),
+					ExpiryTimestamp:     endTimestamp,
+				},
+			})
+			err = svc.OffchainTxs().AddOrUpdateOffchainTx(ctx, acceptedOffchainTx)
+			require.NoError(t, err)
+
+			vtxos := []domain.Vtxo{
+				{Outpoint: domain.Outpoint{Txid: randomString(32), VOut: 0}, PubKey: pubkey, Amount: 10000, Spent: true, SpentBy: checkpointTxid1, ArkTxid: finalizedArkTxid},
+				{Outpoint: domain.Outpoint{Txid: randomString(32), VOut: 0}, PubKey: pubkey, Amount: 10000, Spent: true, SpentBy: checkpointTxid2, ArkTxid: finalizedArkTxid},
+				{Outpoint: domain.Outpoint{Txid: randomString(32), VOut: 0}, PubKey: pubkey2, Amount: 10000, Spent: true, SpentBy: checkpointTxid3, ArkTxid: finalizedArkTxid},
+				{Outpoint: domain.Outpoint{Txid: randomString(32), VOut: 0}, PubKey: pubkey2, Amount: 10000, Spent: true, SpentBy: checkpointTxid4, ArkTxid: acceptedArkTxid},
+				{Outpoint: domain.Outpoint{Txid: randomString(32), VOut: 0}, PubKey: pubkey2, Amount: 10000, Spent: true, Swept: true, SpentBy: checkpointTxid3, ArkTxid: finalizedArkTxid},
+			}
+			err = svc.Vtxos().AddVtxos(ctx, vtxos)
+			require.NoError(t, err)
+
+			txs, err := svc.Vtxos().GetCheckpointTxsByVtxoPubKeys(ctx, []string{pubkey})
+			require.NoError(t, err)
+			require.ElementsMatch(t, []domain.Tx{{Txid: checkpointTxid1, Str: checkpointTx1}, {Txid: checkpointTxid2, Str: checkpointTx2}}, txs)
+
+			txs, err = svc.Vtxos().GetCheckpointTxsByVtxoPubKeys(ctx, []string{pubkey, pubkey2})
+			require.NoError(t, err)
+			require.ElementsMatch(t, []domain.Tx{{Txid: checkpointTxid1, Str: checkpointTx1}, {Txid: checkpointTxid2, Str: checkpointTx2}, {Txid: checkpointTxid3, Str: checkpointTx3}}, txs)
+
+			txs, err = svc.Vtxos().GetCheckpointTxsByVtxoPubKeys(ctx, []string{})
+			require.NoError(t, err)
+			require.Empty(t, txs)
+
+			txs, err = svc.Vtxos().GetCheckpointTxsByVtxoPubKeys(ctx, []string{randomString(32)})
+			require.NoError(t, err)
+			require.Empty(t, txs)
+		})
+
 		t.Run("test_get_pending_spent_vtxos", func(t *testing.T) {
 			ctx := t.Context()
 

--- a/internal/infrastructure/db/sqlite/sqlc/queries/query.sql.go
+++ b/internal/infrastructure/db/sqlite/sqlc/queries/query.sql.go
@@ -345,6 +345,54 @@ func (q *Queries) SelectAssetsWithUnspentAmountsByIds(ctx context.Context, ids [
 	return items, nil
 }
 
+const selectCheckpointTxsByVtxoPubKeys = `-- name: SelectCheckpointTxsByVtxoPubKeys :many
+SELECT DISTINCT c.txid, c.tx AS data
+FROM vtxo v
+JOIN checkpoint_tx c ON c.txid = v.spent_by
+JOIN offchain_tx o ON o.txid = c.offchain_txid
+WHERE v.pubkey IN (/*SLICE:pubkeys*/?)
+  AND v.swept = false
+  AND o.stage_code = 3
+`
+
+type SelectCheckpointTxsByVtxoPubKeysRow struct {
+	Txid string
+	Data string
+}
+
+func (q *Queries) SelectCheckpointTxsByVtxoPubKeys(ctx context.Context, pubkeys []string) ([]SelectCheckpointTxsByVtxoPubKeysRow, error) {
+	query := selectCheckpointTxsByVtxoPubKeys
+	var queryParams []interface{}
+	if len(pubkeys) > 0 {
+		for _, v := range pubkeys {
+			queryParams = append(queryParams, v)
+		}
+		query = strings.Replace(query, "/*SLICE:pubkeys*/?", strings.Repeat(",?", len(pubkeys))[1:], 1)
+	} else {
+		query = strings.Replace(query, "/*SLICE:pubkeys*/?", "NULL", 1)
+	}
+	rows, err := q.db.QueryContext(ctx, query, queryParams...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SelectCheckpointTxsByVtxoPubKeysRow
+	for rows.Next() {
+		var i SelectCheckpointTxsByVtxoPubKeysRow
+		if err := rows.Scan(&i.Txid, &i.Data); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const selectControlAssetByID = `-- name: SelectControlAssetByID :one
 SELECT control_asset_id FROM asset WHERE id = ?
 `

--- a/internal/infrastructure/db/sqlite/sqlc/query.sql
+++ b/internal/infrastructure/db/sqlite/sqlc/query.sql
@@ -245,6 +245,15 @@ SELECT offchain_tx.txid, offchain_tx.tx AS data FROM offchain_tx WHERE offchain_
 UNION
 SELECT checkpoint_tx.txid, checkpoint_tx.tx AS data FROM checkpoint_tx WHERE checkpoint_tx.txid IN (sqlc.slice('ids3'));
 
+-- name: SelectCheckpointTxsByVtxoPubKeys :many
+SELECT DISTINCT c.txid, c.tx AS data
+FROM vtxo v
+JOIN checkpoint_tx c ON c.txid = v.spent_by
+JOIN offchain_tx o ON o.txid = c.offchain_txid
+WHERE v.pubkey IN (sqlc.slice('pubkeys'))
+  AND v.swept = false
+  AND o.stage_code = 3;
+
 -- name: SelectNotUnrolledVtxos :many
 SELECT sqlc.embed(vtxo_vw) FROM vtxo_vw WHERE unrolled = false;
 

--- a/internal/infrastructure/db/sqlite/vtxo_repo.go
+++ b/internal/infrastructure/db/sqlite/vtxo_repo.go
@@ -294,6 +294,26 @@ func (v *vtxoRepository) GetLeafVtxosForBatch(
 	return readRows(rows)
 }
 
+func (v *vtxoRepository) GetCheckpointTxsByVtxoPubKeys(
+	ctx context.Context, pubkeys []string,
+) ([]domain.Tx, error) {
+	var rows []queries.SelectCheckpointTxsByVtxoPubKeysRow
+	if err := withReadQuerier(ctx, v.db, func(q *queries.Queries) error {
+		var err error
+		rows, err = q.SelectCheckpointTxsByVtxoPubKeys(ctx, pubkeys)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	txs := make([]domain.Tx, 0, len(rows))
+	for _, row := range rows {
+		txs = append(txs, domain.Tx{Txid: row.Txid, Str: row.Data})
+	}
+
+	return txs, nil
+}
+
 func (v *vtxoRepository) UnrollVtxos(ctx context.Context, vtxos []domain.Outpoint) error {
 	txBody := func(querierWithTx *queries.Queries) error {
 		for _, vtxo := range vtxos {


### PR DESCRIPTION
### Summary
`arkd` watched vtxo taproot scripts but not checkpoint-tx output scripts, those scripts are useful to watch for other downstream services connecting to the same NBXplorer instance. This adds checkpoint-script watching in the three places vtxo scripts are already managed:

- **On new finalized offchain tx** — the inline handler in `registerEventHandlers` now extracts the first output's pkscript of each checkpoint tx and calls `scanner.WatchScripts`.
- **On startup restore** — `restoreWatchingVtxos` additionally fetches checkpoint txs for the VTXOs and watches their first output.
- **On shutdown / sweep** — `stopWatchingVtxos` mirrors that, unwatching the same checkpoint scripts.

Both restore and stop soft-fail on DB errors: a checkpoint-tx fetch failure logs a warning rather than aborting startup or shutdown.

### New repo method
`VtxoRepository.GetCheckpointTxsByVtxoPubKeys(ctx, pubkeys) ([]Tx, error)` — returns the finalized checkpoint txs that spent the given (non-swept) vtxo pubkeys. Implemented for:
- **postgres** & **sqlite** — `SelectCheckpointTxsByVtxoPubKeys` query joining `vtxo → checkpoint_tx → offchain_tx` filtered by `v.swept = false` and `o.stage_code = 3` (finalized).
- **badger** — in-memory join: vtxos grouped by `ArkTxid`, offchain tx fetched from the ark store, stage check, dedup by `SpentBy`. The ark store handle is threaded into the vtxo repo via the `ArkRepository.Store()` accessor.

### Tests
- `internal/core/application/script_watch_test.go` — unit tests for `restoreWatchingVtxos` and `stopWatchingVtxos` (happy path, soft-fail on DB error, empty keys, unparseable PSBT skipped, bad tapkey filtered, unwatch retry-then-succeed) plus the inline offchain-tx handler watching checkpoint + vtxo scripts on finalized txs.
- `internal/infrastructure/db/service_test.go` — `test_get_checkpoint_txs_by_vtxo_pubkeys` covering finalized vs accepted (only finalized returned), swept exclusion, multi-pubkey, empty/unknown pubkey. Covers postgres & sqlite.

### Not tested
The badger implementation. This matches the existing pattern — no other `VtxoRepository` method has a badger-specific test in `service_test.go` (the suite only exercises sqlite and postgres backends). This issue #1128 proposes removing badger as a DataStore due to this non-tested pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watching and restoring now includes checkpoint-output scripts alongside vtxo scripts.
  * Offchain updates now start watching related checkpoint outputs for finalized transactions.
  * Added checkpoint-tx lookup by vtxo public keys across storage backends.

* **Bug Fixes**
  * Improved resilience when checkpoint data is malformed or unavailable: continues vtxo watching while checkpoint handling soft-fails.
  * Skips invalid tapkey/checkpoint PSBT inputs and improves unwatch reliability by retrying transient failures.

* **Tests**
  * Expanded automated coverage for script watch/restore, unwatch behavior, and checkpoint-tx lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->