### PR TITLE
Fix: fix two bugs in client-lib (send on closed channel panic and deprecated URL)

### DIFF
--- a/pkg/client-lib/batch_session_handler.go
+++ b/pkg/client-lib/batch_session_handler.go
@@ -132,13 +132,19 @@ func JoinBatchSession(
 				continue
 			}
 
+			// Forward to the caller's replay channel inline and
+			// non-blocking. This must NOT run in a detached goroutine:
+			// the caller owns replayEventsCh and closes it once
+			// JoinBatchSession returns, so a goroutine outliving the
+			// return would race that close and panic ("send on closed
+			// channel"). An inline non-blocking send keeps the loop
+			// responsive (a slow/unread consumer just drops the event)
+			// while guaranteeing every send happens-before the return.
 			if options.replayEventsCh != nil {
-				go func() {
-					select {
-					case options.replayEventsCh <- notify.Event:
-					default:
-					}
-				}()
+				select {
+				case options.replayEventsCh <- notify.Event:
+				default:
+				}
 			}
 
 			switch event := notify.Event; event.(type) {

--- a/pkg/client-lib/batch_session_handler_test.go
+++ b/pkg/client-lib/batch_session_handler_test.go
@@ -1,0 +1,124 @@
+package wallet
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/arkade-os/arkd/pkg/client-lib/client"
+	"github.com/stretchr/testify/require"
+)
+
+// noopBatchHandler satisfies BatchEventsHandler so JoinBatchSession can be
+// driven directly in tests. Its methods are never reached by
+// TestJoinBatchSessionReplayCloseSafe (the events used there either continue
+// before the handler call or terminate the loop via an error).
+type noopBatchHandler struct{}
+
+func (noopBatchHandler) OnBatchStarted(
+	context.Context, client.BatchStartedEvent,
+) (bool, time.Duration, error) {
+	return false, 0, nil
+}
+func (noopBatchHandler) OnBatchFinalized(
+	context.Context, client.BatchFinalizedEvent,
+) error {
+	return nil
+}
+func (noopBatchHandler) OnBatchFailed(
+	context.Context, client.BatchFailedEvent,
+) error {
+	return nil
+}
+func (noopBatchHandler) OnTreeTxEvent(
+	context.Context, client.TreeTxEvent,
+) error {
+	return nil
+}
+func (noopBatchHandler) OnTreeSignatureEvent(
+	context.Context, client.TreeSignatureEvent,
+) error {
+	return nil
+}
+func (noopBatchHandler) OnTreeSigningStarted(
+	context.Context, client.TreeSigningStartedEvent, *tree.TxTree,
+) (bool, error) {
+	return false, nil
+}
+func (noopBatchHandler) OnTreeNoncesAggregated(
+	context.Context, client.TreeNoncesAggregatedEvent,
+) (bool, error) {
+	return false, nil
+}
+func (noopBatchHandler) OnTreeNonces(
+	context.Context, client.TreeNoncesEvent,
+) (bool, error) {
+	return false, nil
+}
+func (noopBatchHandler) OnBatchFinalization(
+	context.Context, client.BatchFinalizationEvent, *tree.TxTree,
+	*tree.TxTree,
+) ([]string, error) {
+	return nil, nil
+}
+func (noopBatchHandler) OnStreamStarted(
+	context.Context, client.StreamStartedEvent,
+) error {
+	return nil
+}
+
+var _ BatchEventsHandler = noopBatchHandler{}
+
+// TestJoinBatchSessionReplayCloseSafe is a regression test for the
+// "panic: send on closed channel" fix during a collaborative exit.
+//
+// JoinBatchSession forwards every batch event to the caller-supplied
+// WithReplay channel. The caller owns that channel and closes it once
+// JoinBatchSession returns. If the forwarding runs in detached goroutines that
+// can outlive the return, the caller's close() races an in-flight send and the
+// process panics.
+//
+// The test drives a burst of forwarded events, terminates the session, then
+// closes the replay channel exactly as a caller would. It must never panic:
+// all forwards have to happen-before JoinBatchSession returns.
+func TestJoinBatchSessionReplayCloseSafe(t *testing.T) {
+	const (
+		iterations = 50
+		burst      = 256
+	)
+
+	errStop := errors.New("stop the session")
+
+	for i := 0; i < iterations; i++ {
+		// Buffer everything up front so JoinBatchSession races through the
+		// whole burst in a tight loop, then returns — maximising the number
+		// of replay forwards in flight when the caller closes below.
+		eventsCh := make(chan client.BatchEventChannel, burst+1)
+		replayCh := make(chan any, burst)
+
+		// At the initial step, a TreeTxEvent makes the loop forward to the
+		// replay channel and then `continue` without invoking the handler.
+		// An Err event then returns from JoinBatchSession.
+		for j := 0; j < burst; j++ {
+			eventsCh <- client.BatchEventChannel{Event: client.TreeTxEvent{}}
+		}
+		eventsCh <- client.BatchEventChannel{Err: errStop}
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, _, _, _, _, err := JoinBatchSession(
+				context.Background(), eventsCh, noopBatchHandler{},
+				WithReplay(replayCh),
+			)
+			errCh <- err
+		}()
+
+		require.ErrorIs(t, <-errCh, errStop)
+
+		// The caller closes the replay channel it owns once the session has
+		// returned. This must be safe: no forwarder may still be running.
+		close(replayCh)
+	}
+}

--- a/pkg/client-lib/batch_session_handler_test.go
+++ b/pkg/client-lib/batch_session_handler_test.go
@@ -11,6 +11,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestJoinBatchSessionReplayCloseSafe is a regression test for the
+// "panic: send on closed channel" fix during a collaborative exit.
+//
+// JoinBatchSession forwards every batch event to the caller-supplied
+// WithReplay channel. The caller owns that channel and closes it once
+// JoinBatchSession returns. If the forwarding runs in detached goroutines that
+// can outlive the return, the caller's close() races an in-flight send and the
+// process panics.
+//
+// The test drives a burst of forwarded events, terminates the session, then
+// closes the replay channel exactly as a caller would. It must never panic:
+// all forwards have to happen-before JoinBatchSession returns.
+func TestJoinBatchSessionReplayCloseSafe(t *testing.T) {
+	const (
+		iterations = 50
+		burst      = 256
+	)
+
+	errStop := errors.New("stop the session")
+
+	for i := 0; i < iterations; i++ {
+		// Buffer everything up front so JoinBatchSession races through the
+		// whole burst in a tight loop, then returns — maximising the number
+		// of replay forwards in flight when the caller closes below.
+		eventsCh := make(chan client.BatchEventChannel, burst+1)
+		replayCh := make(chan any, burst)
+
+		// At the initial step, a TreeTxEvent makes the loop forward to the
+		// replay channel and then `continue` without invoking the handler.
+		// An Err event then returns from JoinBatchSession.
+		for j := 0; j < burst; j++ {
+			eventsCh <- client.BatchEventChannel{Event: client.TreeTxEvent{}}
+		}
+		eventsCh <- client.BatchEventChannel{Err: errStop}
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, _, _, _, _, err := JoinBatchSession(
+				t.Context(), eventsCh, noopBatchHandler{}, WithReplay(replayCh),
+			)
+			errCh <- err
+		}()
+
+		require.ErrorIs(t, <-errCh, errStop)
+
+		// The caller closes the replay channel it owns once the session has
+		// returned. This must be safe: no forwarder may still be running.
+		close(replayCh)
+	}
+}
+
 // noopBatchHandler satisfies BatchEventsHandler so JoinBatchSession can be
 // driven directly in tests. Its methods are never reached by
 // TestJoinBatchSessionReplayCloseSafe (the events used there either continue
@@ -67,58 +118,4 @@ func (noopBatchHandler) OnStreamStarted(
 	context.Context, client.StreamStartedEvent,
 ) error {
 	return nil
-}
-
-var _ BatchEventsHandler = noopBatchHandler{}
-
-// TestJoinBatchSessionReplayCloseSafe is a regression test for the
-// "panic: send on closed channel" fix during a collaborative exit.
-//
-// JoinBatchSession forwards every batch event to the caller-supplied
-// WithReplay channel. The caller owns that channel and closes it once
-// JoinBatchSession returns. If the forwarding runs in detached goroutines that
-// can outlive the return, the caller's close() races an in-flight send and the
-// process panics.
-//
-// The test drives a burst of forwarded events, terminates the session, then
-// closes the replay channel exactly as a caller would. It must never panic:
-// all forwards have to happen-before JoinBatchSession returns.
-func TestJoinBatchSessionReplayCloseSafe(t *testing.T) {
-	const (
-		iterations = 50
-		burst      = 256
-	)
-
-	errStop := errors.New("stop the session")
-
-	for i := 0; i < iterations; i++ {
-		// Buffer everything up front so JoinBatchSession races through the
-		// whole burst in a tight loop, then returns — maximising the number
-		// of replay forwards in flight when the caller closes below.
-		eventsCh := make(chan client.BatchEventChannel, burst+1)
-		replayCh := make(chan any, burst)
-
-		// At the initial step, a TreeTxEvent makes the loop forward to the
-		// replay channel and then `continue` without invoking the handler.
-		// An Err event then returns from JoinBatchSession.
-		for j := 0; j < burst; j++ {
-			eventsCh <- client.BatchEventChannel{Event: client.TreeTxEvent{}}
-		}
-		eventsCh <- client.BatchEventChannel{Err: errStop}
-
-		errCh := make(chan error, 1)
-		go func() {
-			_, _, _, _, _, err := JoinBatchSession(
-				context.Background(), eventsCh, noopBatchHandler{},
-				WithReplay(replayCh),
-			)
-			errCh <- err
-		}()
-
-		require.ErrorIs(t, <-errCh, errStop)
-
-		// The caller closes the replay channel it owns once the session has
-		// returned. This must be safe: no forwarder may still be running.
-		close(replayCh)
-	}
 }

--- a/pkg/client-lib/explorer/mempool/explorer.go
+++ b/pkg/client-lib/explorer/mempool/explorer.go
@@ -230,8 +230,11 @@ func (e *explorerSvc) GetNetwork() arklib.Network {
 	return e.net
 }
 
-func (e *explorerSvc) GetFeeRate() (float64, error) {
-	endpoint, err := url.JoinPath(e.baseUrl, "fee-estimates")
+// readJSON reads from an endpoint with the given path into the target (which
+// must be a pointer to a struct or map) and returns the HTTP status and error
+// if it fails (or http.StatusOK and nil if it succeeds).
+func (e *explorerSvc) readJSON(path string, target any) (int, error) {
+	endpoint, err := url.JoinPath(e.baseUrl, path)
 	if err != nil {
 		return 0, err
 	}
@@ -243,21 +246,56 @@ func (e *explorerSvc) GetFeeRate() (float64, error) {
 	// nolint:all
 	defer resp.Body.Close()
 
-	var response map[string]float64
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return 0, err
 	}
 
+	// Check the status BEFORE decoding. An explorer that answers with a
+	// non-JSON error body (e.g. a transient non-200, or one that doesn't
+	// serve this endpoint) would otherwise fail the Decode below with a
+	// misleading "invalid character ..." parse error instead of surfacing
+	// the real response — which callers can't retry on intelligently.
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("failed to get fee rate: %s", resp.Status)
+		return resp.StatusCode, fmt.Errorf(
+			"failed to get fee rate: status %d: %s",
+			resp.StatusCode, string(body),
+		)
+	}
+
+	if err := json.Unmarshal(body, target); err != nil {
+		return 0, fmt.Errorf(
+			"failed to decode fee rate response %q: %w",
+			string(body), err,
+		)
+	}
+
+	return http.StatusOK, nil
+}
+
+func (e *explorerSvc) GetFeeRate() (float64, error) {
+	var response map[string]float64
+	status, err := e.readJSON("v1/fees/recommended", &response)
+	if err != nil {
+		// If the new v1/fees/recommended endpoint is not found, we try
+		// the old fee-estimates. This is also the path to take in
+		// regtest, where we might not have a full mempool backend but
+		// just a bare electrs server.
+		if status == http.StatusNotFound {
+			status, err = e.readJSON("fee-estimates", &response)
+			if err != nil {
+				return 0, err
+			}
+		} else {
+			return 0, err
+		}
 	}
 
 	if len(response) == 0 {
 		return 1, nil
 	}
 
-	return response["1"], nil
+	return response["fastestFee"], nil
 }
 
 func (e *explorerSvc) GetConnectionCount() int {

--- a/pkg/client-lib/explorer/mempool/explorer.go
+++ b/pkg/client-lib/explorer/mempool/explorer.go
@@ -230,65 +230,17 @@ func (e *explorerSvc) GetNetwork() arklib.Network {
 	return e.net
 }
 
-// readJSON reads from an endpoint with the given path into the target (which
-// must be a pointer to a struct or map) and returns the HTTP status and error
-// if it fails (or http.StatusOK and nil if it succeeds).
-func (e *explorerSvc) readJSON(path string, target any) (int, error) {
-	endpoint, err := url.JoinPath(e.baseUrl, path)
-	if err != nil {
-		return 0, err
-	}
-
-	resp, err := http.Get(endpoint)
-	if err != nil {
-		return 0, err
-	}
-	// nolint:all
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return 0, err
-	}
-
-	// Check the status BEFORE decoding. An explorer that answers with a
-	// non-JSON error body (e.g. a transient non-200, or one that doesn't
-	// serve this endpoint) would otherwise fail the Decode below with a
-	// misleading "invalid character ..." parse error instead of surfacing
-	// the real response — which callers can't retry on intelligently.
-	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, fmt.Errorf(
-			"failed to get fee rate: status %d: %s",
-			resp.StatusCode, string(body),
-		)
-	}
-
-	if err := json.Unmarshal(body, target); err != nil {
-		return 0, fmt.Errorf(
-			"failed to decode fee rate response %q: %w",
-			string(body), err,
-		)
-	}
-
-	return http.StatusOK, nil
-}
-
 func (e *explorerSvc) GetFeeRate() (float64, error) {
 	var response map[string]float64
-	status, err := e.readJSON("v1/fees/recommended", &response)
+	status, err := e.get("v1/fees/recommended", &response)
 	if err != nil {
-		// If the new v1/fees/recommended endpoint is not found, we try
-		// the old fee-estimates. This is also the path to take in
-		// regtest, where we might not have a full mempool backend but
-		// just a bare electrs server.
+		// If the new v1/fees/recommended endpoint is not found, we try the old /fee-estimates to
+		// keep backward compatibility in case the environment does not make use of the latest
+		// mempool backend version.
 		if status == http.StatusNotFound {
-			status, err = e.readJSON("fee-estimates", &response)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			return 0, err
+			return e.getLegacyFeeRate()
 		}
+		return 0, err
 	}
 
 	if len(response) == 0 {
@@ -296,6 +248,19 @@ func (e *explorerSvc) GetFeeRate() (float64, error) {
 	}
 
 	return response["fastestFee"], nil
+}
+
+func (e *explorerSvc) getLegacyFeeRate() (float64, error) {
+	var response map[string]float64
+	if _, err := e.get("fee-estimates", &response); err != nil {
+		return 0, err
+	}
+
+	if len(response) == 0 {
+		return 1, nil
+	}
+
+	return response["1"], nil
 }
 
 func (e *explorerSvc) GetConnectionCount() int {
@@ -1075,4 +1040,47 @@ func (e *explorerSvc) broadcastPackage(txs ...string) (string, error) {
 	}
 
 	return string(bodyResponse), nil
+}
+
+// get reads from an endpoint with the given path into the target (which
+// must be a pointer to a struct or map) and returns the HTTP status and error
+// if it fails (or http.StatusOK and nil if it succeeds).
+func (e *explorerSvc) get(path string, target any) (int, error) {
+	endpoint, err := url.JoinPath(e.baseUrl, path)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		return 0, err
+	}
+	// nolint:all
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+
+	// Check the status BEFORE decoding. An explorer that answers with a
+	// non-JSON error body (e.g. a transient non-200, or one that doesn't
+	// serve this endpoint) would otherwise fail the Decode below with a
+	// misleading "invalid character ..." parse error instead of surfacing
+	// the real response — which callers can't retry on intelligently.
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, fmt.Errorf(
+			"failed to get fee rate: status %d: %s",
+			resp.StatusCode, string(body),
+		)
+	}
+
+	if err := json.Unmarshal(body, target); err != nil {
+		return 0, fmt.Errorf(
+			"failed to decode fee rate response %q: %w",
+			string(body), err,
+		)
+	}
+
+	return http.StatusOK, nil
 }

--- a/pkg/client-lib/explorer/service_test.go
+++ b/pkg/client-lib/explorer/service_test.go
@@ -314,9 +314,7 @@ func TestGetFeeRate(t *testing.T) {
 		t.Run("populated map on old endpoint", func(t *testing.T) {
 			ts := newTestServer(t)
 			ts.handle("/fee-estimates", ts.jsonResponse(
-				http.StatusOK, map[string]float64{
-					"fastestFee": 5.5,
-				},
+				http.StatusOK, map[string]float64{"1": 5.5},
 			))
 
 			svc := makeExplorer(t, ts.URL)

--- a/pkg/client-lib/explorer/service_test.go
+++ b/pkg/client-lib/explorer/service_test.go
@@ -298,8 +298,25 @@ func TestGetFeeRate(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		t.Run("populated map", func(t *testing.T) {
 			ts := newTestServer(t)
+			ts.handle("/v1/fees/recommended", ts.jsonResponse(
+				http.StatusOK, map[string]float64{
+					"fastestFee": 5.5,
+				},
+			))
+
+			svc := makeExplorer(t, ts.URL)
+
+			fee, err := svc.GetFeeRate()
+			require.NoError(t, err)
+			require.Equal(t, 5.5, fee)
+		})
+
+		t.Run("populated map on old endpoint", func(t *testing.T) {
+			ts := newTestServer(t)
 			ts.handle("/fee-estimates", ts.jsonResponse(
-				http.StatusOK, map[string]float64{"1": 5.5},
+				http.StatusOK, map[string]float64{
+					"fastestFee": 5.5,
+				},
 			))
 
 			svc := makeExplorer(t, ts.URL)
@@ -311,7 +328,9 @@ func TestGetFeeRate(t *testing.T) {
 
 		t.Run("empty map returns 1", func(t *testing.T) {
 			ts := newTestServer(t)
-			ts.handle("/fee-estimates", ts.jsonResponse(http.StatusOK, map[string]float64{}))
+			ts.handle("/v1/fees/recommended", ts.jsonResponse(
+				http.StatusOK, map[string]float64{},
+			))
 
 			svc := makeExplorer(t, ts.URL)
 
@@ -322,9 +341,27 @@ func TestGetFeeRate(t *testing.T) {
 	})
 
 	t.Run("invalid", func(t *testing.T) {
-		t.Run("non-200", func(t *testing.T) {
+		t.Run("non-200-unavialable", func(t *testing.T) {
 			ts := newTestServer(t)
-			ts.handle("/fee-estimates", ts.textResponse(http.StatusInternalServerError, "error"))
+			ts.handle("/v1/fees/recommended", ts.textResponse(
+				http.StatusServiceUnavailable,
+				"electrs is warming up",
+			))
+
+			svc := makeExplorer(t, ts.URL)
+
+			_, err := svc.GetFeeRate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "503")
+			require.Contains(t, err.Error(), "electrs")
+			require.NotContains(t, err.Error(), "invalid character")
+		})
+
+		t.Run("non-200-internal-server-error", func(t *testing.T) {
+			ts := newTestServer(t)
+			ts.handle("/v1/fees/recommended", ts.textResponse(
+				http.StatusInternalServerError, "error",
+			))
 
 			svc := makeExplorer(t, ts.URL)
 
@@ -334,7 +371,9 @@ func TestGetFeeRate(t *testing.T) {
 
 		t.Run("malformed json", func(t *testing.T) {
 			ts := newTestServer(t)
-			ts.handle("/fee-estimates", ts.textResponse(http.StatusOK, "not-json"))
+			ts.handle("/v1/fees/recommended", ts.textResponse(
+				http.StatusOK, "not-json",
+			))
 
 			svc := makeExplorer(t, ts.URL)
 


### PR DESCRIPTION
Two issues I ran into after updating to the latest version of `arkd` and the Go SDK (`pkg/client-lib`).

1. If the caller passes in a replay channel but closes it before the anonymous goroutine could write to it, a "send on closed channel" panic occurs. Not sending in a goroutine fixes the issue.
2. The `/api/fee-estimates` endpoint of Mempool is deprecated and currently not served anymore on https://mempool.mutinynet.arkade.sh/api/fee-estimates, so we switch the client library to use the `/api/v1/fees/recommended` endpoint instead, which works on [mutinynet](https://mempool.mutinynet.arkade.sh/api/v1/fees/recommended).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved batch session shutdown to prevent rare “send on closed channel” panics when replay events are still in flight.
  - Updated mempool fee rate fetching to use the recommended-fee endpoint and field, with safe fallback behavior for missing endpoints.
- **Tests**
  - Added a regression test to ensure batch sessions terminate cleanly even if the caller closes the replay channel immediately after return.
  - Updated fee-rate service tests to match the latest recommended-fee API contract and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->