### PR TITLE
Fix: cap metadata of interest values size in logging interceptor

### DIFF
--- a/internal/interface/grpc/interceptors/logger.go
+++ b/internal/interface/grpc/interceptors/logger.go
@@ -13,6 +13,11 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+const (
+	maxMetadataValueSizeBytes = 100
+	invalidMetadataValue      = "arklabs/invalid"
+)
+
 // metadataOfInterest is the allowlist of incoming gRPC metadata keys we log.
 // gRPC lowercases all incoming metadata keys, so entries here must be lowercase.
 var metadataOfInterest = map[string]struct{}{
@@ -97,11 +102,23 @@ func sanitizeMetadata(ctx context.Context) (string, bool) {
 		if len(vals) == 0 {
 			continue
 		}
-		if len(vals) == 1 {
-			selected[key] = vals[0]
-			continue
+		sanitizedVals := make([]string, 0, len(vals))
+		for _, v := range vals {
+			if len(v) > maxMetadataValueSizeBytes {
+				log.WithFields(log.Fields{
+					"key": key,
+					"len": len(v),
+				}).Warn("metadata of interest value too large")
+				sanitizedVals = append(sanitizedVals, invalidMetadataValue)
+				continue
+			}
+			sanitizedVals = append(sanitizedVals, v)
 		}
-		selected[key] = vals
+		if len(sanitizedVals) == 1 {
+			selected[key] = sanitizedVals[0]
+		} else {
+			selected[key] = sanitizedVals
+		}
 	}
 
 	if len(selected) == 0 {

--- a/internal/interface/grpc/interceptors/logger_test.go
+++ b/internal/interface/grpc/interceptors/logger_test.go
@@ -1,0 +1,76 @@
+package interceptors
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestSanitizeMetadata(t *testing.T) {
+	t.Run("selects metadata of interest", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+			"x-build-version", "1.2.3",
+			"x-sdk-version", "0.9.0",
+			"x-digest", "abc123",
+			"authorization", "secret",
+		))
+
+		got, ok := sanitizeMetadata(ctx)
+
+		require.True(t, ok)
+		require.JSONEq(t, `{
+			"x-build-version": "1.2.3",
+			"x-sdk-version": "0.9.0",
+			"x-digest": "abc123"
+		}`, got)
+	})
+
+	t.Run("preserves multiple values", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+			"x-sdk-version", "0.9.0",
+			"x-sdk-version", "0.9.1",
+		))
+
+		got, ok := sanitizeMetadata(ctx)
+
+		require.True(t, ok)
+		require.JSONEq(t, `{
+			"x-sdk-version": ["0.9.0", "0.9.1"]
+		}`, got)
+	})
+
+	t.Run("returns false without incoming metadata", func(t *testing.T) {
+		got, ok := sanitizeMetadata(context.Background())
+
+		require.False(t, ok)
+		require.Empty(t, got)
+	})
+
+	t.Run("returns false without metadata of interest", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+			"authorization", "secret",
+			"x-request-id", "request-id",
+		))
+
+		got, ok := sanitizeMetadata(ctx)
+
+		require.False(t, ok)
+		require.Empty(t, got)
+	})
+
+	t.Run("replaces oversized values", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+			"x-digest", strings.Repeat("a", maxMetadataValueSizeBytes+1),
+		))
+
+		got, ok := sanitizeMetadata(ctx)
+
+		require.True(t, ok)
+		require.JSONEq(t, `{
+			"x-digest": "`+invalidMetadataValue+`"
+		}`, got)
+	})
+}


### PR DESCRIPTION
**Summary**
- Adds a 100-byte limit for single incoming gRPC metadata values selected for debug logging.
- Logs a warning with the metadata key and value length when a selected value is too large.
- Replaces oversized values with `arklabs/invalid` before writing metadata to logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging safety by limiting the maximum size of metadata values included in debug output.
  * Added warnings when a metadata value exceeds the allowed size, replacing oversized entries with a fixed placeholder instead of logging the full content.
  * Improved multi-value metadata handling so sanitized results reflect either a single value or a list based on what was received.
* **Tests**
  * Added coverage for metadata sanitization scenarios, including empty/non-matching metadata and oversized value replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->