### PR TITLE
docs: drop nostr DM contact from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Disclosures
 
-Security is a top priority for Ark. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately by sending an email to <security@arklabs.to>.
+Security is a top priority for Ark Labs. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately by sending an email to <security@arklabs.to>.
 
 Security reports are greatly appreciated and we will publicly thank you for it.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,6 @@
 # Security Disclosures
 
-Security is a top priority for Ark. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately:
-
-- sending an email to <security@arklabs.to>; or
-- sending a NIP-04 DM to [npub1hf5...dp8n](https://primal.net/p/npub1hf5sgehj874r3y2hps9r36qap20cffauc7t895var2ajlsg32mcqa7dp8n).
+Security is a top priority for Ark. If you discover a security issue, please bring it to our attention right away. Please DO NOT file a public issue, instead send your report privately by sending an email to <security@arklabs.to>.
 
 Security reports are greatly appreciated and we will publicly thank you for it.
 


### PR DESCRIPTION
Removes the NIP-04 DM bullet from the security disclosure policy; reports go to <security@arklabs.to>. Matches what landed in wallet and the TS/Go/Rust/.NET SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ek8iDTwb1V7PVh1kKewSVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ek8iDTwb1V7PVh1kKewSVg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security disclosure guidance to identify Ark Labs as the contact.
  * Consolidated reporting instructions into a single private email channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->