### PR TITLE
fix(indexer): restore not-found message and add SUBSCRIPTION_NOT_FOUND code

### DIFF
--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/arkade-os/arkd/internal/core/domain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/asset"
 	"github.com/arkade-os/arkd/pkg/ark-lib/intent"
+	arkdErrors "github.com/arkade-os/arkd/pkg/errors"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/txscript"
@@ -495,10 +496,7 @@ func (h *indexerService) GetSubscription(
 		var err error
 		scriptCh, err = h.scriptSubsHandler.getListenerChannel(subscriptionId)
 		if err != nil {
-			if errors.Is(err, ErrSubscriptionNotFound) {
-				return status.Error(codes.NotFound, err.Error())
-			}
-			return status.Error(codes.Internal, err.Error())
+			return subscriptionErr(subscriptionId, err)
 		}
 	}
 
@@ -603,22 +601,15 @@ func (h *indexerService) applyFilter(
 
 	// Mutate: expressions first (literal overwrite), then scripts.
 	if err := h.scriptSubsHandler.installTxFilters(subscriptionID, compiledExprs); err != nil {
-		switch {
-		case errors.Is(err, ErrSubscriptionNotFound):
-			return status.Error(codes.NotFound, err.Error())
-		case errors.Is(err, ErrTxFiltersLimitExceeded):
+		if errors.Is(err, ErrTxFiltersLimitExceeded) {
 			return status.Error(codes.InvalidArgument, err.Error())
-		default:
-			return status.Error(codes.Internal, err.Error())
 		}
+		return subscriptionErr(subscriptionID, err)
 	}
 
 	if len(parsedAdd) > 0 {
 		if err := h.scriptSubsHandler.addTopics(subscriptionID, parsedAdd); err != nil {
-			if errors.Is(err, ErrSubscriptionNotFound) {
-				return status.Error(codes.NotFound, err.Error())
-			}
-			return status.Error(codes.Internal, err.Error())
+			return subscriptionErr(subscriptionID, err)
 		}
 	}
 
@@ -629,18 +620,12 @@ func (h *indexerService) applyFilter(
 	switch {
 	case len(parsedRemove) > 0:
 		if err := h.scriptSubsHandler.removeTopics(subscriptionID, parsedRemove); err != nil {
-			if errors.Is(err, ErrSubscriptionNotFound) {
-				return status.Error(codes.NotFound, err.Error())
-			}
-			return status.Error(codes.Internal, err.Error())
+			return subscriptionErr(subscriptionID, err)
 		}
 	case len(parsedAdd) == 0:
 		// Both add and remove empty: mirror UnsubscribeForScripts and clear all.
 		if err := h.scriptSubsHandler.removeAllTopics(subscriptionID); err != nil {
-			if errors.Is(err, ErrSubscriptionNotFound) {
-				return status.Error(codes.NotFound, err.Error())
-			}
-			return status.Error(codes.Internal, err.Error())
+			return subscriptionErr(subscriptionID, err)
 		}
 	}
 
@@ -659,10 +644,7 @@ func (h *indexerService) UnsubscribeForScripts(
 	if len(scripts) == 0 {
 		// remove all topics
 		if err := h.scriptSubsHandler.removeAllTopics(subscriptionId); err != nil {
-			if errors.Is(err, ErrSubscriptionNotFound) {
-				return nil, status.Error(codes.NotFound, err.Error())
-			}
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, subscriptionErr(subscriptionId, err)
 		}
 		// Only tear down the listener if no tx filters remain on it, otherwise
 		// tx-only subscriptions would be silently dropped.
@@ -673,13 +655,26 @@ func (h *indexerService) UnsubscribeForScripts(
 	}
 
 	if err := h.scriptSubsHandler.removeTopics(subscriptionId, scripts); err != nil {
-		if errors.Is(err, ErrSubscriptionNotFound) {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, subscriptionErr(subscriptionId, err)
 	}
 
 	return &arkv1.UnsubscribeForScriptsResponse{}, nil
+}
+
+// subscriptionErr maps an error returned by the script-subscription broker
+// onto the error surfaced to the client. A missing subscription becomes the
+// structured SUBSCRIPTION_NOT_FOUND code (gRPC NotFound); any other error is
+// reported as Internal. The message keeps the legacy
+// "subscription <id> not found" phrasing so SDKs that still match on the error
+// string keep detecting stale subscriptions (see ts-sdk#600), while the
+// structured code lets clients detect it without parsing the message.
+func subscriptionErr(id string, err error) error {
+	if errors.Is(err, ErrSubscriptionNotFound) {
+		return arkdErrors.SUBSCRIPTION_NOT_FOUND.
+			New("subscription %s not found", id).
+			WithMetadata(arkdErrors.SubscriptionMetadata{SubscriptionId: id})
+	}
+	return status.Error(codes.Internal, err.Error())
 }
 
 func (h *indexerService) SubscribeForScripts(
@@ -702,7 +697,7 @@ func (h *indexerService) SubscribeForScripts(
 	} else {
 		// update listener topic
 		if err := h.scriptSubsHandler.addTopics(subscriptionId, scripts); err != nil {
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, subscriptionErr(subscriptionId, err)
 		}
 	}
 	return &arkv1.SubscribeForScriptsResponse{

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	stderrors "errors"
 	"fmt"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/arkade-os/arkd/internal/core/application"
 	"github.com/arkade-os/arkd/internal/core/domain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
+	arkdErrors "github.com/arkade-os/arkd/pkg/errors"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
@@ -753,10 +755,7 @@ func TestUpdateSubscription(t *testing.T) {
 				Filter:         scriptsAddFilter(testScript1),
 			},
 		)
-		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.NotFound, st.Code())
+		requireSubscriptionNotFound(t, err)
 	})
 
 	t.Run("unknown subscription_id with remove returns NotFound", func(t *testing.T) {
@@ -771,10 +770,7 @@ func TestUpdateSubscription(t *testing.T) {
 				},
 			},
 		)
-		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.NotFound, st.Code())
+		requireSubscriptionNotFound(t, err)
 	})
 
 	t.Run("adding duplicate scripts is idempotent", func(t *testing.T) {
@@ -1364,7 +1360,7 @@ func TestTxFilter(t *testing.T) {
 		}
 	})
 
-	t.Run("not-found maps to gRPC NotFound via sentinel error", func(t *testing.T) {
+	t.Run("not-found maps to structured SUBSCRIPTION_NOT_FOUND", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestIndexerService(t)
 		_, err := svc.UpdateSubscription(context.Background(),
@@ -1373,10 +1369,7 @@ func TestTxFilter(t *testing.T) {
 				Filter:         txExpressionsFilter(hasExtension),
 			},
 		)
-		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.NotFound, st.Code())
+		requireSubscriptionNotFound(t, err)
 	})
 
 	t.Run("UnsubscribeForScripts keeps listener with tx filters", func(t *testing.T) {
@@ -1427,10 +1420,7 @@ func TestTxFilter(t *testing.T) {
 		_, err := svc.UnsubscribeForScripts(context.Background(),
 			&arkv1.UnsubscribeForScriptsRequest{SubscriptionId: "missing"},
 		)
-		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.NotFound, st.Code())
+		requireSubscriptionNotFound(t, err)
 
 		// Non-empty scripts path goes through removeTopics.
 		_, err = svc.UnsubscribeForScripts(context.Background(),
@@ -1439,11 +1429,51 @@ func TestTxFilter(t *testing.T) {
 				Scripts:        []string{testScript1},
 			},
 		)
-		require.Error(t, err)
-		st, ok = status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.NotFound, st.Code())
+		requireSubscriptionNotFound(t, err)
 	})
+}
+
+func TestSubscribeForScripts(t *testing.T) {
+	t.Parallel()
+
+	// Reconnecting with a subscription id the server has already dropped (its
+	// listener timed out) must return the structured SUBSCRIPTION_NOT_FOUND
+	// error rather than a generic Internal error. This is the exact path an SDK
+	// hits when it retries with a stale id; it previously regressed to
+	// codes.Internal with a message the SDK could no longer classify
+	// (see ts-sdk#600).
+	t.Run("stale subscription id returns SUBSCRIPTION_NOT_FOUND", func(t *testing.T) {
+		t.Parallel()
+		svc := newTestIndexerService(t)
+
+		_, err := svc.SubscribeForScripts(context.Background(),
+			&arkv1.SubscribeForScriptsRequest{
+				SubscriptionId: "stale-id",
+				Scripts:        []string{testScript1},
+			},
+		)
+		requireSubscriptionNotFound(t, err)
+		require.Contains(t, err.Error(), "subscription stale-id not found")
+	})
+}
+
+// requireSubscriptionNotFound asserts err is the structured
+// SUBSCRIPTION_NOT_FOUND error: it exposes the NotFound gRPC code and the
+// SUBSCRIPTION_NOT_FOUND structured code, and preserves the legacy
+// "subscription <id> not found" phrasing that some SDKs still match on.
+func requireSubscriptionNotFound(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var arkErr arkdErrors.Error
+	require.True(
+		t, stderrors.As(err, &arkErr),
+		"expected a structured arkerrors.Error, got %T: %v", err, err,
+	)
+	require.Equal(t, arkdErrors.SUBSCRIPTION_NOT_FOUND.Name, arkErr.CodeName())
+	require.Equal(t, codes.NotFound, arkErr.GrpcCode())
+	// The pre-#1074 "subscription <id> not found" phrasing must survive so SDKs
+	// that still match on the message keep detecting stale subscriptions.
+	require.Regexp(t, `(?i)subscription\s+\S+\s+not\s+found`, arkErr.Error())
 }
 
 func newTestIndexerServiceWithEvents(

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -477,3 +477,13 @@ var DIGEST_MISMATCH = Code[DigestMetadata]{
 	"DIGEST_MISMATCH",
 	grpccodes.FailedPrecondition,
 }
+
+type SubscriptionMetadata struct {
+	SubscriptionId string `json:"subscription_id"`
+}
+
+var SUBSCRIPTION_NOT_FOUND = Code[SubscriptionMetadata]{
+	50,
+	"SUBSCRIPTION_NOT_FOUND",
+	grpccodes.NotFound,
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,36 @@
+package errors
+
+import (
+	"regexp"
+	"testing"
+
+	grpccodes "google.golang.org/grpc/codes"
+)
+
+// legacyNotFoundRe is the message pattern SDKs used to detect a stale
+// subscription before structured error codes existed (see ts-sdk#600). The
+// SUBSCRIPTION_NOT_FOUND message must keep matching it so those SDKs keep
+// working.
+var legacyNotFoundRe = regexp.MustCompile(`(?i)subscription\s+\S+\s+not\s+found`)
+
+func TestSubscriptionNotFoundContract(t *testing.T) {
+	err := SUBSCRIPTION_NOT_FOUND.
+		New("subscription %s not found", "stale-id").
+		WithMetadata(SubscriptionMetadata{SubscriptionId: "stale-id"})
+
+	if got := err.Code(); got != 50 {
+		t.Fatalf("Code() = %d, want 50", got)
+	}
+	if got := err.CodeName(); got != "SUBSCRIPTION_NOT_FOUND" {
+		t.Fatalf("CodeName() = %q, want SUBSCRIPTION_NOT_FOUND", got)
+	}
+	if got := err.GrpcCode(); got != grpccodes.NotFound {
+		t.Fatalf("GrpcCode() = %v, want NotFound", got)
+	}
+	if got := err.Metadata()["subscription_id"]; got != "stale-id" {
+		t.Fatalf("Metadata()[subscription_id] = %q, want stale-id", got)
+	}
+	if !legacyNotFoundRe.MatchString(err.Error()) {
+		t.Fatalf("Error() = %q does not match legacy SDK pattern %q", err.Error(), legacyNotFoundRe)
+	}
+}


### PR DESCRIPTION
## Summary

PR #1074 reworked the indexer subscription broker and changed the not-found error message from `subscription <id> not found` to `subscription not found: <id>`. That broke SDKs which detect a stale subscription by matching the message string — see [arkade-os/ts-sdk#600](https://github.com/arkade-os/ts-sdk/pull/600), which had to loosen its regex to cope. The `SubscribeForScripts` reconnect path (the exact path an SDK hits when retrying with a stale id) also returned `codes.Internal` with no structured code at all.

This restores the legacy message **and**, following the structured-error convention already used across arkd (`pkg/errors` + the gRPC `errorConverter` interceptor), introduces a `SUBSCRIPTION_NOT_FOUND` code so clients can detect the condition without parsing the message.

## Changes

- **`pkg/errors`**: new `SUBSCRIPTION_NOT_FOUND` code (id 50, gRPC `NotFound`) + `SubscriptionMetadata{subscription_id}`, matching the `TX_NOT_FOUND` / `VTXO_NOT_FOUND` pattern.
- **`indexer.go`**: a single `subscriptionErr(id, err)` mapper returns the structured error for the `ErrSubscriptionNotFound` sentinel (`Internal` otherwise). Every indexer not-found path routes through it — `GetSubscription`, `UpdateSubscription`/`applyFilter`, `UnsubscribeForScripts`, and crucially `SubscribeForScripts`, which previously returned `codes.Internal` with no classification.
- Clients now receive gRPC `NotFound` with `ErrorDetails{code:50, name:"SUBSCRIPTION_NOT_FOUND", metadata:{subscription_id}}`. The message is `SUBSCRIPTION_NOT_FOUND (50): subscription <id> not found`, so the legacy substring survives and existing string-matching SDKs keep working (both the pre- and post-#600 ts-sdk regexes match).

## Test plan

- New `TestSubscribeForScripts` reproduces the stale-id reconnect and asserts the structured `SUBSCRIPTION_NOT_FOUND` — the regression that previously returned `Internal`.
- The existing handler NotFound assertions now go through a `requireSubscriptionNotFound` helper that checks the structured code / gRPC code **and** that the legacy `/subscription\s+\S+\s+not\s+found/i` regex still matches the message.
- New `pkg/errors/errors_test.go` locks the new code's contract (code, name, gRPC code, metadata, legacy-regex match).
- Verified locally on Linux (`golang:1.26.4`): `handlers`, `interceptors`, and `pkg/errors` test packages all green.

## Follow-up (not in this PR)

SDKs can now detect a stale subscription via `ErrorDetails.name === "SUBSCRIPTION_NOT_FOUND"` and drop message-string matching (ts-sdk#600, and the Go `client-lib`).

Relates to #1074.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for subscription and script filter actions, including clearer “not found” handling for missing or stale subscription IDs.
  * Added a structured error format for subscription-not-found cases while preserving the existing user-facing error message.
  * Reconnect, update, unsubscribe, and filter-install failures now return more consistent and appropriate error codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->