### PR TITLE
docs: give the generated OpenAPI documents info and servers

### DIFF
--- a/api-spec/openapi/swagger/ark/v1/admin.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/admin.openapi.json
@@ -1,8 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "",
-    "version": "version not set"
+    "title": "Arkade Admin API",
+    "description": "Operator-internal administration API. Not intended for application developers, and not exposed on the public operator endpoints.",
+    "version": "v1"
   },
   "paths": {
     "/v1/admin/auth/revoke": {

--- a/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
@@ -1,9 +1,28 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "",
-    "version": "version not set"
+    "title": "Arkade Indexer API",
+    "description": "The read API of the Arkade operator. Use it to look up virtual outputs, commitment transactions, batch trees, and to subscribe to script activity.\n\nMost applications should use an SDK rather than these endpoints directly: https://docs.arkadeos.com",
+    "version": "v1"
   },
+  "servers": [
+    {
+      "url": "https://arkade.computer",
+      "description": "Bitcoin mainnet"
+    },
+    {
+      "url": "https://mutinynet.arkade.sh",
+      "description": "Mutinynet"
+    },
+    {
+      "url": "https://signet.arkade.sh",
+      "description": "Signet"
+    },
+    {
+      "url": "http://localhost:7070",
+      "description": "Local regtest, through arkade-regtest"
+    }
+  ],
   "paths": {
     "/v1/indexer/asset/{asset_id}": {
       "get": {

--- a/api-spec/openapi/swagger/ark/v1/service.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/service.openapi.json
@@ -1,9 +1,28 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "",
-    "version": "version not set"
+    "title": "Arkade Service API",
+    "description": "The REST API of the Arkade operator. Use it to read operator parameters, register intents, take part in a batch swap, and submit transactions.\n\nMost applications should use an SDK rather than these endpoints directly: https://docs.arkadeos.com",
+    "version": "v1"
   },
+  "servers": [
+    {
+      "url": "https://arkade.computer",
+      "description": "Bitcoin mainnet"
+    },
+    {
+      "url": "https://mutinynet.arkade.sh",
+      "description": "Mutinynet"
+    },
+    {
+      "url": "https://signet.arkade.sh",
+      "description": "Signet"
+    },
+    {
+      "url": "http://localhost:7070",
+      "description": "Local regtest, through arkade-regtest"
+    }
+  ],
   "paths": {
     "/v1/batch/ack": {
       "post": {

--- a/api-spec/openapi/swagger/ark/v1/signer_manager.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/signer_manager.openapi.json
@@ -1,8 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "",
-    "version": "version not set"
+    "title": "Arkade Signer Manager API",
+    "description": "Operator-internal API for managing signers. Not intended for application developers.",
+    "version": "v1"
   },
   "paths": {
     "/v1/admin/signer": {

--- a/api-spec/openapi/swagger/ark/v1/types.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/types.openapi.json
@@ -1,8 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "",
-    "version": "version not set"
+    "title": "Arkade Shared Types",
+    "description": "Message types shared by the Arkade service and indexer APIs. This document defines schemas only and binds no endpoints.",
+    "version": "v1"
   },
   "components": {
     "schemas": {

--- a/api-spec/openapi/swagger/ark/v1/wallet.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/wallet.openapi.json
@@ -1,8 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "",
-    "version": "version not set"
+    "title": "Arkade Wallet Initializer API",
+    "description": "Operator-internal API for initializing and unlocking the arkd wallet. Not intended for application developers.",
+    "version": "v1"
   },
   "paths": {
     "/v1/admin/wallet/address": {

--- a/api-spec/protobuf/ark/v1/admin.proto
+++ b/api-spec/protobuf/ark/v1/admin.proto
@@ -5,6 +5,16 @@ package ark.v1;
 import "meshapi/gateway/annotations.proto";
 import "ark/v1/types.proto";
 
+option (meshapi.gateway.openapi_doc) = {
+  info: {
+    title: "Arkade Admin API"
+    version: "v1"
+    description:
+      "Operator-internal administration API. Not intended for application "
+      "developers, and not exposed on the public operator endpoints."
+  }
+};
+
 service AdminService {
   rpc GetScheduledSweep(GetScheduledSweepRequest) returns (GetScheduledSweepResponse) {
     option (meshapi.gateway.http) = {

--- a/api-spec/protobuf/ark/v1/indexer.proto
+++ b/api-spec/protobuf/ark/v1/indexer.proto
@@ -3,6 +3,38 @@ syntax = "proto3";
 package ark.v1;
 
 import "meshapi/gateway/annotations.proto";
+
+option (meshapi.gateway.openapi_doc) = {
+  info: {
+    title: "Arkade Indexer API"
+    version: "v1"
+    description:
+      "The read API of the Arkade operator. Use it to look up virtual "
+      "outputs, commitment transactions, batch trees, and to subscribe to "
+      "script activity.\n\n"
+      "Most applications should use an SDK rather than these endpoints "
+      "directly: https://docs.arkadeos.com"
+  }
+  servers: [
+    {
+      url: "https://arkade.computer"
+      description: "Bitcoin mainnet"
+    },
+    {
+      url: "https://mutinynet.arkade.sh"
+      description: "Mutinynet"
+    },
+    {
+      url: "https://signet.arkade.sh"
+      description: "Signet"
+    },
+    {
+      url: "http://localhost:7070"
+      description: "Local regtest, through arkade-regtest"
+    }
+  ]
+};
+
 service IndexerService {
   // GetCommitmentTx returns information about a specific commitment transaction identified by the
   // provided txid.

--- a/api-spec/protobuf/ark/v1/service.proto
+++ b/api-spec/protobuf/ark/v1/service.proto
@@ -5,6 +5,37 @@ package ark.v1;
 import "meshapi/gateway/annotations.proto";
 import "ark/v1/types.proto";
 
+option (meshapi.gateway.openapi_doc) = {
+  info: {
+    title: "Arkade Service API"
+    version: "v1"
+    description:
+      "The REST API of the Arkade operator. Use it to read operator "
+      "parameters, register intents, take part in a batch swap, and submit "
+      "transactions.\n\n"
+      "Most applications should use an SDK rather than these endpoints "
+      "directly: https://docs.arkadeos.com"
+  }
+  servers: [
+    {
+      url: "https://arkade.computer"
+      description: "Bitcoin mainnet"
+    },
+    {
+      url: "https://mutinynet.arkade.sh"
+      description: "Mutinynet"
+    },
+    {
+      url: "https://signet.arkade.sh"
+      description: "Signet"
+    },
+    {
+      url: "http://localhost:7070"
+      description: "Local regtest, through arkade-regtest"
+    }
+  ]
+};
+
 service ArkService {
   // GetInfo returns information and parameters of the server.
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse) {

--- a/api-spec/protobuf/ark/v1/signer_manager.proto
+++ b/api-spec/protobuf/ark/v1/signer_manager.proto
@@ -4,6 +4,16 @@ package ark.v1;
 
 import "meshapi/gateway/annotations.proto";
 
+option (meshapi.gateway.openapi_doc) = {
+  info: {
+    title: "Arkade Signer Manager API"
+    version: "v1"
+    description:
+      "Operator-internal API for managing signers. Not intended for "
+      "application developers."
+  }
+};
+
 service SignerManagerService {
   rpc LoadSigner(LoadSignerRequest) returns (LoadSignerResponse) {
     option (meshapi.gateway.http) = {

--- a/api-spec/protobuf/ark/v1/types.proto
+++ b/api-spec/protobuf/ark/v1/types.proto
@@ -2,6 +2,18 @@ syntax = "proto3";
 
 package ark.v1;
 
+import "meshapi/gateway/annotations.proto";
+
+option (meshapi.gateway.openapi_doc) = {
+  info: {
+    title: "Arkade Shared Types"
+    version: "v1"
+    description:
+      "Message types shared by the Arkade service and indexer APIs. This "
+      "document defines schemas only and binds no endpoints."
+  }
+};
+
 /* Types */
 
 message Outpoint {

--- a/api-spec/protobuf/ark/v1/wallet.proto
+++ b/api-spec/protobuf/ark/v1/wallet.proto
@@ -4,6 +4,16 @@ package ark.v1;
 
 import "meshapi/gateway/annotations.proto";
 
+option (meshapi.gateway.openapi_doc) = {
+  info: {
+    title: "Arkade Wallet Initializer API"
+    version: "v1"
+    description:
+      "Operator-internal API for initializing and unlocking the arkd wallet. "
+      "Not intended for application developers."
+  }
+};
+
 service WalletInitializerService {
   rpc GenSeed(GenSeedRequest) returns (GenSeedResponse) {
     option (meshapi.gateway.http) = {

--- a/api-spec/protobuf/gen/ark/v1/admin.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/admin.pb.go
@@ -4183,7 +4183,9 @@ const file_ark_v1_admin_proto_rawDesc = "" +
 	"\x05Sweep\x12\x14.ark.v1.SweepRequest\x1a\x15.ark.v1.SweepResponse\"\x17\xb2J\x14B\x01*\"\x0f/v1/admin/sweep\x12_\n" +
 	"\vGetSettings\x12\x1a.ark.v1.GetSettingsRequest\x1a\x1b.ark.v1.GetSettingsResponse\"\x17\xb2J\x14\x12\x12/v1/admin/settings\x12k\n" +
 	"\x0eUpdateSettings\x12\x1d.ark.v1.UpdateSettingsRequest\x1a\x1e.ark.v1.UpdateSettingsResponse\"\x1a\xb2J\x17B\x01*\"\x12/v1/admin/settings\x12{\n" +
-	"\x13GetMainAccountUtxos\x12\".ark.v1.GetMainAccountUtxosRequest\x1a#.ark.v1.GetMainAccountUtxosResponse\"\x1b\xb2J\x18\x12\x16/v1/admin/wallet/utxosBy\n" +
+	"\x13GetMainAccountUtxos\x12\".ark.v1.GetMainAccountUtxosRequest\x1a#.ark.v1.GetMainAccountUtxosResponse\"\x1b\xb2J\x18\x12\x16/v1/admin/wallet/utxosB\x99\x02\xbaJ\x9c\x01\n" +
+	"\x99\x01\n" +
+	"\x10Arkade Admin API\x1a\x80\x01Operator-internal administration API. Not intended for application developers, and not exposed on the public operator endpoints.:\x02v1\n" +
 	"\n" +
 	"com.ark.v1B\n" +
 	"AdminProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"

--- a/api-spec/protobuf/gen/ark/v1/indexer.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/indexer.pb.go
@@ -3249,7 +3249,15 @@ const file_ark_v1_indexer_proto_rawDesc = "" +
 	"\x13SubscribeForScripts\x12\".ark.v1.SubscribeForScriptsRequest\x1a#.ark.v1.SubscribeForScriptsResponse\"$\xb2J!B\x01*\"\x1c/v1/indexer/script/subscribe\x12\x8c\x01\n" +
 	"\x15UnsubscribeForScripts\x12$.ark.v1.UnsubscribeForScriptsRequest\x1a%.ark.v1.UnsubscribeForScriptsResponse\"&\xb2J#B\x01*\"\x1e/v1/indexer/script/unsubscribe\x12\xb4\x01\n" +
 	"\x0fGetSubscription\x12\x1e.ark.v1.GetSubscriptionRequest\x1a\x1f.ark.v1.GetSubscriptionResponse\"^\xb2J[R b\x04\b\x01\x18\x01\x12\x18/v1/indexer/subscriptionb\x04\b\x01\x18\x01\x121/v1/indexer/script/subscription/{subscription_id}0\x01\x12\x84\x01\n" +
-	"\x12UpdateSubscription\x12!.ark.v1.UpdateSubscriptionRequest\x1a\".ark.v1.UpdateSubscriptionResponse\"'\xb2J$B\x01*\"\x1f/v1/indexer/subscription/updateB{\n" +
+	"\x12UpdateSubscription\x12!.ark.v1.UpdateSubscriptionRequest\x1a\".ark.v1.UpdateSubscriptionResponse\"'\xb2J$B\x01*\"\x1f/v1/indexer/subscription/updateB\xce\x04\xbaJ\xcf\x03\n" +
+	"\x92\x02\n" +
+	"\x12Arkade Indexer API\x1a\xf7\x01The read API of the Arkade operator. Use it to look up virtual outputs, commitment transactions, batch trees, and to subscribe to script activity.\n" +
+	"\n" +
+	"Most applications should use an SDK rather than these endpoints directly: https://docs.arkadeos.com:\x02v1\x12*\n" +
+	"\x17https://arkade.computer\x12\x0fBitcoin mainnet\x12(\n" +
+	"\x1bhttps://mutinynet.arkade.sh\x12\tMutinynet\x12\"\n" +
+	"\x18https://signet.arkade.sh\x12\x06Signet\x12>\n" +
+	"\x15http://localhost:7070\x12%Local regtest, through arkade-regtest\n" +
 	"\n" +
 	"com.ark.v1B\fIndexerProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"
 

--- a/api-spec/protobuf/gen/ark/v1/service.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/service.pb.go
@@ -2154,7 +2154,15 @@ const file_ark_v1_service_proto_rawDesc = "" +
 	"\x15GetTransactionsStream\x12$.ark.v1.GetTransactionsStreamRequest\x1a%.ark.v1.GetTransactionsStreamResponse\"\x12\xb2J\x0fb\x04\b\x01\x18\x01\x12\a/v1/txs0\x01\x12b\n" +
 	"\tGetIntent\x12\x18.ark.v1.GetIntentRequest\x1a\x19.ark.v1.GetIntentResponse\" \xb2J\x1dR\x0fB\x01*\"\n" +
 	"/v1/intent\x12\n" +
-	"/v1/intentB{\n" +
+	"/v1/intentB\xca\x04\xbaJ\xcb\x03\n" +
+	"\x8e\x02\n" +
+	"\x12Arkade Service API\x1a\xf3\x01The REST API of the Arkade operator. Use it to read operator parameters, register intents, take part in a batch swap, and submit transactions.\n" +
+	"\n" +
+	"Most applications should use an SDK rather than these endpoints directly: https://docs.arkadeos.com:\x02v1\x12*\n" +
+	"\x17https://arkade.computer\x12\x0fBitcoin mainnet\x12(\n" +
+	"\x1bhttps://mutinynet.arkade.sh\x12\tMutinynet\x12\"\n" +
+	"\x18https://signet.arkade.sh\x12\x06Signet\x12>\n" +
+	"\x15http://localhost:7070\x12%Local regtest, through arkade-regtest\n" +
 	"\n" +
 	"com.ark.v1B\fServiceProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"
 

--- a/api-spec/protobuf/gen/ark/v1/signer_manager.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/signer_manager.pb.go
@@ -153,7 +153,9 @@ const file_ark_v1_signer_manager_proto_rawDesc = "" +
 	"\x12LoadSignerResponse2u\n" +
 	"\x14SignerManagerService\x12]\n" +
 	"\n" +
-	"LoadSigner\x12\x19.ark.v1.LoadSignerRequest\x1a\x1a.ark.v1.LoadSignerResponse\"\x18\xb2J\x15B\x01*\"\x10/v1/admin/signerB\x81\x01\n" +
+	"LoadSigner\x12\x19.ark.v1.LoadSignerRequest\x1a\x1a.ark.v1.LoadSignerResponse\"\x18\xb2J\x15B\x01*\"\x10/v1/admin/signerB\xfb\x01\xbaJw\n" +
+	"u\n" +
+	"\x19Arkade Signer Manager API\x1aTOperator-internal API for managing signers. Not intended for application developers.:\x02v1\n" +
 	"\n" +
 	"com.ark.v1B\x12SignerManagerProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"
 

--- a/api-spec/protobuf/gen/ark/v1/types.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/types.pb.go
@@ -7,6 +7,7 @@
 package arkv1
 
 import (
+	_ "github.com/meshapi/grpc-api-gateway/api"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -1582,7 +1583,7 @@ var File_ark_v1_types_proto protoreflect.FileDescriptor
 
 const file_ark_v1_types_proto_rawDesc = "" +
 	"\n" +
-	"\x12ark/v1/types.proto\x12\x06ark.v1\"2\n" +
+	"\x12ark/v1/types.proto\x12\x06ark.v1\x1a!meshapi/gateway/annotations.proto\"2\n" +
 	"\bOutpoint\x12\x12\n" +
 	"\x04txid\x18\x01 \x01(\tR\x04txid\x12\x12\n" +
 	"\x04vout\x18\x02 \x01(\rR\x04vout\"l\n" +
@@ -1718,7 +1719,9 @@ const file_ark_v1_types_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x03(\v2\".ark.v1.ErrorDetails.MetadataEntryR\bmetadata\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01By\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x92\x02\xbaJ\x95\x01\n" +
+	"\x92\x01\n" +
+	"\x13Arkade Shared Types\x1awMessage types shared by the Arkade service and indexer APIs. This document defines schemas only and binds no endpoints.:\x02v1\n" +
 	"\n" +
 	"com.ark.v1B\n" +
 	"TypesProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"

--- a/api-spec/protobuf/gen/ark/v1/wallet.pb.go
+++ b/api-spec/protobuf/gen/ark/v1/wallet.pb.go
@@ -914,7 +914,9 @@ const file_ark_v1_wallet_proto_rawDesc = "" +
 	"\rDeriveAddress\x12\x1c.ark.v1.DeriveAddressRequest\x1a\x1d.ark.v1.DeriveAddressResponse\"\x1d\xb2J\x1a\x12\x18/v1/admin/wallet/address\x12b\n" +
 	"\n" +
 	"GetBalance\x12\x19.ark.v1.GetBalanceRequest\x1a\x1a.ark.v1.GetBalanceResponse\"\x1d\xb2J\x1a\x12\x18/v1/admin/wallet/balance\x12`\n" +
-	"\bWithdraw\x12\x17.ark.v1.WithdrawRequest\x1a\x18.ark.v1.WithdrawResponse\"!\xb2J\x1eB\x01*\"\x19/v1/admin/wallet/withdrawBz\n" +
+	"\bWithdraw\x12\x17.ark.v1.WithdrawRequest\x1a\x18.ark.v1.WithdrawResponse\"!\xb2J\x1eB\x01*\"\x19/v1/admin/wallet/withdrawB\x94\x02\xbaJ\x96\x01\n" +
+	"\x93\x01\n" +
+	"\x1dArkade Wallet Initializer API\x1anOperator-internal API for initializing and unlocking the arkd wallet. Not intended for application developers.:\x02v1\n" +
 	"\n" +
 	"com.ark.v1B\vWalletProtoP\x01Z&github.com/arkade-os/arkd/ark/v1;arkv1\xa2\x02\x03AXX\xaa\x02\x06Ark.V1\xca\x02\x06Ark\\V1\xe2\x02\x12Ark\\V1\\GPBMetadata\xea\x02\aArk::V1b\x06proto3"
 


### PR DESCRIPTION
Documentation metadata for the generated OpenAPI specs. No endpoint, message, or handler behaviour changes.

## Problem

Every spec under `api-spec/openapi/swagger/ark/v1/` is generated with placeholder metadata:

```json
"info": { "title": "", "version": "version not set" },
```

and **no `servers` block at all**. Two consequences:

1. An OpenAPI document without `servers` has no base URL. Any tool that renders an interactive console has nothing to send a request to, so "Try it" cannot work.
2. An empty `title` renders as a blank heading, and `"version not set"` is visible to anyone reading the spec.

This is the blocker for the API playground the docs site wants to publish — arkade-os/docs#60.

## Approach

Set the metadata through the `meshapi.gateway.openapi_doc` annotation, which the protos already have available (they import `meshapi/gateway/annotations.proto` for their HTTP bindings). Keeping it in the proto means it regenerates correctly and nobody has to remember to patch generated JSON.

| Spec | Title | Servers |
|---|---|---|
| `service` | Arkade Service API | all four |
| `indexer` | Arkade Indexer API | all four |
| `admin` | Arkade Admin API | none |
| `wallet` | Arkade Wallet Initializer API | none |
| `signer_manager` | Arkade Signer Manager API | none |
| `types` | Arkade Shared Types | none |

The four servers are `https://arkade.computer` (mainnet), `https://mutinynet.arkade.sh`, `https://signet.arkade.sh`, and `http://localhost:7070` (arkade-regtest).

**`admin`, `wallet`, and `signer_manager` deliberately get no `servers`.** They are operator-internal, and a spec that lists a public URL next to administrative endpoints invites someone to point a console at it. Their descriptions say plainly that they are not for application developers.

`version` is `"v1"`, matching the `ark.v1` proto package. That describes the API surface and stays correct, rather than drifting with each arkd release the way an embedded release number would.

The service and indexer descriptions both point at https://docs.arkadeos.com and say most applications should reach for an SDK first. These endpoints are for debugging and for understanding the wire format.

## Verification

Regenerated with `make proto`, then:

```
go build ./...   # passes
```

```
service:  title 'Arkade Service API',  version 'v1', 4 servers, 15 paths
indexer:  title 'Arkade Indexer API',  version 'v1', 4 servers, 15 paths
types:    title 'Arkade Shared Types', version 'v1', no servers
admin:    title 'Arkade Admin API',    version 'v1', no servers
```

Documents remain OpenAPI 3.1.0 and path counts are unchanged.

## Notes for review

- The `.pb.go` diffs are the embedded file descriptors picking up the new option — expected, and the reason those files move at all.
- `make proto` also reordered a `trie.New(...)` argument list in `indexer.pb.rgw.go`. That is generator nondeterminism over a set, unrelated to this change, so I reverted it to keep the diff honest. It will reappear for whoever regenerates next.
- `buf lint` emits a pre-existing warning that the `DEFAULT` lint category is deprecated in favour of `STANDARD`. Untouched here, but worth a follow-up in `api-spec/protobuf/buf.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation with clear titles, descriptions, and `v1` version information across Arkade services.
  * Documented available environments, including mainnet, Mutinynet, Signet, and local regtest where applicable.
  * Added operator-internal visibility notes for administrative, signer management, and wallet initialization APIs.
  * Added OpenAPI metadata to service definitions to keep generated documentation consistent with published API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->