### PR TITLE
fix(indexer): snapshot listener topics in dispatch loop to avoid map race

### DIFF
--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -812,7 +812,13 @@ func (h *indexerService) listenToTxEvents() {
 			spentVtxos := make([]*arkv1.IndexerVtxo, 0)
 			involvedScripts := make([]string, 0)
 
-			for vtxoScript := range l.topics {
+			// Snapshot the topics under the listener's lock. Ranging l.topics
+			// directly races with addTopics/removeTopics/overwriteTopics, which
+			// the Subscribe/Update/Unsubscribe RPCs call under the lock. A
+			// concurrent map iteration and write is a fatal, unrecoverable
+			// runtime error that would crash the whole process. getTopics copies
+			// the keys under the lock, the same way matchesTx does for filters.
+			for _, vtxoScript := range l.getTopics() {
 				spendableVtxosForScript := allSpendableVtxos[vtxoScript]
 				spentVtxosForScript := allSpentVtxos[vtxoScript]
 				spendableVtxos = append(spendableVtxos, spendableVtxosForScript...)

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -1684,6 +1684,59 @@ func TestTxFilter(t *testing.T) {
 		}
 	})
 
+	t.Run("listenToTxEvents topic iteration is race-free under concurrent updates", func(t *testing.T) {
+		t.Parallel()
+		// The dispatch loop iterates each listener's topics for every event.
+		// That read must be synchronized with the Subscribe/Update/Unsubscribe
+		// RPCs that mutate the same map under the listener lock: an
+		// unsynchronized read is a concurrent map iteration and write, a fatal
+		// runtime error that crashes the process. Under -race this fails on the
+		// unsynchronized read and passes once the read is snapshotted under the
+		// lock.
+		eventsCh := make(chan application.TransactionEvent, 8)
+		t.Cleanup(func() { close(eventsCh) })
+		svc := newTestIndexerServiceWithEvents(t, eventsCh)
+		go svc.listenToTxEvents()
+
+		listener := newListener[*arkv1.GetSubscriptionResponse](
+			"sub-race", []string{testScript1},
+		)
+		svc.scriptSubsHandler.pushListener(listener)
+
+		done := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Writer: churn the listener's topics under its lock, the way the
+		// Subscribe/Update/Unsubscribe RPCs do, until the reader is finished.
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					listener.addTopics([]string{testScript2})
+					listener.removeTopics([]string{testScript2})
+				}
+			}
+		}()
+
+		// Reader: drive the dispatch loop, which iterates listener.topics once
+		// per event regardless of whether the event matches.
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 3000; i++ {
+				eventsCh <- application.TransactionEvent{
+					TxData: application.TxData{Txid: "race-evt"},
+				}
+			}
+			close(done)
+		}()
+
+		wg.Wait()
+	})
+
 	t.Run("not-found maps to structured SUBSCRIPTION_NOT_FOUND", func(t *testing.T) {
 		t.Parallel()
 		svc := newTestIndexerService(t)


### PR DESCRIPTION
## Problem

`listenToTxEvents` iterated each listener's `topics` map without holding the listener lock:

```go
for vtxoScript := range l.topics {
```

Meanwhile `addTopics` / `removeTopics` / `overwriteTopics` write that same map under `l.lock`, driven by the `SubscribeForScripts`, `UpdateSubscription`, and `UnsubscribeForScripts` RPCs. A concurrent map iteration and map write is a fatal, unrecoverable Go runtime error (`fatal error: concurrent map iteration and map write`). The dispatch goroutine has no `recover` and could not use one anyway, so this crashes the whole arkd process and takes down every subscription.

`getListenersCopy()` does not help here. It copies the outer map, but the values are `*listener` pointers, so `l.topics` is still the one shared inner map.

## Fix

Iterate a snapshot taken under the lock via the existing `getTopics()` helper, the same pattern `matchesTx` already uses for filters:

```go
for _, vtxoScript := range l.getTopics() {
```

Behavior is unchanged. Dispatch is already best-effort and has no ordering guarantee against concurrent subscription updates, so reading a point-in-time snapshot is equivalent. The only cost is one slice allocation per listener per event. If profiling later shows it matters, the site can switch to holding the read lock across the loop instead.

## Testing

- New `-race` regression test drives `listenToTxEvents` against concurrent topic mutations. It fails on the old code (data race reported by `-race`) and passes with the fix.
- Full `handlers` package passes under `-race`.
- `golangci-lint run --tests=false`: 0 issues.

## Scope

Pre-existing bug, independent of #1143. Found while reviewing the subscription dispatch path for that PR. Kept separate because it is a different defect (dispatch-path map race, not stream lifecycle) with a different blast radius.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction event dispatch stability by iterating over a lock-protected snapshot of each listener’s topics during event handling, preventing concurrent map iteration/write crashes.
  * Ensured event matching continues to function correctly while listeners update their subscriptions concurrently.

* **Tests**
  * Added a concurrency-focused test that repeatedly adds/removes listener topics while publishing many transaction events, validating race-free, panic-free dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->