### PR TITLE
Add structured TX_FILTERS_LIMIT_EXCEEDED and INVALID_TX_FILTER errors

### DIFF
--- a/internal/interface/grpc/handlers/broker.go
+++ b/internal/interface/grpc/handlers/broker.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/arkade-os/arkd/internal/interface/grpc/handlers/txfilter"
+	arkdErrors "github.com/arkade-os/arkd/pkg/errors"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -307,7 +308,11 @@ func compileTxFilters(exprs []string) (map[string]txfilter.Filter, error) {
 	for _, expr := range exprs {
 		f, err := txfilter.Parse(expr)
 		if err != nil {
-			return nil, err
+			// Structured so clients can detect the failure and the offending
+			// expression without parsing the message.
+			return nil, arkdErrors.INVALID_TX_FILTER.
+				New("invalid tx filter %q: %s", expr, err).
+				WithMetadata(arkdErrors.TxFilterMetadata{Expression: expr})
 		}
 		filters[expr] = *f
 	}

--- a/internal/interface/grpc/handlers/broker.go
+++ b/internal/interface/grpc/handlers/broker.go
@@ -308,8 +308,6 @@ func compileTxFilters(exprs []string) (map[string]txfilter.Filter, error) {
 	for _, expr := range exprs {
 		f, err := txfilter.Parse(expr)
 		if err != nil {
-			// Structured so clients can detect the failure and the offending
-			// expression without parsing the message.
 			return nil, arkdErrors.INVALID_TX_FILTER.
 				New("invalid tx filter %q: %s", expr, err).
 				WithMetadata(arkdErrors.TxFilterMetadata{Expression: expr})

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -575,12 +575,13 @@ func (h *indexerService) applyFilter(
 	exprs := filter.GetExpressions()
 	scripts := filter.GetScripts()
 
-	// Validate all inputs upfront before any mutation. Cap enforcement on
+	// Validate all inputs upfront before any mutation. A bad expression is
+	// returned as the structured INVALID_TX_FILTER code. Cap enforcement on
 	// the compiled set is the broker's responsibility (see installTxFilters
-	// below); we still surface it as InvalidArgument when it fires.
+	// below) and surfaces as the structured TX_FILTERS_LIMIT_EXCEEDED code.
 	compiledExprs, err := compileTxFilters(exprs)
 	if err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
+		return err
 	}
 
 	var parsedAdd, parsedRemove []string
@@ -602,7 +603,15 @@ func (h *indexerService) applyFilter(
 	// Mutate: expressions first (literal overwrite), then scripts.
 	if err := h.scriptSubsHandler.installTxFilters(subscriptionID, compiledExprs); err != nil {
 		if errors.Is(err, ErrTxFiltersLimitExceeded) {
-			return status.Error(codes.InvalidArgument, err.Error())
+			// Keep the legacy message so clients matching on the string keep
+			// working. The structured code lets them detect it without parsing.
+			return arkdErrors.TX_FILTERS_LIMIT_EXCEEDED.
+				New("%s", err.Error()).
+				WithMetadata(arkdErrors.TxFiltersLimitMetadata{
+					SubscriptionId: subscriptionID,
+					MaxTxFilters:   MaxTxFiltersPerListener,
+					GotTxFilters:   len(compiledExprs),
+				})
 		}
 		return subscriptionErr(subscriptionID, err)
 	}

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -603,8 +603,6 @@ func (h *indexerService) applyFilter(
 	// Mutate: expressions first (literal overwrite), then scripts.
 	if err := h.scriptSubsHandler.installTxFilters(subscriptionID, compiledExprs); err != nil {
 		if errors.Is(err, ErrTxFiltersLimitExceeded) {
-			// Keep the legacy message so clients matching on the string keep
-			// working. The structured code lets them detect it without parsing.
 			return arkdErrors.TX_FILTERS_LIMIT_EXCEEDED.
 				New("%s", err.Error()).
 				WithMetadata(arkdErrors.TxFiltersLimitMetadata{

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -1285,8 +1285,6 @@ func TestTxFilter(t *testing.T) {
 		)
 		require.Equal(t, arkdErrors.TX_FILTERS_LIMIT_EXCEEDED.Name, arkErr.CodeName())
 		require.Equal(t, codes.InvalidArgument, arkErr.GrpcCode())
-		// The pre-existing "tx filters per subscription limit" phrasing must
-		// survive for clients that match on the message.
 		require.Contains(t, arkErr.Error(), "tx filters per subscription limit")
 		require.Equal(t, "sub-cap-grpc", arkErr.Metadata()["subscription_id"])
 		require.Equal(
@@ -1484,9 +1482,6 @@ func requireSubscriptionNotFound(t *testing.T, err error) {
 	require.Regexp(t, `(?i)subscription\s+\S+\s+not\s+found`, arkErr.Error())
 }
 
-// requireInvalidTxFilter asserts err is the structured INVALID_TX_FILTER
-// error with the InvalidArgument gRPC code and the offending expression in
-// the metadata.
 func requireInvalidTxFilter(t *testing.T, err error) {
 	t.Helper()
 	require.Error(t, err)

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -934,10 +934,7 @@ func TestTxFilter(t *testing.T) {
 			},
 			stream,
 		)
-		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.InvalidArgument, st.Code())
+		requireInvalidTxFilter(t, err)
 	})
 
 	t.Run("UpdateSubscription overwrites tx filters", func(t *testing.T) {
@@ -1002,10 +999,7 @@ func TestTxFilter(t *testing.T) {
 				Filter:         txExpressionsFilter("&&&"),
 			},
 		)
-		require.Error(t, err)
-		st, ok := status.FromError(err)
-		require.True(t, ok)
-		require.Equal(t, codes.InvalidArgument, st.Code())
+		requireInvalidTxFilter(t, err)
 
 		// Invalid expr must not mutate listener state.
 		require.Empty(t, svc.scriptSubsHandler.getTxFilters("sub-bad"))
@@ -1024,9 +1018,7 @@ func TestTxFilter(t *testing.T) {
 				Filter:         txExpressionsFilter(hasPacket42, "&&& invalid"),
 			},
 		)
-		require.Error(t, err)
-		st, _ := status.FromError(err)
-		require.Equal(t, codes.InvalidArgument, st.Code())
+		requireInvalidTxFilter(t, err)
 		require.ElementsMatch(
 			t, []string{hasExtension}, svc.scriptSubsHandler.getTxFilters("sub-atomic"),
 		)
@@ -1285,8 +1277,16 @@ func TestTxFilter(t *testing.T) {
 			},
 		)
 		require.Error(t, err)
-		st, _ := status.FromError(err)
-		require.Equal(t, codes.InvalidArgument, st.Code())
+		var arkErr arkdErrors.Error
+		require.True(
+			t, stderrors.As(err, &arkErr),
+			"expected a structured arkerrors.Error, got %T: %v", err, err,
+		)
+		require.Equal(t, arkdErrors.TX_FILTERS_LIMIT_EXCEEDED.Name, arkErr.CodeName())
+		require.Equal(t, codes.InvalidArgument, arkErr.GrpcCode())
+		// The pre-existing "tx filters per subscription limit" phrasing must
+		// survive for clients that match on the message.
+		require.Contains(t, arkErr.Error(), "tx filters per subscription limit")
 		require.Empty(t, svc.scriptSubsHandler.getTxFilters("sub-cap-grpc"))
 	})
 
@@ -1474,6 +1474,22 @@ func requireSubscriptionNotFound(t *testing.T, err error) {
 	// The pre-#1074 "subscription <id> not found" phrasing must survive so SDKs
 	// that still match on the message keep detecting stale subscriptions.
 	require.Regexp(t, `(?i)subscription\s+\S+\s+not\s+found`, arkErr.Error())
+}
+
+// requireInvalidTxFilter asserts err is the structured INVALID_TX_FILTER
+// error with the InvalidArgument gRPC code and the offending expression in
+// the metadata.
+func requireInvalidTxFilter(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var arkErr arkdErrors.Error
+	require.True(
+		t, stderrors.As(err, &arkErr),
+		"expected a structured arkerrors.Error, got %T: %v", err, err,
+	)
+	require.Equal(t, arkdErrors.INVALID_TX_FILTER.Name, arkErr.CodeName())
+	require.Equal(t, codes.InvalidArgument, arkErr.GrpcCode())
+	require.NotEmpty(t, arkErr.Metadata()["expression"])
 }
 
 func newTestIndexerServiceWithEvents(

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	stderrors "errors"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1287,6 +1288,13 @@ func TestTxFilter(t *testing.T) {
 		// The pre-existing "tx filters per subscription limit" phrasing must
 		// survive for clients that match on the message.
 		require.Contains(t, arkErr.Error(), "tx filters per subscription limit")
+		require.Equal(t, "sub-cap-grpc", arkErr.Metadata()["subscription_id"])
+		require.Equal(
+			t, strconv.Itoa(MaxTxFiltersPerListener), arkErr.Metadata()["max_tx_filters"],
+		)
+		require.Equal(
+			t, strconv.Itoa(MaxTxFiltersPerListener+1), arkErr.Metadata()["got_tx_filters"],
+		)
 		require.Empty(t, svc.scriptSubsHandler.getTxFilters("sub-cap-grpc"))
 	})
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -487,3 +487,25 @@ var SUBSCRIPTION_NOT_FOUND = Code[SubscriptionMetadata]{
 	"SUBSCRIPTION_NOT_FOUND",
 	grpccodes.NotFound,
 }
+
+type TxFiltersLimitMetadata struct {
+	SubscriptionId string `json:"subscription_id"`
+	MaxTxFilters   int    `json:"max_tx_filters"`
+	GotTxFilters   int    `json:"got_tx_filters"`
+}
+
+var TX_FILTERS_LIMIT_EXCEEDED = Code[TxFiltersLimitMetadata]{
+	51,
+	"TX_FILTERS_LIMIT_EXCEEDED",
+	grpccodes.InvalidArgument,
+}
+
+type TxFilterMetadata struct {
+	Expression string `json:"expression"`
+}
+
+var INVALID_TX_FILTER = Code[TxFilterMetadata]{
+	52,
+	"INVALID_TX_FILTER",
+	grpccodes.InvalidArgument,
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -36,8 +36,7 @@ func TestSubscriptionNotFoundContract(t *testing.T) {
 }
 
 // legacyFiltersLimitRe is the message pattern clients could match on before
-// the structured code existed. The TX_FILTERS_LIMIT_EXCEEDED message must
-// keep matching it so those clients keep working.
+// the structured code existed.
 var legacyFiltersLimitRe = regexp.MustCompile(`tx filters per subscription limit \(\d+\) exceeded`)
 
 func TestTxFiltersLimitExceededContract(t *testing.T) {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -34,3 +34,61 @@ func TestSubscriptionNotFoundContract(t *testing.T) {
 		t.Fatalf("Error() = %q does not match legacy SDK pattern %q", err.Error(), legacyNotFoundRe)
 	}
 }
+
+// legacyFiltersLimitRe is the message pattern clients could match on before
+// the structured code existed. The TX_FILTERS_LIMIT_EXCEEDED message must
+// keep matching it so those clients keep working.
+var legacyFiltersLimitRe = regexp.MustCompile(`tx filters per subscription limit \(\d+\) exceeded`)
+
+func TestTxFiltersLimitExceededContract(t *testing.T) {
+	err := TX_FILTERS_LIMIT_EXCEEDED.
+		New("tx filters per subscription limit (%d) exceeded", 64).
+		WithMetadata(TxFiltersLimitMetadata{
+			SubscriptionId: "sub-id",
+			MaxTxFilters:   64,
+			GotTxFilters:   65,
+		})
+
+	if got := err.Code(); got != 51 {
+		t.Fatalf("Code() = %d, want 51", got)
+	}
+	if got := err.CodeName(); got != "TX_FILTERS_LIMIT_EXCEEDED" {
+		t.Fatalf("CodeName() = %q, want TX_FILTERS_LIMIT_EXCEEDED", got)
+	}
+	if got := err.GrpcCode(); got != grpccodes.InvalidArgument {
+		t.Fatalf("GrpcCode() = %v, want InvalidArgument", got)
+	}
+	if got := err.Metadata()["subscription_id"]; got != "sub-id" {
+		t.Fatalf("Metadata()[subscription_id] = %q, want sub-id", got)
+	}
+	if got := err.Metadata()["max_tx_filters"]; got != "64" {
+		t.Fatalf("Metadata()[max_tx_filters] = %q, want 64", got)
+	}
+	if got := err.Metadata()["got_tx_filters"]; got != "65" {
+		t.Fatalf("Metadata()[got_tx_filters] = %q, want 65", got)
+	}
+	if !legacyFiltersLimitRe.MatchString(err.Error()) {
+		t.Fatalf(
+			"Error() = %q does not match legacy pattern %q", err.Error(), legacyFiltersLimitRe,
+		)
+	}
+}
+
+func TestInvalidTxFilterContract(t *testing.T) {
+	err := INVALID_TX_FILTER.
+		New("invalid tx filter %q: %s", "&&&", "compile failed").
+		WithMetadata(TxFilterMetadata{Expression: "&&&"})
+
+	if got := err.Code(); got != 52 {
+		t.Fatalf("Code() = %d, want 52", got)
+	}
+	if got := err.CodeName(); got != "INVALID_TX_FILTER" {
+		t.Fatalf("CodeName() = %q, want INVALID_TX_FILTER", got)
+	}
+	if got := err.GrpcCode(); got != grpccodes.InvalidArgument {
+		t.Fatalf("GrpcCode() = %v, want InvalidArgument", got)
+	}
+	if got := err.Metadata()["expression"]; got != "&&&" {
+		t.Fatalf("Metadata()[expression] = %q, want &&&", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #1140, which added the structured `SUBSCRIPTION_NOT_FOUND` code for the subscription errors introduced in #1074. That covered the not-found path only. The two other client-facing errors born in #1074 still reached clients as plain strings. This PR converts them.

## What changed

- **`TX_FILTERS_LIMIT_EXCEEDED`** (code 51, gRPC `InvalidArgument`). Returned when a subscription update would push the compiled tx filter count above `MaxTxFiltersPerListener`. Metadata carries `subscription_id`, `max_tx_filters` and `got_tx_filters`. The legacy "tx filters per subscription limit (64) exceeded" message is preserved inside the structured error so clients matching on the string keep working.
- **`INVALID_TX_FILTER`** (code 52, gRPC `InvalidArgument`). Returned when a CEL filter expression fails to compile. Metadata carries the offending `expression`, so a client submitting a batch of filters can tell which one failed without parsing the message.

Both are converted at the same boundary #1140 used. The broker sentinel stays internal and the handler maps it to the structured error, which the existing `ErrorDetails` interceptor exposes to clients. The gRPC codes are unchanged, both were already `InvalidArgument`.

## Tests

- Contract tests in `pkg/errors` pin the code number, name, gRPC code, metadata keys and the legacy limit message pattern, mirroring `TestSubscriptionNotFoundContract` from #1140.
- Handler tests updated to assert the structured codes. Invalid CEL assertions go through a new `requireInvalidTxFilter` helper mirroring `requireSubscriptionNotFound`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction filter validation to return structured, actionable errors that include the exact invalid filter expression.
  * When transaction filter limits are exceeded, the app now returns a structured error with subscription and limit metadata, while preserving the legacy error message format.
* **Tests**
  * Updated and strengthened test coverage to verify the structured error codes (including gRPC codes), required metadata fields, and legacy message-pattern compatibility for invalid filters and limit-exceeded scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->