### PR TITLE
Fix: reconnect arkd-wallet scanner to NBXplorer with backoff

### DIFF
--- a/pkg/arkd-wallet/core/application/scanner/service.go
+++ b/pkg/arkd-wallet/core/application/scanner/service.go
@@ -59,13 +59,20 @@ func (s *scanner) start(ctx context.Context) error {
 	go func() {
 		backoff := initialBackoff
 
+		connected := true
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case utxos, ok := <-notificationCh:
 				if !ok {
-					log.WithFields(log.Fields{"backoff": backoff}).Warn("reconnecting to nbxplorer")
+					if connected {
+						log.Warn("nbxplorer disconnected")
+						connected = false
+					}
+
+					log.WithFields(log.Fields{"backoff": backoff}).Info("reconnecting to nbxplorer")
 					timer := time.NewTimer(backoff)
 					select {
 					case <-ctx.Done():
@@ -77,6 +84,7 @@ func (s *scanner) start(ctx context.Context) error {
 					nextCh, err := s.nbxplorer.GetAddressNotifications(ctx)
 					if err == nil {
 						log.Info("reconnected to nbxplorer")
+						connected = true
 						notificationCh = nextCh
 					}
 

--- a/pkg/arkd-wallet/core/application/scanner/service.go
+++ b/pkg/arkd-wallet/core/application/scanner/service.go
@@ -85,7 +85,9 @@ func (s *scanner) start(ctx context.Context) error {
 					if err == nil {
 						log.Info("reconnected to nbxplorer")
 						connected = true
+						backoff = initialBackoff
 						notificationCh = nextCh
+						continue
 					}
 
 					backoff *= 2
@@ -94,8 +96,6 @@ func (s *scanner) start(ctx context.Context) error {
 					}
 					continue
 				}
-
-				backoff = initialBackoff
 
 				notificationsMap := make(map[string][]application.Utxo)
 				for _, utxo := range utxos {

--- a/pkg/arkd-wallet/core/application/scanner/service.go
+++ b/pkg/arkd-wallet/core/application/scanner/service.go
@@ -5,12 +5,19 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/arkade-os/arkd/pkg/arkd-wallet/core/application"
 	"github.com/arkade-os/arkd/pkg/arkd-wallet/core/ports"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	initialBackoff = time.Second
+	maxBackoff     = 30 * time.Second
 )
 
 type scanner struct {
@@ -50,20 +57,40 @@ func (s *scanner) start(ctx context.Context) error {
 	}
 
 	go func() {
+		backoff := initialBackoff
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case utxos := <-notificationCh:
-				if len(s.notificationListeners) == 0 {
+			case utxos, ok := <-notificationCh:
+				if !ok {
+					log.WithFields(log.Fields{"backoff": backoff}).Warn("reconnecting to nbxplorer")
+					timer := time.NewTimer(backoff)
+					select {
+					case <-ctx.Done():
+						timer.Stop()
+						return
+					case <-timer.C:
+					}
+
+					nextCh, err := s.nbxplorer.GetAddressNotifications(ctx)
+					if err == nil {
+						log.Info("reconnected to nbxplorer")
+						notificationCh = nextCh
+					}
+
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
 					continue
 				}
 
+				backoff = initialBackoff
+
 				notificationsMap := make(map[string][]application.Utxo)
 				for _, utxo := range utxos {
-					if _, ok := notificationsMap[utxo.Script]; !ok {
-						notificationsMap[utxo.Script] = make([]application.Utxo, 0)
-					}
 					notificationsMap[utxo.Script] = append(notificationsMap[utxo.Script], application.Utxo{
 						Txid:   utxo.OutPoint.Hash.String(),
 						Index:  utxo.OutPoint.Index,

--- a/pkg/arkd-wallet/core/application/scanner/service.go
+++ b/pkg/arkd-wallet/core/application/scanner/service.go
@@ -15,9 +15,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
-	initialBackoff = time.Second
-	maxBackoff     = 30 * time.Second
+const (
+	defaultInitialBackoff = time.Second
+	defaultMaxBackoff     = 30 * time.Second
 )
 
 type scanner struct {
@@ -28,6 +28,8 @@ type scanner struct {
 
 	lock                  sync.RWMutex
 	notificationListeners []chan map[string][]application.Utxo
+	initialBackoff        time.Duration
+	maxBackoff            time.Duration
 }
 
 // New creates a new BlockchainScanner service
@@ -41,6 +43,8 @@ func New(nbxplorer ports.Nbxplorer, network string) (application.BlockchainScann
 		lock:                  sync.RWMutex{},
 		notificationListeners: make([]chan map[string][]application.Utxo, 0),
 		chainParams:           application.NetworkToChainParams(network),
+		initialBackoff:        defaultInitialBackoff,
+		maxBackoff:            defaultMaxBackoff,
 	}
 
 	if err := svc.start(ctx); err != nil {
@@ -57,7 +61,7 @@ func (s *scanner) start(ctx context.Context) error {
 	}
 
 	go func() {
-		backoff := initialBackoff
+		backoff := s.initialBackoff
 
 		connected := true
 
@@ -85,14 +89,14 @@ func (s *scanner) start(ctx context.Context) error {
 					if err == nil {
 						log.Info("reconnected to nbxplorer")
 						connected = true
-						backoff = initialBackoff
+						backoff = s.initialBackoff
 						notificationCh = nextCh
 						continue
 					}
 
 					backoff *= 2
-					if backoff > maxBackoff {
-						backoff = maxBackoff
+					if backoff > s.maxBackoff {
+						backoff = s.maxBackoff
 					}
 					continue
 				}

--- a/pkg/arkd-wallet/core/application/scanner/service_test.go
+++ b/pkg/arkd-wallet/core/application/scanner/service_test.go
@@ -1,0 +1,198 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/pkg/arkd-wallet/core/application"
+	"github.com/arkade-os/arkd/pkg/arkd-wallet/core/ports"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeNbxplorer struct {
+	ports.Nbxplorer
+
+	mu         sync.Mutex
+	notifChs   []chan []ports.Utxo
+	callIdx    int
+	initialErr error
+}
+
+func (f *fakeNbxplorer) GetAddressNotifications(ctx context.Context) (<-chan []ports.Utxo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	idx := f.callIdx
+	f.callIdx++
+	if idx == 0 && f.initialErr != nil {
+		return nil, f.initialErr
+	}
+	if idx >= len(f.notifChs) {
+		ch := make(chan []ports.Utxo)
+		return ch, nil
+	}
+	return f.notifChs[idx], nil
+}
+
+func (f *fakeNbxplorer) Close() error { return nil }
+
+func (f *fakeNbxplorer) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callIdx
+}
+
+func TestNew_InitialGetAddressNotificationsError(t *testing.T) {
+	fake := &fakeNbxplorer{
+		initialErr: fmt.Errorf("nbxplorer unavailable"),
+	}
+	_, err := New(fake, "regtest")
+	require.Error(t, err)
+}
+
+func TestStart_FanoutToListeners(t *testing.T) {
+	notifCh := make(chan []ports.Utxo, 1)
+	fake := &fakeNbxplorer{
+		notifChs: []chan []ports.Utxo{notifCh},
+	}
+
+	ctx := t.Context()
+
+	s := &scanner{
+		nbxplorer:             fake,
+		chainParams:           &chaincfg.RegressionNetParams,
+		notificationListeners: make([]chan map[string][]application.Utxo, 0),
+	}
+	require.NoError(t, s.start(ctx))
+
+	listener1 := make(chan map[string][]application.Utxo, 128)
+	listener2 := make(chan map[string][]application.Utxo, 128)
+	s.lock.Lock()
+	s.notificationListeners = append(s.notificationListeners, listener1, listener2)
+	s.lock.Unlock()
+
+	notifCh <- []ports.Utxo{{
+		OutPoint: wire.OutPoint{Index: 0},
+		Script:   "deadbeef",
+		Value:    1000,
+	}}
+
+	expectNotification := func(ch <-chan map[string][]application.Utxo) {
+		select {
+		case msg := <-ch:
+			require.Len(t, msg, 1)
+			utxos := msg["deadbeef"]
+			require.Len(t, utxos, 1)
+			require.Equal(t, "deadbeef", utxos[0].Script)
+			require.EqualValues(t, 1000, utxos[0].Value)
+		case <-time.After(time.Second):
+			require.Fail(t, "timeout waiting for notification")
+		}
+	}
+
+	expectNotification(listener1)
+	expectNotification(listener2)
+}
+
+func TestStart_ReconnectsOnClosedChannel(t *testing.T) {
+	initialBackoff = 10 * time.Millisecond
+	maxBackoff = 50 * time.Millisecond
+	defer func() {
+		initialBackoff = time.Second
+		maxBackoff = 30 * time.Second
+	}()
+
+	firstCh := make(chan []ports.Utxo)
+	secondCh := make(chan []ports.Utxo, 1)
+	fake := &fakeNbxplorer{
+		notifChs: []chan []ports.Utxo{firstCh, secondCh},
+	}
+
+	ctx := t.Context()
+
+	s := &scanner{
+		nbxplorer:             fake,
+		chainParams:           &chaincfg.RegressionNetParams,
+		notificationListeners: make([]chan map[string][]application.Utxo, 0),
+	}
+	require.NoError(t, s.start(ctx))
+
+	listener := make(chan map[string][]application.Utxo, 128)
+	s.lock.Lock()
+	s.notificationListeners = append(s.notificationListeners, listener)
+	s.lock.Unlock()
+
+	close(firstCh)
+
+	secondCh <- []ports.Utxo{{
+		OutPoint: wire.OutPoint{Index: 1},
+		Script:   "cafebabe",
+		Value:    5000,
+	}}
+
+	select {
+	case msg := <-listener:
+		require.Len(t, msg, 1)
+		utxos := msg["cafebabe"]
+		require.Len(t, utxos, 1)
+		require.Equal(t, "cafebabe", utxos[0].Script)
+		require.EqualValues(t, 5000, utxos[0].Value)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for notification after reconnect")
+	}
+	require.GreaterOrEqual(t, fake.calls(), 2)
+}
+
+func TestStart_ReconnectsMultipleTimes(t *testing.T) {
+	initialBackoff = 5 * time.Millisecond
+	maxBackoff = 20 * time.Millisecond
+	defer func() {
+		initialBackoff = time.Second
+		maxBackoff = 30 * time.Second
+	}()
+
+	ch1 := make(chan []ports.Utxo)
+	ch2 := make(chan []ports.Utxo)
+	ch3 := make(chan []ports.Utxo, 1)
+	fake := &fakeNbxplorer{
+		notifChs: []chan []ports.Utxo{ch1, ch2, ch3},
+	}
+
+	ctx := t.Context()
+
+	s := &scanner{
+		nbxplorer:             fake,
+		chainParams:           &chaincfg.RegressionNetParams,
+		notificationListeners: make([]chan map[string][]application.Utxo, 0),
+	}
+	require.NoError(t, s.start(ctx))
+
+	listener := make(chan map[string][]application.Utxo, 128)
+	s.lock.Lock()
+	s.notificationListeners = append(s.notificationListeners, listener)
+	s.lock.Unlock()
+
+	close(ch1)
+	close(ch2)
+	ch3 <- []ports.Utxo{{
+		OutPoint: wire.OutPoint{Index: 2},
+		Script:   "f00dface",
+		Value:    9000,
+	}}
+
+	select {
+	case msg := <-listener:
+		require.Len(t, msg, 1)
+		utxos := msg["f00dface"]
+		require.Len(t, utxos, 1)
+		require.Equal(t, "f00dface", utxos[0].Script)
+		require.EqualValues(t, 9000, utxos[0].Value)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "timeout waiting for notification after multiple reconnects")
+	}
+	require.GreaterOrEqual(t, fake.calls(), 3)
+}

--- a/pkg/arkd-wallet/core/application/scanner/service_test.go
+++ b/pkg/arkd-wallet/core/application/scanner/service_test.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -13,6 +12,100 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConnection(t *testing.T) {
+	startScanner := func(t *testing.T, fake *fakeNbxplorer, initialBackoff, maxBackoff time.Duration) *scanner {
+		t.Helper()
+
+		s := &scanner{
+			nbxplorer:             fake,
+			chainParams:           &chaincfg.RegressionNetParams,
+			notificationListeners: make([]chan map[string][]application.Utxo, 0),
+			initialBackoff:        initialBackoff,
+			maxBackoff:            maxBackoff,
+		}
+		require.NoError(t, s.start(t.Context()))
+		return s
+	}
+
+	addListeners := func(s *scanner, count int) []chan map[string][]application.Utxo {
+		listeners := make([]chan map[string][]application.Utxo, count)
+		s.lock.Lock()
+		defer s.lock.Unlock()
+		for i := range listeners {
+			listeners[i] = make(chan map[string][]application.Utxo, 128)
+			s.notificationListeners = append(s.notificationListeners, listeners[i])
+		}
+		return listeners
+	}
+
+	expectNotification := func(t *testing.T, ch <-chan map[string][]application.Utxo, script string, value uint64, timeout time.Duration) {
+		t.Helper()
+
+		select {
+		case msg := <-ch:
+			require.Len(t, msg, 1)
+			utxos := msg[script]
+			require.Len(t, utxos, 1)
+			require.Equal(t, script, utxos[0].Script)
+			require.EqualValues(t, value, utxos[0].Value)
+		case <-time.After(timeout):
+			require.Fail(t, "timeout waiting for notification")
+		}
+	}
+
+	t.Run("fanout to listeners", func(t *testing.T) {
+		notifCh := make(chan []ports.Utxo, 1)
+		fake := &fakeNbxplorer{notifChs: []chan []ports.Utxo{notifCh}}
+		listeners := addListeners(startScanner(t, fake, defaultInitialBackoff, defaultMaxBackoff), 2)
+
+		notifCh <- []ports.Utxo{{
+			OutPoint: wire.OutPoint{Index: 0},
+			Script:   "deadbeef",
+			Value:    1000,
+		}}
+
+		for _, listener := range listeners {
+			expectNotification(t, listener, "deadbeef", 1000, time.Second)
+		}
+	})
+
+	t.Run("reconnects on closed channel", func(t *testing.T) {
+		firstCh := make(chan []ports.Utxo)
+		secondCh := make(chan []ports.Utxo, 1)
+		fake := &fakeNbxplorer{notifChs: []chan []ports.Utxo{firstCh, secondCh}}
+		listener := addListeners(startScanner(t, fake, 10*time.Millisecond, 50*time.Millisecond), 1)[0]
+
+		close(firstCh)
+		secondCh <- []ports.Utxo{{
+			OutPoint: wire.OutPoint{Index: 1},
+			Script:   "cafebabe",
+			Value:    5000,
+		}}
+
+		expectNotification(t, listener, "cafebabe", 5000, 2*time.Second)
+		require.GreaterOrEqual(t, fake.calls(), 2)
+	})
+
+	t.Run("reconnects multiple times", func(t *testing.T) {
+		ch1 := make(chan []ports.Utxo)
+		ch2 := make(chan []ports.Utxo)
+		ch3 := make(chan []ports.Utxo, 1)
+		fake := &fakeNbxplorer{notifChs: []chan []ports.Utxo{ch1, ch2, ch3}}
+		listener := addListeners(startScanner(t, fake, 5*time.Millisecond, 20*time.Millisecond), 1)[0]
+
+		close(ch1)
+		close(ch2)
+		ch3 <- []ports.Utxo{{
+			OutPoint: wire.OutPoint{Index: 2},
+			Script:   "f00dface",
+			Value:    9000,
+		}}
+
+		expectNotification(t, listener, "f00dface", 9000, 2*time.Second)
+		require.GreaterOrEqual(t, fake.calls(), 3)
+	})
+}
 
 type fakeNbxplorer struct {
 	ports.Nbxplorer
@@ -44,155 +137,4 @@ func (f *fakeNbxplorer) calls() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.callIdx
-}
-
-func TestNew_InitialGetAddressNotificationsError(t *testing.T) {
-	fake := &fakeNbxplorer{
-		initialErr: fmt.Errorf("nbxplorer unavailable"),
-	}
-	_, err := New(fake, "regtest")
-	require.Error(t, err)
-}
-
-func TestStart_FanoutToListeners(t *testing.T) {
-	notifCh := make(chan []ports.Utxo, 1)
-	fake := &fakeNbxplorer{
-		notifChs: []chan []ports.Utxo{notifCh},
-	}
-
-	ctx := t.Context()
-
-	s := &scanner{
-		nbxplorer:             fake,
-		chainParams:           &chaincfg.RegressionNetParams,
-		notificationListeners: make([]chan map[string][]application.Utxo, 0),
-	}
-	require.NoError(t, s.start(ctx))
-
-	listener1 := make(chan map[string][]application.Utxo, 128)
-	listener2 := make(chan map[string][]application.Utxo, 128)
-	s.lock.Lock()
-	s.notificationListeners = append(s.notificationListeners, listener1, listener2)
-	s.lock.Unlock()
-
-	notifCh <- []ports.Utxo{{
-		OutPoint: wire.OutPoint{Index: 0},
-		Script:   "deadbeef",
-		Value:    1000,
-	}}
-
-	expectNotification := func(ch <-chan map[string][]application.Utxo) {
-		select {
-		case msg := <-ch:
-			require.Len(t, msg, 1)
-			utxos := msg["deadbeef"]
-			require.Len(t, utxos, 1)
-			require.Equal(t, "deadbeef", utxos[0].Script)
-			require.EqualValues(t, 1000, utxos[0].Value)
-		case <-time.After(time.Second):
-			require.Fail(t, "timeout waiting for notification")
-		}
-	}
-
-	expectNotification(listener1)
-	expectNotification(listener2)
-}
-
-func TestStart_ReconnectsOnClosedChannel(t *testing.T) {
-	initialBackoff = 10 * time.Millisecond
-	maxBackoff = 50 * time.Millisecond
-	defer func() {
-		initialBackoff = time.Second
-		maxBackoff = 30 * time.Second
-	}()
-
-	firstCh := make(chan []ports.Utxo)
-	secondCh := make(chan []ports.Utxo, 1)
-	fake := &fakeNbxplorer{
-		notifChs: []chan []ports.Utxo{firstCh, secondCh},
-	}
-
-	ctx := t.Context()
-
-	s := &scanner{
-		nbxplorer:             fake,
-		chainParams:           &chaincfg.RegressionNetParams,
-		notificationListeners: make([]chan map[string][]application.Utxo, 0),
-	}
-	require.NoError(t, s.start(ctx))
-
-	listener := make(chan map[string][]application.Utxo, 128)
-	s.lock.Lock()
-	s.notificationListeners = append(s.notificationListeners, listener)
-	s.lock.Unlock()
-
-	close(firstCh)
-
-	secondCh <- []ports.Utxo{{
-		OutPoint: wire.OutPoint{Index: 1},
-		Script:   "cafebabe",
-		Value:    5000,
-	}}
-
-	select {
-	case msg := <-listener:
-		require.Len(t, msg, 1)
-		utxos := msg["cafebabe"]
-		require.Len(t, utxos, 1)
-		require.Equal(t, "cafebabe", utxos[0].Script)
-		require.EqualValues(t, 5000, utxos[0].Value)
-	case <-time.After(2 * time.Second):
-		require.Fail(t, "timeout waiting for notification after reconnect")
-	}
-	require.GreaterOrEqual(t, fake.calls(), 2)
-}
-
-func TestStart_ReconnectsMultipleTimes(t *testing.T) {
-	initialBackoff = 5 * time.Millisecond
-	maxBackoff = 20 * time.Millisecond
-	defer func() {
-		initialBackoff = time.Second
-		maxBackoff = 30 * time.Second
-	}()
-
-	ch1 := make(chan []ports.Utxo)
-	ch2 := make(chan []ports.Utxo)
-	ch3 := make(chan []ports.Utxo, 1)
-	fake := &fakeNbxplorer{
-		notifChs: []chan []ports.Utxo{ch1, ch2, ch3},
-	}
-
-	ctx := t.Context()
-
-	s := &scanner{
-		nbxplorer:             fake,
-		chainParams:           &chaincfg.RegressionNetParams,
-		notificationListeners: make([]chan map[string][]application.Utxo, 0),
-	}
-	require.NoError(t, s.start(ctx))
-
-	listener := make(chan map[string][]application.Utxo, 128)
-	s.lock.Lock()
-	s.notificationListeners = append(s.notificationListeners, listener)
-	s.lock.Unlock()
-
-	close(ch1)
-	close(ch2)
-	ch3 <- []ports.Utxo{{
-		OutPoint: wire.OutPoint{Index: 2},
-		Script:   "f00dface",
-		Value:    9000,
-	}}
-
-	select {
-	case msg := <-listener:
-		require.Len(t, msg, 1)
-		utxos := msg["f00dface"]
-		require.Len(t, utxos, 1)
-		require.Equal(t, "f00dface", utxos[0].Script)
-		require.EqualValues(t, 9000, utxos[0].Value)
-	case <-time.After(2 * time.Second):
-		require.Fail(t, "timeout waiting for notification after multiple reconnects")
-	}
-	require.GreaterOrEqual(t, fake.calls(), 3)
 }

--- a/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
+++ b/pkg/arkd-wallet/core/infrastructure/nbxplorer/service.go
@@ -673,16 +673,15 @@ func (n *nbxplorer) GetAddressNotifications(ctx context.Context) (<-chan []ports
 		}
 	}
 
+	if err := n.connectWebSocket(ctx); err != nil {
+		return nil, fmt.Errorf("failed to connect to WebSocket: %w", err)
+	}
+
 	// buffered channel to prevent blocking
 	notificationsChan := make(chan []ports.Utxo, 64)
 
 	go func() {
 		defer close(notificationsChan)
-
-		if err := n.connectWebSocket(ctx); err != nil {
-			log.Errorf("failed to connect to WebSocket: %s", err)
-			return
-		}
 
 		for {
 			select {
@@ -691,12 +690,8 @@ func (n *nbxplorer) GetAddressNotifications(ctx context.Context) (<-chan []ports
 			default:
 				_, message, err := n.wsConn.ReadMessage()
 				if err != nil {
-					// reconnect on error
-					if err := n.connectWebSocket(ctx); err != nil {
-						log.Errorf("failed to connect to WebSocket: %s", err)
-						return
-					}
-					continue
+					log.Errorf("failed to read WebSocket message: %s", err)
+					return
 				}
 
 				var event event


### PR DESCRIPTION
## Summary
- Make the `arkd-wallet` scanner reconnect when the NBXplorer notification stream closes.
- Add exponential backoff for NBXplorer reconnect attempts, capped at 30 seconds.
- Surface initial NBXplorer WebSocket connection errors to callers instead of failing silently in the reader goroutine.
- Add scanner service tests covering initial connection errors, listener fanout, and single/multiple reconnect flows.

## Testing
- Added unit coverage in `pkg/arkd-wallet/core/application/scanner/service_test.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet address scanning reliability by automatically reconnecting when the notification stream disconnects or closes.
  * Added exponential backoff with a capped delay to reduce noisy rapid retry behavior during outages.
  * Preserved delivery to all registered listeners after reconnection.
  * Tightened notification startup and stream error handling to fail more predictably and surface issues clearly.
* **Tests**
  * Consolidated scanner connection/reconnect coverage into a unified test suite with sub-cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->