### PR TITLE
indexer: Add renewableOnly filter to GetVtxos

### DIFF
--- a/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
@@ -928,6 +928,14 @@
             }
           },
           {
+            "name": "renewableOnly",
+            "in": "query",
+            "description": "Retrieve spendable and recoverable vtxos",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "page.size",
             "in": "query",
             "schema": {
@@ -1343,6 +1351,10 @@
           "recoverableOnly": {
             "type": "boolean",
             "description": "Retrieve only recoverable vtxos (notes, subdust or swept vtxos).\nThe 3 filters are mutually exclusive,"
+          },
+          "renewableOnly": {
+            "type": "boolean",
+            "description": "Retrieve spendable and recoverable vtxos"
           },
           "scripts": {
             "type": "array",

--- a/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
@@ -880,7 +880,7 @@
           {
             "name": "spendableOnly",
             "in": "query",
-            "description": "Retrieve only spendable vtxos",
+            "description": "The spendable_only, spent_only, recoverable_only, pending_only and\nrenewable_only filters are mutually exclusive, and are applied only when\nthe scripts filter is used. They are ignored when querying by outpoints.\nRetrieve only spendable vtxos",
             "schema": {
               "type": "boolean"
             }
@@ -896,7 +896,7 @@
           {
             "name": "recoverableOnly",
             "in": "query",
-            "description": "Retrieve only recoverable vtxos (notes, subdust or swept vtxos).\nThe 3 filters are mutually exclusive,",
+            "description": "Retrieve only recoverable vtxos (notes, subdust or swept vtxos).",
             "schema": {
               "type": "boolean"
             }
@@ -930,7 +930,7 @@
           {
             "name": "renewableOnly",
             "in": "query",
-            "description": "Retrieve spendable and recoverable vtxos",
+            "description": "Retrieve the union of the spendable and recoverable vtxos.",
             "schema": {
               "type": "boolean"
             }
@@ -1350,11 +1350,11 @@
           },
           "recoverableOnly": {
             "type": "boolean",
-            "description": "Retrieve only recoverable vtxos (notes, subdust or swept vtxos).\nThe 3 filters are mutually exclusive,"
+            "description": "Retrieve only recoverable vtxos (notes, subdust or swept vtxos)."
           },
           "renewableOnly": {
             "type": "boolean",
-            "description": "Retrieve spendable and recoverable vtxos"
+            "description": "Retrieve the union of the spendable and recoverable vtxos."
           },
           "scripts": {
             "type": "array",
@@ -1365,7 +1365,7 @@
           },
           "spendableOnly": {
             "type": "boolean",
-            "description": "Retrieve only spendable vtxos"
+            "description": "The spendable_only, spent_only, recoverable_only, pending_only and\nrenewable_only filters are mutually exclusive, and are applied only when\nthe scripts filter is used. They are ignored when querying by outpoints.\nRetrieve only spendable vtxos"
           },
           "spentOnly": {
             "type": "boolean",

--- a/api-spec/protobuf/ark/v1/indexer.proto
+++ b/api-spec/protobuf/ark/v1/indexer.proto
@@ -204,12 +204,14 @@ message GetVtxosRequest {
   repeated string scripts = 1;
   // Or specify a list of vtxo outpoints. The 2 filters are mutually exclusive.
   repeated string outpoints = 2;
+  // The spendable_only, spent_only, recoverable_only, pending_only and
+  // renewable_only filters are mutually exclusive, and are applied only when
+  // the scripts filter is used. They are ignored when querying by outpoints.
   // Retrieve only spendable vtxos
   bool spendable_only = 3;
   // Retrieve only spent vtxos.
   bool spent_only = 4;
   // Retrieve only recoverable vtxos (notes, subdust or swept vtxos).
-  // The 3 filters are mutually exclusive,
   bool recoverable_only = 5;
   IndexerPageRequest page = 6;
   // Include only spent vtxos that are not finalized.
@@ -219,9 +221,9 @@ message GetVtxosRequest {
   int64 after = 8;
   // Include only vtxos with last update before the given unix time in milliseconds,
   // greater value than the after when specified. A value of 0 means no upper bound.
-  int64 before = 9; 
-  // Retrieve spendable and recoverable vtxos
-  bool renewable_only = 10; 
+  int64 before = 9;
+  // Retrieve the union of the spendable and recoverable vtxos.
+  bool renewable_only = 10;
 }
 message GetVtxosResponse {
   repeated IndexerVtxo vtxos = 1;

--- a/api-spec/protobuf/ark/v1/indexer.proto
+++ b/api-spec/protobuf/ark/v1/indexer.proto
@@ -220,6 +220,8 @@ message GetVtxosRequest {
   // Include only vtxos with last update before the given unix time in milliseconds,
   // greater value than the after when specified. A value of 0 means no upper bound.
   int64 before = 9; 
+  // Retrieve spendable and recoverable vtxos
+  bool renewable_only = 10; 
 }
 message GetVtxosResponse {
   repeated IndexerVtxo vtxos = 1;

--- a/api-spec/protobuf/gen/ark/v1/indexer.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/indexer.pb.go
@@ -699,7 +699,9 @@ type GetVtxosRequest struct {
 	After int64 `protobuf:"varint,8,opt,name=after,proto3" json:"after,omitempty"`
 	// Include only vtxos with last update before the given unix time in milliseconds,
 	// greater value than the after when specified. A value of 0 means no upper bound.
-	Before        int64 `protobuf:"varint,9,opt,name=before,proto3" json:"before,omitempty"`
+	Before int64 `protobuf:"varint,9,opt,name=before,proto3" json:"before,omitempty"`
+	// Retrieve spendable and recoverable vtxos
+	RenewableOnly bool `protobuf:"varint,10,opt,name=renewable_only,json=renewableOnly,proto3" json:"renewable_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -795,6 +797,13 @@ func (x *GetVtxosRequest) GetBefore() int64 {
 		return x.Before
 	}
 	return 0
+}
+
+func (x *GetVtxosRequest) GetRenewableOnly() bool {
+	if x != nil {
+		return x.RenewableOnly
+	}
+	return false
 }
 
 type GetVtxosResponse struct {
@@ -3037,7 +3046,7 @@ const file_ark_v1_indexer_proto_rawDesc = "" +
 	"\x04page\x18\x02 \x01(\v2\x1a.ark.v1.IndexerPageRequestR\x04page\"}\n" +
 	"\x19GetVtxoTreeLeavesResponse\x12/\n" +
 	"\x06leaves\x18\x01 \x03(\v2\x17.ark.v1.IndexerOutpointR\x06leaves\x12/\n" +
-	"\x04page\x18\x02 \x01(\v2\x1b.ark.v1.IndexerPageResponseR\x04page\"\xbb\x02\n" +
+	"\x04page\x18\x02 \x01(\v2\x1b.ark.v1.IndexerPageResponseR\x04page\"\xe2\x02\n" +
 	"\x0fGetVtxosRequest\x12\x18\n" +
 	"\ascripts\x18\x01 \x03(\tR\ascripts\x12\x1c\n" +
 	"\toutpoints\x18\x02 \x03(\tR\toutpoints\x12%\n" +
@@ -3048,7 +3057,9 @@ const file_ark_v1_indexer_proto_rawDesc = "" +
 	"\x04page\x18\x06 \x01(\v2\x1a.ark.v1.IndexerPageRequestR\x04page\x12!\n" +
 	"\fpending_only\x18\a \x01(\bR\vpendingOnly\x12\x14\n" +
 	"\x05after\x18\b \x01(\x03R\x05after\x12\x16\n" +
-	"\x06before\x18\t \x01(\x03R\x06before\"n\n" +
+	"\x06before\x18\t \x01(\x03R\x06before\x12%\n" +
+	"\x0erenewable_only\x18\n" +
+	" \x01(\bR\rrenewableOnly\"n\n" +
 	"\x10GetVtxosResponse\x12)\n" +
 	"\x05vtxos\x18\x01 \x03(\v2\x13.ark.v1.IndexerVtxoR\x05vtxos\x12/\n" +
 	"\x04page\x18\x02 \x01(\v2\x1b.ark.v1.IndexerPageResponseR\x04page\"\xea\x01\n" +

--- a/api-spec/protobuf/gen/ark/v1/indexer.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/indexer.pb.go
@@ -684,12 +684,14 @@ type GetVtxosRequest struct {
 	Scripts []string `protobuf:"bytes,1,rep,name=scripts,proto3" json:"scripts,omitempty"`
 	// Or specify a list of vtxo outpoints. The 2 filters are mutually exclusive.
 	Outpoints []string `protobuf:"bytes,2,rep,name=outpoints,proto3" json:"outpoints,omitempty"`
+	// The spendable_only, spent_only, recoverable_only, pending_only and
+	// renewable_only filters are mutually exclusive, and are applied only when
+	// the scripts filter is used. They are ignored when querying by outpoints.
 	// Retrieve only spendable vtxos
 	SpendableOnly bool `protobuf:"varint,3,opt,name=spendable_only,json=spendableOnly,proto3" json:"spendable_only,omitempty"`
 	// Retrieve only spent vtxos.
 	SpentOnly bool `protobuf:"varint,4,opt,name=spent_only,json=spentOnly,proto3" json:"spent_only,omitempty"`
 	// Retrieve only recoverable vtxos (notes, subdust or swept vtxos).
-	// The 3 filters are mutually exclusive,
 	RecoverableOnly bool                `protobuf:"varint,5,opt,name=recoverable_only,json=recoverableOnly,proto3" json:"recoverable_only,omitempty"`
 	Page            *IndexerPageRequest `protobuf:"bytes,6,opt,name=page,proto3" json:"page,omitempty"`
 	// Include only spent vtxos that are not finalized.
@@ -700,7 +702,7 @@ type GetVtxosRequest struct {
 	// Include only vtxos with last update before the given unix time in milliseconds,
 	// greater value than the after when specified. A value of 0 means no upper bound.
 	Before int64 `protobuf:"varint,9,opt,name=before,proto3" json:"before,omitempty"`
-	// Retrieve spendable and recoverable vtxos
+	// Retrieve the union of the spendable and recoverable vtxos.
 	RenewableOnly bool `protobuf:"varint,10,opt,name=renewable_only,json=renewableOnly,proto3" json:"renewable_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -63,8 +63,8 @@ type IndexerService interface {
 	GetForfeitTxs(ctx context.Context, txid string, page *Page) (*ForfeitTxsResp, error)
 	GetConnectors(ctx context.Context, txid string, page *Page) (*TreeTxResp, error)
 	GetVtxos(
-		ctx context.Context,
-		pubkeys []string, spendableOnly, spendOnly, recoverableOnly, pendingOnly bool,
+		ctx context.Context, pubkeys []string,
+		spendableOnly, spendOnly, recoverableOnly, pendingOnly, renewableOnly bool,
 		after, before int64, page *Page,
 	) (*GetVtxosResp, error)
 	GetVtxosByOutpoint(
@@ -268,7 +268,7 @@ func (i *indexerService) GetConnectors(
 func (i *indexerService) GetVtxos(
 	ctx context.Context,
 	pubkeys []string,
-	spendableOnly, spentOnly, recoverableOnly, pendingOnly bool,
+	spendableOnly, spentOnly, recoverableOnly, pendingOnly, renewableOnly bool,
 	after, before int64,
 	page *Page,
 ) (*GetVtxosResp, error) {
@@ -328,6 +328,15 @@ func (i *indexerService) GetVtxos(
 				}
 			}
 			allVtxos = recoverableVtxos
+		}
+		if renewableOnly {
+			renewableVtxos := make([]domain.Vtxo, 0, len(allVtxos))
+			for _, vtxo := range allVtxos {
+				if !vtxo.Spent && !vtxo.Unrolled {
+					renewableVtxos = append(renewableVtxos, vtxo)
+				}
+			}
+			allVtxos = renewableVtxos
 		}
 	}
 

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -64,7 +64,7 @@ type IndexerService interface {
 	GetConnectors(ctx context.Context, txid string, page *Page) (*TreeTxResp, error)
 	GetVtxos(
 		ctx context.Context, pubkeys []string,
-		spendableOnly, spendOnly, recoverableOnly, pendingOnly, renewableOnly bool,
+		spendableOnly, spentOnly, recoverableOnly, pendingOnly, renewableOnly bool,
 		after, before int64, page *Page,
 	) (*GetVtxosResp, error)
 	GetVtxosByOutpoint(
@@ -275,7 +275,7 @@ func (i *indexerService) GetVtxos(
 	if err := validateTimeRange(after, before); err != nil {
 		return nil, err
 	}
-	options := []bool{spendableOnly, spentOnly, recoverableOnly, pendingOnly}
+	options := []bool{spendableOnly, spentOnly, recoverableOnly, pendingOnly, renewableOnly}
 	count := 0
 	for _, v := range options {
 		if v {
@@ -284,7 +284,7 @@ func (i *indexerService) GetVtxos(
 	}
 	if count > 1 {
 		return nil, fmt.Errorf(
-			"spendable, spent, recoverable and pending filters are mutually exclusive",
+			"spendable, spent, recoverable, pending and renewable filters are mutually exclusive",
 		)
 	}
 
@@ -330,6 +330,9 @@ func (i *indexerService) GetVtxos(
 			allVtxos = recoverableVtxos
 		}
 		if renewableOnly {
+			// Renewable is the union of the spendable and recoverable sets: an
+			// unspent, non-unrolled vtxo is spendable when not swept, and
+			// recoverable otherwise (RequiresForfeit is false once swept).
 			renewableVtxos := make([]domain.Vtxo, 0, len(allVtxos))
 			for _, vtxo := range allVtxos {
 				if !vtxo.Spent && !vtxo.Unrolled {

--- a/internal/core/application/indexer_vtxo_filters_test.go
+++ b/internal/core/application/indexer_vtxo_filters_test.go
@@ -10,6 +10,120 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetVtxosFilters(t *testing.T) {
+	// renewableIsUnionOfSpendableAndRecoverable pins the invariant the
+	// renewableOnly filter relies on. It holds only because RequiresForfeit expands
+	// to (Swept || IsExpired || IsNote || Unrolled), so any unspent, non-unrolled
+	// vtxo lands in the spendable set when not swept and in the recoverable set
+	// otherwise. If RequiresForfeit ever gains a condition, this test fails instead
+	// of the filter silently returning the wrong set.
+	t.Run("renewable is union of spendable and recoverable", func(t *testing.T) {
+		ctx := context.Background()
+		fixtures := filterTestFixtures()
+
+		all := make([]domain.Vtxo, 0, len(fixtures))
+		for _, f := range fixtures {
+			all = append(all, f.vtxo)
+		}
+		pubkeys := []string{filterTestPubkey}
+
+		get := func(spendable, recoverable, renewable bool) []domain.Vtxo {
+			t.Helper()
+			svc := newFilterTestIndexer(all)
+			resp, err := svc.GetVtxos(
+				ctx, pubkeys, spendable, false, recoverable, false, renewable, 0, 0, nil,
+			)
+			require.NoError(t, err)
+			return resp.Vtxos
+		}
+
+		spendable := get(true, false, false)
+		recoverable := get(false, true, false)
+		renewable := get(false, false, true)
+
+		// Each filter matches the hand-labelled expectation.
+		wantSpendable := make([]string, 0)
+		wantRecoverable := make([]string, 0)
+		union := make(map[string]struct{})
+		for _, f := range fixtures {
+			key := f.vtxo.Outpoint.String()
+			if f.spendable {
+				wantSpendable = append(wantSpendable, key)
+				union[key] = struct{}{}
+			}
+			if f.recoverable {
+				wantRecoverable = append(wantRecoverable, key)
+				union[key] = struct{}{}
+			}
+		}
+		require.ElementsMatch(t, wantSpendable, outpointsOf(spendable), "spendableOnly")
+		require.ElementsMatch(t, wantRecoverable, outpointsOf(recoverable), "recoverableOnly")
+
+		wantUnion := make([]string, 0, len(union))
+		for key := range union {
+			wantUnion = append(wantUnion, key)
+		}
+		require.ElementsMatch(t, wantUnion, outpointsOf(renewable), "renewableOnly must be the union")
+
+		// And the union is exactly the unspent, non-unrolled vtxos.
+		wantRenewable := make([]string, 0)
+		for _, f := range fixtures {
+			if !f.vtxo.Spent && !f.vtxo.Unrolled {
+				wantRenewable = append(wantRenewable, f.vtxo.Outpoint.String())
+			}
+		}
+		require.ElementsMatch(t, wantRenewable, outpointsOf(renewable))
+	})
+
+	// filtersAreMutuallyExclusive covers the service-level guard, which is enforced
+	// independently of the gRPC handler.
+	t.Run("filters are mutually exclusive", func(t *testing.T) {
+		ctx := context.Background()
+		pubkeys := []string{filterTestPubkey}
+
+		tests := []struct {
+			name                                              string
+			spendable, spent, recoverable, pending, renewable bool
+		}{
+			{"spendable and renewable", true, false, false, false, true},
+			{"spent and renewable", false, true, false, false, true},
+			{"recoverable and renewable", false, false, true, false, true},
+			{"pending and renewable", false, false, false, true, true},
+			{"spendable and spent", true, true, false, false, false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				svc := newFilterTestIndexer(nil)
+				_, err := svc.GetVtxos(
+					ctx, pubkeys,
+					tt.spendable, tt.spent, tt.recoverable, tt.pending, tt.renewable,
+					0, 0, nil,
+				)
+				require.ErrorContains(t, err, "mutually exclusive")
+			})
+		}
+	})
+
+	// renewableExcludesSpentAndUnrolled guards the two flags the filter actually
+	// tests, independently of the union invariant above.
+	t.Run("renewable excludes spent and unrolled", func(t *testing.T) {
+		ctx := context.Background()
+		all := []domain.Vtxo{
+			filterTestVtxo("b1", false, false, false, false, false),
+			filterTestVtxo("b2", true, false, false, false, false),
+			filterTestVtxo("b3", false, false, true, false, false),
+		}
+
+		svc := newFilterTestIndexer(all)
+		resp, err := svc.GetVtxos(
+			ctx, []string{filterTestPubkey}, false, false, false, false, true, 0, 0, nil,
+		)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"b1:0"}, outpointsOf(resp.Vtxos))
+	})
+}
+
 const filterTestPubkey = "0000000000000000000000000000000000000000000000000000000000000001"
 
 // filterTestVtxo builds a vtxo with the flag combination under test. A note has
@@ -80,116 +194,4 @@ func filterTestFixtures() []struct {
 		{"unrolled", filterTestVtxo("a6", false, false, true, false, false), false, false},
 		{"spent and swept", filterTestVtxo("a7", true, true, false, false, false), false, false},
 	}
-}
-
-// TestGetVtxosRenewableIsUnionOfSpendableAndRecoverable pins the invariant the
-// renewableOnly filter relies on. It holds only because RequiresForfeit expands
-// to (Swept || IsExpired || IsNote || Unrolled), so any unspent, non-unrolled
-// vtxo lands in the spendable set when not swept and in the recoverable set
-// otherwise. If RequiresForfeit ever gains a condition, this test fails instead
-// of the filter silently returning the wrong set.
-func TestGetVtxosRenewableIsUnionOfSpendableAndRecoverable(t *testing.T) {
-	ctx := context.Background()
-	fixtures := filterTestFixtures()
-
-	all := make([]domain.Vtxo, 0, len(fixtures))
-	for _, f := range fixtures {
-		all = append(all, f.vtxo)
-	}
-	pubkeys := []string{filterTestPubkey}
-
-	get := func(spendable, recoverable, renewable bool) []domain.Vtxo {
-		t.Helper()
-		svc := newFilterTestIndexer(all)
-		resp, err := svc.GetVtxos(
-			ctx, pubkeys, spendable, false, recoverable, false, renewable, 0, 0, nil,
-		)
-		require.NoError(t, err)
-		return resp.Vtxos
-	}
-
-	spendable := get(true, false, false)
-	recoverable := get(false, true, false)
-	renewable := get(false, false, true)
-
-	// Each filter matches the hand-labelled expectation.
-	wantSpendable := make([]string, 0)
-	wantRecoverable := make([]string, 0)
-	union := make(map[string]struct{})
-	for _, f := range fixtures {
-		key := f.vtxo.Outpoint.String()
-		if f.spendable {
-			wantSpendable = append(wantSpendable, key)
-			union[key] = struct{}{}
-		}
-		if f.recoverable {
-			wantRecoverable = append(wantRecoverable, key)
-			union[key] = struct{}{}
-		}
-	}
-	require.ElementsMatch(t, wantSpendable, outpointsOf(spendable), "spendableOnly")
-	require.ElementsMatch(t, wantRecoverable, outpointsOf(recoverable), "recoverableOnly")
-
-	wantUnion := make([]string, 0, len(union))
-	for key := range union {
-		wantUnion = append(wantUnion, key)
-	}
-	require.ElementsMatch(t, wantUnion, outpointsOf(renewable), "renewableOnly must be the union")
-
-	// And the union is exactly the unspent, non-unrolled vtxos.
-	wantRenewable := make([]string, 0)
-	for _, f := range fixtures {
-		if !f.vtxo.Spent && !f.vtxo.Unrolled {
-			wantRenewable = append(wantRenewable, f.vtxo.Outpoint.String())
-		}
-	}
-	require.ElementsMatch(t, wantRenewable, outpointsOf(renewable))
-}
-
-// TestGetVtxosFiltersAreMutuallyExclusive covers the service-level guard, which
-// is enforced independently of the gRPC handler.
-func TestGetVtxosFiltersAreMutuallyExclusive(t *testing.T) {
-	ctx := context.Background()
-	pubkeys := []string{filterTestPubkey}
-
-	tests := []struct {
-		name                                              string
-		spendable, spent, recoverable, pending, renewable bool
-	}{
-		{"spendable and renewable", true, false, false, false, true},
-		{"spent and renewable", false, true, false, false, true},
-		{"recoverable and renewable", false, false, true, false, true},
-		{"pending and renewable", false, false, false, true, true},
-		{"spendable and spent", true, true, false, false, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc := newFilterTestIndexer(nil)
-			_, err := svc.GetVtxos(
-				ctx, pubkeys,
-				tt.spendable, tt.spent, tt.recoverable, tt.pending, tt.renewable,
-				0, 0, nil,
-			)
-			require.ErrorContains(t, err, "mutually exclusive")
-		})
-	}
-}
-
-// TestGetVtxosRenewableExcludesSpentAndUnrolled guards the two flags the filter
-// actually tests, independently of the union invariant above.
-func TestGetVtxosRenewableExcludesSpentAndUnrolled(t *testing.T) {
-	ctx := context.Background()
-	all := []domain.Vtxo{
-		filterTestVtxo("b1", false, false, false, false, false),
-		filterTestVtxo("b2", true, false, false, false, false),
-		filterTestVtxo("b3", false, false, true, false, false),
-	}
-
-	svc := newFilterTestIndexer(all)
-	resp, err := svc.GetVtxos(
-		ctx, []string{filterTestPubkey}, false, false, false, false, true, 0, 0, nil,
-	)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"b1:0"}, outpointsOf(resp.Vtxos))
 }

--- a/internal/core/application/indexer_vtxo_filters_test.go
+++ b/internal/core/application/indexer_vtxo_filters_test.go
@@ -1,0 +1,195 @@
+package application
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/arkade-os/arkd/internal/core/domain"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const filterTestPubkey = "0000000000000000000000000000000000000000000000000000000000000001"
+
+// filterTestVtxo builds a vtxo with the flag combination under test. A note has
+// no commitment txids, an expired vtxo has an ExpiresAt in the past.
+func filterTestVtxo(txid string, spent, swept, unrolled, note, expired bool) domain.Vtxo {
+	v := domain.Vtxo{
+		Outpoint: domain.Outpoint{Txid: txid, VOut: 0},
+		Amount:   1000,
+		PubKey:   filterTestPubkey,
+		Spent:    spent,
+		Swept:    swept,
+		Unrolled: unrolled,
+	}
+	if !note {
+		v.RootCommitmentTxid = "commitment"
+		v.CommitmentTxids = []string{"commitment"}
+	}
+	if expired {
+		v.ExpiresAt = time.Now().Add(-time.Hour).Unix()
+	} else {
+		v.ExpiresAt = time.Now().Add(time.Hour).Unix()
+	}
+	return v
+}
+
+func newFilterTestIndexer(vtxos []domain.Vtxo) *indexerService {
+	vtxoRepo := &mockedVtxoRepo{}
+	vtxoRepo.On(
+		"GetAllVtxosWithPubKeys", mock.Anything, []string{filterTestPubkey}, int64(0), int64(0),
+	).Return(vtxos, nil)
+
+	repoManager := &mockedRepoManager{}
+	repoManager.On("Vtxos").Return(vtxoRepo)
+
+	return &indexerService{repoManager: repoManager, txExposure: exposurePublic}
+}
+
+func outpointsOf(vtxos []domain.Vtxo) []string {
+	out := make([]string, 0, len(vtxos))
+	for _, v := range vtxos {
+		out = append(out, v.Outpoint.String())
+	}
+	return out
+}
+
+// The fixture set covers every combination that changes the outcome of the
+// spendable, recoverable and renewable predicates.
+func filterTestFixtures() []struct {
+	name        string
+	vtxo        domain.Vtxo
+	spendable   bool
+	recoverable bool
+} {
+	return []struct {
+		name        string
+		vtxo        domain.Vtxo
+		spendable   bool
+		recoverable bool
+	}{
+		// spent=F swept=F unrolled=F note=F expired=F
+		{"plain", filterTestVtxo("a1", false, false, false, false, false), true, false},
+		// swept vtxos stop requiring a forfeit, so they become recoverable
+		{"swept", filterTestVtxo("a2", false, true, false, false, false), false, true},
+		// expired and note vtxos are both spendable and recoverable
+		{"expired", filterTestVtxo("a3", false, false, false, false, true), true, true},
+		{"note", filterTestVtxo("a4", false, false, false, true, false), true, true},
+		{"spent", filterTestVtxo("a5", true, false, false, false, false), false, false},
+		{"unrolled", filterTestVtxo("a6", false, false, true, false, false), false, false},
+		{"spent and swept", filterTestVtxo("a7", true, true, false, false, false), false, false},
+	}
+}
+
+// TestGetVtxosRenewableIsUnionOfSpendableAndRecoverable pins the invariant the
+// renewableOnly filter relies on. It holds only because RequiresForfeit expands
+// to (Swept || IsExpired || IsNote || Unrolled), so any unspent, non-unrolled
+// vtxo lands in the spendable set when not swept and in the recoverable set
+// otherwise. If RequiresForfeit ever gains a condition, this test fails instead
+// of the filter silently returning the wrong set.
+func TestGetVtxosRenewableIsUnionOfSpendableAndRecoverable(t *testing.T) {
+	ctx := context.Background()
+	fixtures := filterTestFixtures()
+
+	all := make([]domain.Vtxo, 0, len(fixtures))
+	for _, f := range fixtures {
+		all = append(all, f.vtxo)
+	}
+	pubkeys := []string{filterTestPubkey}
+
+	get := func(spendable, recoverable, renewable bool) []domain.Vtxo {
+		t.Helper()
+		svc := newFilterTestIndexer(all)
+		resp, err := svc.GetVtxos(
+			ctx, pubkeys, spendable, false, recoverable, false, renewable, 0, 0, nil,
+		)
+		require.NoError(t, err)
+		return resp.Vtxos
+	}
+
+	spendable := get(true, false, false)
+	recoverable := get(false, true, false)
+	renewable := get(false, false, true)
+
+	// Each filter matches the hand-labelled expectation.
+	wantSpendable := make([]string, 0)
+	wantRecoverable := make([]string, 0)
+	union := make(map[string]struct{})
+	for _, f := range fixtures {
+		key := f.vtxo.Outpoint.String()
+		if f.spendable {
+			wantSpendable = append(wantSpendable, key)
+			union[key] = struct{}{}
+		}
+		if f.recoverable {
+			wantRecoverable = append(wantRecoverable, key)
+			union[key] = struct{}{}
+		}
+	}
+	require.ElementsMatch(t, wantSpendable, outpointsOf(spendable), "spendableOnly")
+	require.ElementsMatch(t, wantRecoverable, outpointsOf(recoverable), "recoverableOnly")
+
+	wantUnion := make([]string, 0, len(union))
+	for key := range union {
+		wantUnion = append(wantUnion, key)
+	}
+	require.ElementsMatch(t, wantUnion, outpointsOf(renewable), "renewableOnly must be the union")
+
+	// And the union is exactly the unspent, non-unrolled vtxos.
+	wantRenewable := make([]string, 0)
+	for _, f := range fixtures {
+		if !f.vtxo.Spent && !f.vtxo.Unrolled {
+			wantRenewable = append(wantRenewable, f.vtxo.Outpoint.String())
+		}
+	}
+	require.ElementsMatch(t, wantRenewable, outpointsOf(renewable))
+}
+
+// TestGetVtxosFiltersAreMutuallyExclusive covers the service-level guard, which
+// is enforced independently of the gRPC handler.
+func TestGetVtxosFiltersAreMutuallyExclusive(t *testing.T) {
+	ctx := context.Background()
+	pubkeys := []string{filterTestPubkey}
+
+	tests := []struct {
+		name                                              string
+		spendable, spent, recoverable, pending, renewable bool
+	}{
+		{"spendable and renewable", true, false, false, false, true},
+		{"spent and renewable", false, true, false, false, true},
+		{"recoverable and renewable", false, false, true, false, true},
+		{"pending and renewable", false, false, false, true, true},
+		{"spendable and spent", true, true, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newFilterTestIndexer(nil)
+			_, err := svc.GetVtxos(
+				ctx, pubkeys,
+				tt.spendable, tt.spent, tt.recoverable, tt.pending, tt.renewable,
+				0, 0, nil,
+			)
+			require.ErrorContains(t, err, "mutually exclusive")
+		})
+	}
+}
+
+// TestGetVtxosRenewableExcludesSpentAndUnrolled guards the two flags the filter
+// actually tests, independently of the union invariant above.
+func TestGetVtxosRenewableExcludesSpentAndUnrolled(t *testing.T) {
+	ctx := context.Background()
+	all := []domain.Vtxo{
+		filterTestVtxo("b1", false, false, false, false, false),
+		filterTestVtxo("b2", true, false, false, false, false),
+		filterTestVtxo("b3", false, false, true, false, false),
+	}
+
+	svc := newFilterTestIndexer(all)
+	resp, err := svc.GetVtxos(
+		ctx, []string{filterTestPubkey}, false, false, false, false, true, 0, 0, nil,
+	)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"b1:0"}, outpointsOf(resp.Vtxos))
+}

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -53,6 +53,16 @@ func (m *mockedVtxoRepo) GetVtxos(ctx context.Context, outpoints []domain.Outpoi
 	return nil, args.Error(1)
 }
 
+func (m *mockedVtxoRepo) GetAllVtxosWithPubKeys(
+	ctx context.Context, pubkeys []string, after, before int64,
+) ([]domain.Vtxo, error) {
+	args := m.Called(ctx, pubkeys, after, before)
+	if v := args.Get(0); v != nil {
+		return v.([]domain.Vtxo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (m *mockedVtxoRepo) GetVtxoPubKeysByCommitmentTxids(
 	ctx context.Context, commitmentTxids []string, withMinimumAmount uint64,
 ) ([]string, error) {

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -267,13 +267,14 @@ func (e *indexerService) GetVtxos(
 	spentOnly := request.GetSpentOnly()
 	recoverableOnly := request.GetRecoverableOnly()
 	pendingOnly := request.GetPendingOnly()
+	renewableOnly := request.GetRenewableOnly()
 
 	var resp *application.GetVtxosResp
 
 	if len(pubkeys) > 0 {
 		// Validate filters
 		// TODO: get rid of this and move to oneof in the protos
-		options := []bool{spendableOnly, spentOnly, recoverableOnly, pendingOnly}
+		options := []bool{spendableOnly, spentOnly, recoverableOnly, pendingOnly, renewableOnly}
 
 		count := 0
 		for _, v := range options {
@@ -294,8 +295,8 @@ func (e *indexerService) GetVtxos(
 		}
 
 		resp, err = e.indexerSvc.GetVtxos(
-			ctx, pubkeys,
-			spendableOnly, spentOnly, recoverableOnly, pendingOnly, after, before, page,
+			ctx, pubkeys, spendableOnly, spentOnly, recoverableOnly,
+			pendingOnly, renewableOnly, after, before, page,
 		)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "%s", err.Error())

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -285,7 +285,7 @@ func (e *indexerService) GetVtxos(
 		if count > 1 {
 			return nil, status.Error(
 				codes.InvalidArgument,
-				"spendable, spent, recoverable and pending filters are mutually exclusive",
+				"spendable, spent, recoverable, pending and renewable filters are mutually exclusive",
 			)
 		}
 


### PR DESCRIPTION
Adds `renewableOnly` filter to indexer.GetVtxos endpoint

Closes #1148

Please @bitcoin-coder-bob review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `renewableOnly` filter to return the union of spendable and recoverable VTXOs (neither spent nor unrolled).
  * Exposed via both the query API and the public request schema.
  * Maintains mutual exclusivity with the existing VTXO status filters.
* **Tests**
  * Added unit tests verifying union behavior, mutual-exclusivity validation, and that spent/unrolled VTXOs are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->