### PR TITLE
Whitelist `channelz` endpoints in permissions

### DIFF
--- a/internal/interface/grpc/permissions/permissions.go
+++ b/internal/interface/grpc/permissions/permissions.go
@@ -17,6 +17,7 @@ const (
 	EntityArk               = "ark"
 	EntityIndexer           = "indexer"
 	EntityHealth            = "health"
+	EntityChannelz          = "channelz"
 	EntityAuthManager       = "authmanager"
 )
 
@@ -265,6 +266,15 @@ func Whitelist() map[string][]bakery.Op {
 			Entity: EntityIndexer,
 			Action: "read",
 		}},
+
+		/* Channelz APIs (restricted to admin port) */
+		"/grpc.channelz.v1.Channelz/GetTopChannels":   {{Entity: EntityChannelz, Action: "read"}},
+		"/grpc.channelz.v1.Channelz/GetServers":       {{Entity: EntityChannelz, Action: "read"}},
+		"/grpc.channelz.v1.Channelz/GetServer":        {{Entity: EntityChannelz, Action: "read"}},
+		"/grpc.channelz.v1.Channelz/GetServerSockets": {{Entity: EntityChannelz, Action: "read"}},
+		"/grpc.channelz.v1.Channelz/GetChannel":       {{Entity: EntityChannelz, Action: "read"}},
+		"/grpc.channelz.v1.Channelz/GetSubchannel":    {{Entity: EntityChannelz, Action: "read"}},
+		"/grpc.channelz.v1.Channelz/GetSocket":        {{Entity: EntityChannelz, Action: "read"}},
 	}
 }
 

--- a/internal/interface/grpc/permissions/permissions.go
+++ b/internal/interface/grpc/permissions/permissions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
+	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	grpchealth "google.golang.org/grpc/health/grpc_health_v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 )
@@ -268,13 +269,13 @@ func Whitelist() map[string][]bakery.Op {
 		}},
 
 		/* Channelz APIs (restricted to admin port) */
-		"/grpc.channelz.v1.Channelz/GetTopChannels":   {{Entity: EntityChannelz, Action: "read"}},
-		"/grpc.channelz.v1.Channelz/GetServers":       {{Entity: EntityChannelz, Action: "read"}},
-		"/grpc.channelz.v1.Channelz/GetServer":        {{Entity: EntityChannelz, Action: "read"}},
-		"/grpc.channelz.v1.Channelz/GetServerSockets": {{Entity: EntityChannelz, Action: "read"}},
-		"/grpc.channelz.v1.Channelz/GetChannel":       {{Entity: EntityChannelz, Action: "read"}},
-		"/grpc.channelz.v1.Channelz/GetSubchannel":    {{Entity: EntityChannelz, Action: "read"}},
-		"/grpc.channelz.v1.Channelz/GetSocket":        {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetTopChannels", channelzgrpc.Channelz_ServiceDesc.ServiceName):   {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetServers", channelzgrpc.Channelz_ServiceDesc.ServiceName):       {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetServer", channelzgrpc.Channelz_ServiceDesc.ServiceName):        {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetServerSockets", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetChannel", channelzgrpc.Channelz_ServiceDesc.ServiceName):       {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetSubchannel", channelzgrpc.Channelz_ServiceDesc.ServiceName):    {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetSocket", channelzgrpc.Channelz_ServiceDesc.ServiceName):        {{Entity: EntityChannelz, Action: "read"}},
 	}
 }
 

--- a/internal/interface/grpc/permissions/permissions.go
+++ b/internal/interface/grpc/permissions/permissions.go
@@ -269,13 +269,27 @@ func Whitelist() map[string][]bakery.Op {
 		}},
 
 		/* Channelz APIs (restricted to admin port) */
-		fmt.Sprintf("/%s/GetTopChannels", channelzgrpc.Channelz_ServiceDesc.ServiceName):   {{Entity: EntityChannelz, Action: "read"}},
-		fmt.Sprintf("/%s/GetServers", channelzgrpc.Channelz_ServiceDesc.ServiceName):       {{Entity: EntityChannelz, Action: "read"}},
-		fmt.Sprintf("/%s/GetServer", channelzgrpc.Channelz_ServiceDesc.ServiceName):        {{Entity: EntityChannelz, Action: "read"}},
-		fmt.Sprintf("/%s/GetServerSockets", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{Entity: EntityChannelz, Action: "read"}},
-		fmt.Sprintf("/%s/GetChannel", channelzgrpc.Channelz_ServiceDesc.ServiceName):       {{Entity: EntityChannelz, Action: "read"}},
-		fmt.Sprintf("/%s/GetSubchannel", channelzgrpc.Channelz_ServiceDesc.ServiceName):    {{Entity: EntityChannelz, Action: "read"}},
-		fmt.Sprintf("/%s/GetSocket", channelzgrpc.Channelz_ServiceDesc.ServiceName):        {{Entity: EntityChannelz, Action: "read"}},
+		fmt.Sprintf("/%s/GetTopChannels", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
+		fmt.Sprintf("/%s/GetServers", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
+		fmt.Sprintf("/%s/GetServer", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
+		fmt.Sprintf("/%s/GetServerSockets", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
+		fmt.Sprintf("/%s/GetChannel", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
+		fmt.Sprintf("/%s/GetSubchannel", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
+		fmt.Sprintf("/%s/GetSocket", channelzgrpc.Channelz_ServiceDesc.ServiceName): {{
+			Entity: EntityChannelz, Action: "read",
+		}},
 	}
 }
 

--- a/internal/interface/grpc/permissions/permissions_test.go
+++ b/internal/interface/grpc/permissions/permissions_test.go
@@ -7,6 +7,7 @@ import (
 	arkv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/ark/v1"
 	"github.com/arkade-os/arkd/internal/interface/grpc/permissions"
 	"github.com/stretchr/testify/require"
+	channelzgrpc "google.golang.org/grpc/channelz/grpc_channelz_v1"
 	grpchealth "google.golang.org/grpc/health/grpc_health_v1"
 )
 
@@ -75,6 +76,12 @@ func TestWhitelistedMethods(t *testing.T) {
 	allMethods = append(allMethods, fmt.Sprintf(
 		"/%s/%s", grpchealth.Health_ServiceDesc.ServiceName, "Check",
 	))
+
+	for _, path := range channelzgrpc.Channelz_ServiceDesc.Methods {
+		allMethods = append(allMethods, fmt.Sprintf(
+			"/%s/%s", channelzgrpc.Channelz_ServiceDesc.ServiceName, path.MethodName,
+		))
+	}
 
 	whitelist := permissions.Whitelist()
 	for _, m := range allMethods {


### PR DESCRIPTION
Whitelists the `channelz` endpoints in the permissions system. Seems reasonable as it's only enabled for the admin port and if `ENABLE_CHANNELZ` is set.

cc @altafan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Channelz admin API access control.
  * Introduced a new permission category so Channelz-related gRPC methods now require read access.
  * Whitelisted Channelz operations such as viewing top channels, servers, server sockets, channels, subchannels, and sockets under the appropriate permission check.
* **Tests**
  * Updated permission tests to include Channelz gRPC methods in the validated allowlist set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->