### PR TITLE
fix: CSVMultisigClosure small int decoding logic

### DIFF
--- a/pkg/ark-lib/locktime.go
+++ b/pkg/ark-lib/locktime.go
@@ -97,10 +97,6 @@ func BIP68DecodeSequenceFromBytes(sequence []byte) (*RelativeLocktime, error) {
 		return nil, err
 	}
 
-	if scriptNumber >= txscript.OP_1 && scriptNumber <= txscript.OP_16 {
-		scriptNumber = scriptNumber - (txscript.OP_1 - 1)
-	}
-
 	asNumber := int64(scriptNumber)
 
 	if asNumber&SEQUENCE_LOCKTIME_DISABLE_FLAG != 0 {

--- a/pkg/ark-lib/locktime_test.go
+++ b/pkg/ark-lib/locktime_test.go
@@ -116,6 +116,21 @@ func TestBIP68Sequence(t *testing.T) {
 				require.Equal(t, tt.expected, got)
 			})
 		}
+
+		t.Run("block locktimes roundtrip", func(t *testing.T) {
+			for value := uint32(0); value <= arklib.SEQUENCE_LOCKTIME_MASK; value++ {
+				loctime := arklib.RelativeLocktime{
+					Type:  arklib.LocktimeTypeBlock,
+					Value: value,
+				}
+				val, err := arklib.BIP68Sequence(loctime)
+				require.NoError(t, err)
+
+				gotLocktime, disabled := arklib.BIP68DecodeSequence(val)
+				require.False(t, disabled)
+				require.Equal(t, loctime, *gotLocktime)
+			}
+		})
 	})
 
 	t.Run("invalid", func(t *testing.T) {

--- a/pkg/ark-lib/script/closure.go
+++ b/pkg/ark-lib/script/closure.go
@@ -355,14 +355,17 @@ func (d *CSVMultisigClosure) Decode(script []byte) (bool, error) {
 	}
 
 	var sequence []byte
-	if txscript.IsSmallInt(tokenizer.Opcode()) {
-		if tokenizer.Opcode() == txscript.OP_0 {
-			// minimal encoding for a zero scriptnum is an empty slice
-			sequence = []byte{}
+	
+	scriptNumOpcode := tokenizer.Opcode()
+	// small int (0-16) are encoded with 1 OP_x opcode
+	if txscript.IsSmallInt(scriptNumOpcode) {
+		if scriptNumOpcode == txscript.OP_0 {
+			sequence = []byte{} // minimal encoding policy forces empty byte slice for OP_0
 		} else {
-			sequence = []byte{tokenizer.Opcode()}
+			sequence = []byte{scriptNumOpcode - (txscript.OP_1 - 1)}
 		}
 	} else {
+		// if bigger than 16, int is encoded as pushdata byte slice
 		sequence = tokenizer.Data()
 	}
 

--- a/pkg/ark-lib/script/script_test.go
+++ b/pkg/ark-lib/script/script_test.go
@@ -784,6 +784,30 @@ func TestCSVMultisigClosure(t *testing.T) {
 		require.True(t, valid)
 		require.Equal(t, uint32(arklib.SECONDS_MAX), decodedCSV.Locktime.Value)
 	})
+
+	t.Run("all block locktimes", func(t *testing.T) {
+		for value := uint32(0); value <= arklib.SEQUENCE_LOCKTIME_MASK; value++ {
+			csvSig := &script.CSVMultisigClosure{
+				MultisigClosure: script.MultisigClosure{
+					PubKeys: []*btcec.PublicKey{pubkey1},
+				},
+				Locktime: arklib.RelativeLocktime{
+					Type:  arklib.LocktimeTypeBlock,
+					Value: value,
+				},
+			}
+
+			scriptBytes, err := csvSig.Script()
+			require.NoError(t, err)
+
+			decodedCSV := &script.CSVMultisigClosure{}
+			valid, err := decodedCSV.Decode(scriptBytes)
+			require.NoError(t, err)
+			require.True(t, valid)
+			require.Equal(t, arklib.LocktimeTypeBlock, decodedCSV.Locktime.Type)
+			require.Equal(t, value, decodedCSV.Locktime.Value)
+		}
+	})
 }
 
 func TestMultisigClosureWitness(t *testing.T) {

--- a/pkg/ark-lib/script/script_test.go
+++ b/pkg/ark-lib/script/script_test.go
@@ -784,30 +784,6 @@ func TestCSVMultisigClosure(t *testing.T) {
 		require.True(t, valid)
 		require.Equal(t, uint32(arklib.SECONDS_MAX), decodedCSV.Locktime.Value)
 	})
-
-	t.Run("all block locktimes", func(t *testing.T) {
-		for value := uint32(0); value <= arklib.SEQUENCE_LOCKTIME_MASK; value++ {
-			csvSig := &script.CSVMultisigClosure{
-				MultisigClosure: script.MultisigClosure{
-					PubKeys: []*btcec.PublicKey{pubkey1},
-				},
-				Locktime: arklib.RelativeLocktime{
-					Type:  arklib.LocktimeTypeBlock,
-					Value: value,
-				},
-			}
-
-			scriptBytes, err := csvSig.Script()
-			require.NoError(t, err)
-
-			decodedCSV := &script.CSVMultisigClosure{}
-			valid, err := decodedCSV.Decode(scriptBytes)
-			require.NoError(t, err)
-			require.True(t, valid)
-			require.Equal(t, arklib.LocktimeTypeBlock, decodedCSV.Locktime.Type)
-			require.Equal(t, value, decodedCSV.Locktime.Value)
-		}
-	})
 }
 
 func TestMultisigClosureWitness(t *testing.T) {


### PR DESCRIPTION
fix the small int decoding logic. the current version is failing to decode block locktime from 81 to 96. this PR is fixing it.

@altafan @d4rp4t please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative locktime decoding consistency, including cases using small-integer encodings, so the interpreted locktime type/value is preserved.
  * Fixed CSV multisig locktime token parsing to retain the correct numeric value for small locktime tokens.
* **Tests**
  * Expanded round-trip test coverage for block-based relative locktimes across the full supported range, including decoding verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->