### PR TITLE
Hotfix: pass vtxoTreeExpiry in txbuilder.BuildCommitmentTx instead of constructor

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -849,9 +849,7 @@ func (c *Config) txBuilderService() error {
 	var err error
 	switch c.TxBuilderType {
 	case "covenantless":
-		svc = txbuilder.NewTxBuilder(
-			c.wallet, c.signer, *c.network, c.VtxoTreeExpiry, c.BoardingExitDelay,
-		)
+		svc = txbuilder.NewTxBuilder(c.wallet, c.signer, *c.network)
 	default:
 		err = fmt.Errorf("unknown tx builder type")
 	}

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -2898,7 +2898,7 @@ func (s *service) startFinalization(
 	s.roundReportSvc.OpStarted(BuildCommitmentTxOp)
 
 	commitmentTx, vtxoTree, connectorAddress, connectors, err := s.builder.BuildCommitmentTx(
-		forfeitPubkey, intents, boardingInputs, cosignersPublicKeys,
+		forfeitPubkey, intents, boardingInputs, cosignersPublicKeys, settings.VtxoTreeExpiry,
 	)
 	if err != nil {
 		round.Fail(errors.INTERNAL_ERROR.New("failed to create commitment tx: %s", err))

--- a/internal/core/ports/tx_builder.go
+++ b/internal/core/ports/tx_builder.go
@@ -49,8 +49,8 @@ type TxBuilder interface {
 	// utxos as inputs of the transaction.
 	// Returns the commitment tx, the vtxo tree, the connector tree and its root address.
 	BuildCommitmentTx(
-		signerPubkey *btcec.PublicKey, intents domain.Intents,
-		boardingInputs []BoardingInput, cosigners [][]string,
+		signerPubkey *btcec.PublicKey, intents domain.Intents, boardingInputs []BoardingInput,
+		cosigners [][]string, vtxoTreeExpiry arklib.RelativeLocktime,
 	) (
 		commitmentTx string, vtxoTree *tree.TxTree,
 		connectorAddress string, connectors *tree.TxTree, err error,

--- a/internal/infrastructure/live-store/live_store_test.go
+++ b/internal/infrastructure/live-store/live_store_test.go
@@ -869,13 +869,13 @@ func (m *mockedTxBuilder) VerifyForfeitTxs(
 }
 
 func (m *mockedTxBuilder) BuildCommitmentTx(
-	signerPubkey *btcec.PublicKey, intents domain.Intents,
-	boardingInputs []ports.BoardingInput, cosignerPubkeys [][]string,
+	signerPubkey *btcec.PublicKey, intents domain.Intents, boardingInputs []ports.BoardingInput,
+	cosignerPubkeys [][]string, vtxoTreeExpiry arklib.RelativeLocktime,
 ) (
 	commitmentTx string, vtxoTree *tree.TxTree,
 	connectorAddress string, connectors *tree.TxTree, err error,
 ) {
-	args := m.Called(signerPubkey, intents, boardingInputs, cosignerPubkeys)
+	args := m.Called(signerPubkey, intents, boardingInputs, cosignerPubkeys, vtxoTreeExpiry)
 	res0 := args.Get(0).(string)
 	res1 := args.Get(1).(*tree.TxTree)
 	res2 := args.Get(2).(string)

--- a/internal/infrastructure/tx-builder/covenantless/builder.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder.go
@@ -26,18 +26,15 @@ import (
 )
 
 type txBuilder struct {
-	wallet            ports.WalletService
-	signer            ports.SignerService
-	network           arklib.Network
-	vtxoTreeExpiry    arklib.RelativeLocktime
-	boardingExitDelay arklib.RelativeLocktime
+	wallet  ports.WalletService
+	signer  ports.SignerService
+	network arklib.Network
 }
 
 func NewTxBuilder(
 	wallet ports.WalletService, signer ports.SignerService, network arklib.Network,
-	vtxoTreeExpiry, boardingExitDelay arklib.RelativeLocktime,
 ) ports.TxBuilder {
-	return &txBuilder{wallet, signer, network, vtxoTreeExpiry, boardingExitDelay}
+	return &txBuilder{wallet, signer, network}
 }
 
 func (b *txBuilder) GetTxid(tx string) (string, error) {
@@ -525,7 +522,7 @@ func (b *txBuilder) VerifyForfeitTxs(
 func (b *txBuilder) BuildCommitmentTx(
 	signerPubkey *btcec.PublicKey, intents domain.Intents,
 	boardingInputs []ports.BoardingInput,
-	cosignersPublicKeys [][]string,
+	cosignersPublicKeys [][]string, vtxoTreeExpiry arklib.RelativeLocktime,
 ) (string, *tree.TxTree, string, *tree.TxTree, error) {
 	var batchOutputScript []byte
 	var batchOutputAmount int64
@@ -539,7 +536,7 @@ func (b *txBuilder) BuildCommitmentTx(
 		MultisigClosure: script.MultisigClosure{
 			PubKeys: []*btcec.PublicKey{signerPubkey},
 		},
-		Locktime: b.vtxoTreeExpiry,
+		Locktime: vtxoTreeExpiry,
 	}).Script()
 	if err != nil {
 		return "", nil, "", nil, err
@@ -644,7 +641,7 @@ func (b *txBuilder) BuildCommitmentTx(
 		}
 
 		vtxoTree, err = tree.BuildVtxoTree(
-			initialOutpoint, receivers, sweepTapscriptRoot[:], b.vtxoTreeExpiry,
+			initialOutpoint, receivers, sweepTapscriptRoot[:], vtxoTreeExpiry,
 		)
 		if err != nil {
 			return "", nil, "", nil, err

--- a/internal/infrastructure/tx-builder/covenantless/builder_test.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder_test.go
@@ -57,9 +57,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestBuildCommitmentTx(t *testing.T) {
-	builder := txbuilder.NewTxBuilder(
-		wallet, nil, arklib.Bitcoin, vtxoTreeExpiry, boardingExitDelay,
-	)
+	builder := txbuilder.NewTxBuilder(wallet, nil, arklib.Bitcoin)
 
 	fixtures, err := parseCommitmentTxFixtures()
 	require.NoError(t, err)
@@ -80,7 +78,7 @@ func TestBuildCommitmentTx(t *testing.T) {
 				}
 
 				commitmentTx, vtxoTree, connAddr, _, err := builder.BuildCommitmentTx(
-					pubkey, f.Intents, []ports.BoardingInput{}, cosignersPublicKeys,
+					pubkey, f.Intents, []ports.BoardingInput{}, cosignersPublicKeys, vtxoTreeExpiry,
 				)
 				require.NoError(t, err)
 				require.NotEmpty(t, commitmentTx)
@@ -112,6 +110,7 @@ func TestBuildCommitmentTx(t *testing.T) {
 
 				commitmentTx, vtxoTree, connAddr, _, err := builder.BuildCommitmentTx(
 					pubkey, f.Intents, []ports.BoardingInput{}, cosignersPublicKeys,
+					vtxoTreeExpiry,
 				)
 				require.EqualError(t, err, f.ExpectedErr)
 				require.Empty(t, commitmentTx)
@@ -127,8 +126,7 @@ func TestVerifyVtxoTapscriptSigs(t *testing.T) {
 	require.NoError(t, err)
 
 	builder := txbuilder.NewTxBuilder(
-		wallet, &staticSigner{pubkey: signerKey.PubKey()},
-		arklib.Bitcoin, vtxoTreeExpiry, boardingExitDelay,
+		wallet, &staticSigner{pubkey: signerKey.PubKey()}, arklib.Bitcoin,
 	)
 
 	t.Run("valid", func(t *testing.T) {

--- a/internal/infrastructure/tx-builder/covenantless/builder_test.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder_test.go
@@ -31,8 +31,7 @@ var (
 	wallet *mockedWallet
 	pubkey *btcec.PublicKey
 
-	vtxoTreeExpiry    = arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 1209344}
-	boardingExitDelay = arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512}
+	vtxoTreeExpiry = arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 1209344}
 )
 
 func TestMain(m *testing.M) {
@@ -119,6 +118,61 @@ func TestBuildCommitmentTx(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildCommitmentTxUsesVtxoTreeExpiryArg pins that the vtxoTreeExpiry argument is what gets
+// baked into the vtxo tree.
+// ValidateVtxoTree derives the expected taproot output key from the expiry, so a tree built with
+// one expiry fails validation against another; if BuildCommitmentTx ignored the argument this test
+// would fail.
+func TestBuildCommitmentTxUsesVtxoTreeExpiryArg(t *testing.T) {
+	builder := txbuilder.NewTxBuilder(wallet, nil, arklib.Bitcoin)
+
+	fixtures, err := parseCommitmentTxFixtures()
+	require.NoError(t, err)
+	require.NotEmpty(t, fixtures.Valid)
+
+	// Pick a multi-leaf fixture: ValidateVtxoTree only checks the expiry-derived
+	// taproot key on nodes that have children, so a single-leaf tree would not
+	// exercise the expiry and the mismatch below would go undetected.
+	best := 0
+	for i, cand := range fixtures.Valid {
+		if cand.ExpectedNumOfLeaves > fixtures.Valid[best].ExpectedNumOfLeaves {
+			best = i
+		}
+	}
+	f := fixtures.Valid[best]
+	require.Greater(t, f.ExpectedNumOfLeaves, 1, "need a multi-leaf fixture to exercise the expiry")
+
+	cosignersPublicKeys := make([][]string, 0, len(f.Intents))
+	for range f.Intents {
+		randKey, err := btcec.NewPrivateKey()
+		require.NoError(t, err)
+		cosignersPublicKeys = append(cosignersPublicKeys, []string{
+			hex.EncodeToString(randKey.PubKey().SerializeCompressed()),
+		})
+	}
+
+	// Use an expiry distinct from the package default, so a regression that
+	// reverted to a constructor-captured or hardcoded value would be caught.
+	usedExpiry := arklib.RelativeLocktime{
+		Type:  arklib.LocktimeTypeSecond,
+		Value: vtxoTreeExpiry.Value * 2,
+	}
+	require.NotEqual(t, vtxoTreeExpiry, usedExpiry)
+
+	commitmentTx, vtxoTree, _, _, err := builder.BuildCommitmentTx(
+		pubkey, f.Intents, []ports.BoardingInput{}, cosignersPublicKeys, usedExpiry,
+	)
+	require.NoError(t, err)
+
+	roundPtx, err := psbt.NewFromRawBytes(strings.NewReader(commitmentTx), true)
+	require.NoError(t, err)
+
+	// The tree validates against the expiry it was built with, and not against
+	// a different one, proving the argument determined the tree's timelock.
+	require.NoError(t, tree.ValidateVtxoTree(vtxoTree, roundPtx, pubkey, usedExpiry))
+	require.Error(t, tree.ValidateVtxoTree(vtxoTree, roundPtx, pubkey, vtxoTreeExpiry))
 }
 
 func TestVerifyVtxoTapscriptSigs(t *testing.T) {


### PR DESCRIPTION
This fix ensures that whenever the vtxo tree expiry changes, the server makes use of the right csv value to build the commitmemnt tx within the batch execution.
Before this, the value was passed at tx builder init time and therefore the component would not have used the right value if the vtxo tree expiry changed at runtime via settings update.

Please @bitcoin-coder-bob @louisinger review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed commitment transaction construction to apply the VTXO tree expiry during finalization.
  - Updated the transaction builder interface and implementation to accept VTXO tree expiry as an explicit input, ensuring consistent use across the flow.
  - Adjusted mocks and unit tests (including a new test) to verify the builder honors the provided expiry value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->