### PR TITLE
fix(sweeper): correct expiry handling and add the epoch sweep primitives

### DIFF
--- a/docs/version-compat.md
+++ b/docs/version-compat.md
@@ -1,23 +1,24 @@
 # Build Version Compatibility
 
-The server enforces a minimum build (major) version globally, derived from its own
-build version. Any client whose major version is below the server's major
-version is rejected.
+The server enforces a minimum build version globally, derived from its own build
+version. Any client below that version is rejected.
 
-Only the **major** version component is compared. Minor and patch versions are
-ignored. For example, if the server is built as `v2.3.1`, a client at `2.0.0`,
-`2.1.0`, or `2.99.0` all pass, but `1.9.9` is rejected.
+The full `major.minor.patch` triple is compared, in that order. If the server is
+built as `v2.3.1` then `2.3.1` and `2.4.0` pass, but `2.3.0`, `2.2.9` and `1.9.9`
+are all rejected. Pre-release and build suffixes on the patch component are
+ignored, so `1.2.3-rc1` is treated as patch `3`.
 
 ## How it works
 
 1. At build time the server version is set via `-ldflags` (see
    `scripts/build-arkd`).
-2. On startup the server parses the major version from its build version string.
-3. On every request the server reads the client's SDK version header, extracts
-   the major version, and compares it against its own. If the client's major
-   version is lower, the request is rejected.
+2. On startup the server parses its own build version string.
+3. On every request the server reads the client's SDK version header and compares
+   it against its own, major first, then minor, then patch. If the client is
+   lower, the request is rejected.
 4. If a client does not send a header, the version check is skipped, allowing
-   backward compatibility.
+   backward compatibility — unless `build_version_header_required` is set, in
+   which case a missing or unparseable header is rejected.
 
 ### Client header
 
@@ -27,16 +28,23 @@ ignored. For example, if the server is built as `v2.3.1`, a client at `2.0.0`,
 | REST | `X-Build-Version` (HTTP header) |
 
 The value must be a semver string, optionally prefixed with `v` (e.g. `1.0.0` or
-`v1.0.0`). Only the major version component is used for comparison.
+`v1.0.0`). Missing components default to zero, so `1` is read as `1.0.0`.
 
 ### Decision table
 
 | Condition | Result |
 |-----------|--------|
-| No header sent | Request allowed |
-| Major version >= server major | Request allowed |
-| Major version < server major | `BUILD_VERSION_TOO_OLD` error |
-| Malformed version string | Request allowed |
+| No header sent | Allowed, unless `build_version_header_required` is set |
+| Malformed version string | Allowed, unless `build_version_header_required` is set |
+| Version >= server version | Request allowed |
+| Version < server version | `BUILD_VERSION_TOO_OLD` error |
+
+Two things worth knowing:
+
+- The guard applies only to the public `ArkService`. Admin and indexer RPCs are
+  never gated.
+- If the server's own build version cannot be parsed — a local or unreleased
+  build with no `-ldflags` — the guard is disabled for every client.
 
 ## Future: method-level versioning
 

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -3169,12 +3169,7 @@ func (s *service) startFinalization(
 	flatVtxoTree := make(tree.FlatTxTree, 0)
 	if vtxoTree != nil {
 
-		sweepClosure := script.CSVMultisigClosure{
-			MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{forfeitPubkey}},
-			Locktime:        vtxoTreeExpiry,
-		}
-
-		sweepScript, err := sweepClosure.Script()
+		root, _, err := tree.BuildLegacySweepTapTreeRoot(forfeitPubkey, vtxoTreeExpiry)
 		if err != nil {
 			return
 		}
@@ -3184,10 +3179,6 @@ func (s *service) startFinalization(
 			return
 		}
 		batchOutputAmount := commitmentPtx.UnsignedTx.TxOut[0].Value
-
-		sweepLeaf := txscript.NewBaseTapLeaf(sweepScript)
-		sweepTapTree := txscript.AssembleTaprootScriptTree(sweepLeaf)
-		root := sweepTapTree.RootNode.TapHash()
 
 		coordinator, err := tree.NewTreeCoordinatorSession(
 			root.CloneBytes(), batchOutputAmount, vtxoTree,

--- a/internal/core/application/service.go
+++ b/internal/core/application/service.go
@@ -1828,14 +1828,15 @@ func (s *service) RegisterIntent(
 			continue
 		}
 
-		if settlementMinExpiryGap > 0 && !vtxo.Swept {
-			// reject if expires after now + settlementMinExpiryGap
-			expiresAt := time.Unix(vtxo.ExpiresAt, 0)
-			limit := time.Now().Add(settlementMinExpiryGap)
-			if expiresAt.After(limit) {
+		// A swept vtxo is exempt: settling one is how recovery works, and the
+		// operator already holds the funds onchain.
+		if !vtxo.Swept {
+			if err := checkSettlementExpiryGap(
+				time.Unix(vtxo.ExpiresAt, 0), time.Now(), settlementMinExpiryGap,
+			); err != nil {
 				return "", errors.INVALID_PSBT_INPUT.New(
-					"vtxo %s expires after %s (minExpiryGap: %s)",
-					vtxo.Outpoint.String(), limit, settlementMinExpiryGap,
+					"vtxo %s: %s (minExpiryGap: %s)",
+					vtxo.Outpoint.String(), err, settlementMinExpiryGap,
 				).WithMetadata(errors.InputMetadata{
 					Txid:       proofTxid,
 					InputIndex: int(outpoint.Index),

--- a/internal/core/application/sweeper.go
+++ b/internal/core/application/sweeper.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -699,8 +698,10 @@ func (s *sweeper) createBatchSweepTask(commitmentTxid, vtxoTreeRootTxid string) 
 			}
 
 			err = nil
-			// retry until the tx is broadcasted or the error is not BIP68 final
-			for len(txid) == 0 && (err == nil || errors.Is(err, ports.ErrNonFinalBIP68)) {
+			// retry until the tx is broadcasted or the error is not a timelock
+			// one. Both kinds matter: batch outputs can be gated by a relative
+			// sequence, an absolute nLockTime, or both.
+			for len(txid) == 0 && (err == nil || ports.IsNonFinal(err)) {
 				select {
 				case <-s.ctx.Done():
 					return nil

--- a/internal/core/application/sweeper.go
+++ b/internal/core/application/sweeper.go
@@ -382,7 +382,11 @@ func (s *sweeper) scheduleTask(task sweeperTask) error {
 			"sweeper: trying to schedule task in the past for tx %s, executing it immediately",
 			task.id,
 		)
-		return task.execute()
+		// Same retry policy as the scheduled path. This is the branch a restart
+		// takes for a batch that expired while the service was down, so it is the
+		// one that most needs retrying: nothing re-arms the task until the next
+		// restart.
+		return s.executeWithRetry(task)
 	}
 
 	s.locker.Lock()
@@ -412,7 +416,9 @@ func (s *sweeper) scheduleTask(task sweeperTask) error {
 		// block every later schedule for this tree, including our own retries.
 		s.removeTask(task.id)
 
-		s.executeWithRetry(task)
+		// Nothing to return the error to from a scheduler callback; executeWithRetry
+		// has already logged the give-up.
+		_ = s.executeWithRetry(task)
 	})
 }
 
@@ -429,7 +435,9 @@ var (
 // executeWithRetry runs a sweep task, re-attempting it on failure. Without this a
 // single failed broadcast left the batch outputs unswept until an operator
 // restart, which is the window an attacker racing the sweep needs.
-func (s *sweeper) executeWithRetry(task sweeperTask) {
+// Returns the last error if every attempt failed, so callers running a task
+// inline still learn it did not succeed.
+func (s *sweeper) executeWithRetry(task sweeperTask) error {
 	ctx := s.ctx
 	if ctx == nil {
 		ctx = context.Background()
@@ -437,7 +445,7 @@ func (s *sweeper) executeWithRetry(task sweeperTask) {
 
 	err := task.execute()
 	if err == nil {
-		return
+		return nil
 	}
 
 	for attempt := 1; attempt <= sweepRetryAttempts; attempt++ {
@@ -448,12 +456,12 @@ func (s *sweeper) executeWithRetry(task sweeperTask) {
 
 		select {
 		case <-ctx.Done():
-			return
+			return err
 		case <-time.After(sweepRetryDelay):
 		}
 
 		if err = task.execute(); err == nil {
-			return
+			return nil
 		}
 	}
 
@@ -461,6 +469,7 @@ func (s *sweeper) executeWithRetry(task sweeperTask) {
 		"sweeper: giving up on sweep of tx %s after %d attempts, outputs remain unswept "+
 			"until the next restart", task.id, sweepRetryAttempts,
 	)
+	return err
 }
 
 // createBatchSweepTask returns a function passed as handler in the scheduler

--- a/internal/core/application/sweeper.go
+++ b/internal/core/application/sweeper.go
@@ -408,12 +408,60 @@ func (s *sweeper) scheduleTask(task sweeperTask) error {
 		}
 		s.locker.Unlock()
 
+		// Release the dedup slot before running: scheduledTasks guards against
+		// registering the same task twice, so holding the id past execution would
+		// block every later schedule for this tree, including our own retries.
 		s.removeTask(task.id)
 
-		if err := task.execute(); err != nil {
-			log.WithError(err).Errorf("failed to execute sweep of tx %s", task.id)
-		}
+		s.executeWithRetry(task)
 	})
+}
+
+var (
+	// sweepRetryDelay is how long to wait before re-attempting a sweep whose
+	// execution failed. A failure is usually a mempool conflict or a transient
+	// node error, neither of which clears in milliseconds.
+	sweepRetryDelay = time.Minute
+	// sweepRetryAttempts bounds the in-process retries. Beyond this the sweep is
+	// left for the next process start, which rebuilds tasks from the repository.
+	sweepRetryAttempts = 10
+)
+
+// executeWithRetry runs a sweep task, re-attempting it on failure. Without this a
+// single failed broadcast left the batch outputs unswept until an operator
+// restart, which is the window an attacker racing the sweep needs.
+func (s *sweeper) executeWithRetry(task sweeperTask) {
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	err := task.execute()
+	if err == nil {
+		return
+	}
+
+	for attempt := 1; attempt <= sweepRetryAttempts; attempt++ {
+		log.WithError(err).Warnf(
+			"sweeper: sweep of tx %s failed, retrying in %s (attempt %d/%d)",
+			task.id, sweepRetryDelay, attempt, sweepRetryAttempts,
+		)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(sweepRetryDelay):
+		}
+
+		if err = task.execute(); err == nil {
+			return
+		}
+	}
+
+	log.WithError(err).Errorf(
+		"sweeper: giving up on sweep of tx %s after %d attempts, outputs remain unswept "+
+			"until the next restart", task.id, sweepRetryAttempts,
+	)
 }
 
 // createBatchSweepTask returns a function passed as handler in the scheduler

--- a/internal/core/application/sweeper_test.go
+++ b/internal/core/application/sweeper_test.go
@@ -685,3 +685,126 @@ func newTestSweeper(t *testing.T) (
 	s := newSweeper(wallet, repoManager, builder, scheduler)
 	return wallet, vtxoRepo, markerRepo, builder, s
 }
+
+// controllableScheduler captures the scheduled closure so a test can fire it on
+// demand. mockScheduler above is a no-op and cannot drive scheduleTask.
+type controllableScheduler struct {
+	fn func()
+}
+
+func (s *controllableScheduler) Start()               {}
+func (s *controllableScheduler) Stop()                {}
+func (s *controllableScheduler) Unit() ports.TimeUnit { return ports.UnixTime }
+func (s *controllableScheduler) AfterNow(expiry int64) bool {
+	return true // always "in the future" so scheduleTask registers rather than running inline
+}
+func (s *controllableScheduler) ScheduleTaskOnce(at int64, task func()) error {
+	s.fn = task
+	return nil
+}
+func (s *controllableScheduler) fire() {
+	if s.fn != nil {
+		s.fn()
+	}
+}
+
+// newSchedulableSweeper builds a sweeper wired to a scheduler the test controls.
+// newTestSweeper above uses mockScheduler, whose ScheduleTaskOnce is a no-op.
+func newSchedulableSweeper(sched ports.SchedulerService) *sweeper {
+	s := newSweeper(&mockWalletService{}, &mockRepoManager{}, &mockTxBuilder{}, sched)
+	s.ctx = context.Background()
+	return s
+}
+
+// TestScheduleTaskRetriesFailedExecution pins that a sweep whose broadcast fails
+// is re-attempted rather than silently dropped. Before this, a single mempool
+// conflict left the batch unswept until an operator restart.
+func TestScheduleTaskRetriesFailedExecution(t *testing.T) {
+	prevDelay, prevAttempts := sweepRetryDelay, sweepRetryAttempts
+	sweepRetryDelay, sweepRetryAttempts = time.Millisecond, 3
+	t.Cleanup(func() { sweepRetryDelay, sweepRetryAttempts = prevDelay, prevAttempts })
+
+	sched := &controllableScheduler{}
+	s := newSchedulableSweeper(sched)
+
+	calls := 0
+	require.NoError(t, s.scheduleTask(sweeperTask{
+		id: "task-fail",
+		at: time.Now().Add(time.Hour).Unix(),
+		execute: func() error {
+			calls++
+			return fmt.Errorf("broadcast rejected")
+		},
+	}))
+
+	sched.fire()
+
+	// one initial attempt plus sweepRetryAttempts retries
+	require.Equal(t, 1+3, calls, "a failed sweep must be retried, not dropped")
+}
+
+// TestScheduleTaskStopsRetryingOnSuccess pins that a retry that succeeds ends the
+// loop instead of burning the remaining attempts.
+func TestScheduleTaskStopsRetryingOnSuccess(t *testing.T) {
+	prevDelay, prevAttempts := sweepRetryDelay, sweepRetryAttempts
+	sweepRetryDelay, sweepRetryAttempts = time.Millisecond, 5
+	t.Cleanup(func() { sweepRetryDelay, sweepRetryAttempts = prevDelay, prevAttempts })
+
+	sched := &controllableScheduler{}
+	s := newSchedulableSweeper(sched)
+
+	calls := 0
+	require.NoError(t, s.scheduleTask(sweeperTask{
+		id: "task-eventually-ok",
+		at: time.Now().Add(time.Hour).Unix(),
+		execute: func() error {
+			calls++
+			if calls < 3 {
+				return fmt.Errorf("still conflicting")
+			}
+			return nil
+		},
+	}))
+
+	sched.fire()
+	require.Equal(t, 3, calls, "retrying must stop as soon as the sweep succeeds")
+}
+
+// TestScheduleTaskFreesDedupSlot pins that the id is released once the task has
+// run, so a later schedule for the same tree is accepted. scheduledTasks is a
+// dedup guard: holding the id past execution would block re-scheduling entirely.
+func TestScheduleTaskFreesDedupSlot(t *testing.T) {
+	prevDelay, prevAttempts := sweepRetryDelay, sweepRetryAttempts
+	sweepRetryDelay, sweepRetryAttempts = time.Millisecond, 1
+	t.Cleanup(func() { sweepRetryDelay, sweepRetryAttempts = prevDelay, prevAttempts })
+
+	sched := &controllableScheduler{}
+	s := newSchedulableSweeper(sched)
+
+	at := time.Now().Add(time.Hour).Unix()
+	failing := sweeperTask{
+		id: "task-slot", at: at,
+		execute: func() error { return fmt.Errorf("broadcast rejected") },
+	}
+	require.NoError(t, s.scheduleTask(failing))
+
+	s.locker.Lock()
+	_, registered := s.scheduledTasks["task-slot"]
+	s.locker.Unlock()
+	require.True(t, registered, "task must occupy the dedup slot while pending")
+
+	sched.fire()
+
+	s.locker.Lock()
+	_, stillHeld := s.scheduledTasks["task-slot"]
+	s.locker.Unlock()
+	require.False(t, stillHeld, "dedup slot must be released so the id can be re-scheduled")
+
+	second := 0
+	require.NoError(t, s.scheduleTask(sweeperTask{
+		id: "task-slot", at: at,
+		execute: func() error { second++; return nil },
+	}))
+	sched.fire()
+	require.Equal(t, 1, second, "a fresh schedule for the same id must be accepted")
+}

--- a/internal/core/application/sweeper_test.go
+++ b/internal/core/application/sweeper_test.go
@@ -808,3 +808,40 @@ func TestScheduleTaskFreesDedupSlot(t *testing.T) {
 	sched.fire()
 	require.Equal(t, 1, second, "a fresh schedule for the same id must be accepted")
 }
+
+// TestScheduleTaskRetriesAlreadyDueTask covers the path a restart takes. When a
+// batch expired while the service was down, AfterNow is false and scheduleTask
+// runs the task inline rather than handing it to the scheduler. That path must
+// use the same bounded retry policy - it is the case that most needs it, since
+// nothing will re-arm the task until the next restart.
+func TestScheduleTaskRetriesAlreadyDueTask(t *testing.T) {
+	prevDelay, prevAttempts := sweepRetryDelay, sweepRetryAttempts
+	sweepRetryDelay, sweepRetryAttempts = time.Millisecond, 3
+	t.Cleanup(func() { sweepRetryDelay, sweepRetryAttempts = prevDelay, prevAttempts })
+
+	sched := &immediateScheduler{}
+	s := newSchedulableSweeper(sched)
+
+	calls := 0
+	err := s.scheduleTask(sweeperTask{
+		id: "already-due",
+		at: time.Now().Add(-time.Hour).Unix(),
+		execute: func() error {
+			calls++
+			return fmt.Errorf("broadcast rejected")
+		},
+	})
+
+	require.Error(t, err, "the final failure must still reach the caller")
+	require.Equal(t, 1+3, calls, "an already-due task must retry like a scheduled one")
+}
+
+// immediateScheduler reports every task as already due, which is what a restart
+// looks like for a batch that expired while the service was down.
+type immediateScheduler struct{}
+
+func (s *immediateScheduler) Start()                               {}
+func (s *immediateScheduler) Stop()                                {}
+func (s *immediateScheduler) Unit() ports.TimeUnit                 { return ports.UnixTime }
+func (s *immediateScheduler) AfterNow(expiry int64) bool           { return false }
+func (s *immediateScheduler) ScheduleTaskOnce(int64, func()) error { return nil }

--- a/internal/core/application/utils.go
+++ b/internal/core/application/utils.go
@@ -655,6 +655,7 @@ func calculateBoardingInputAmount(ptx *psbt.Packet) uint64 {
 func isBoardingInput(in psbt.PInput) bool {
 	return in.WitnessUtxo != nil && len(in.TaprootLeafScript) > 0
 }
+
 // checkSettlementExpiryGap rejects a vtxo that does not have at least gap of
 // remaining life. A vtxo settled with almost no life left leaves the operator no
 // forfeit-enforcement window, which is the risk class the setting exists to

--- a/internal/core/application/utils.go
+++ b/internal/core/application/utils.go
@@ -655,3 +655,17 @@ func calculateBoardingInputAmount(ptx *psbt.Packet) uint64 {
 func isBoardingInput(in psbt.PInput) bool {
 	return in.WitnessUtxo != nil && len(in.TaprootLeafScript) > 0
 }
+// checkSettlementExpiryGap rejects a vtxo that does not have at least gap of
+// remaining life. A vtxo settled with almost no life left leaves the operator no
+// forfeit-enforcement window, which is the risk class the setting exists to
+// exclude. Mirrors the direction of checkUnrolledVtxoExpiry.
+// A gap of 0 disables the check.
+func checkSettlementExpiryGap(expiresAt, now time.Time, gap time.Duration) error {
+	if gap <= 0 {
+		return nil
+	}
+	if expiresAt.Before(now.Add(gap)) {
+		return fmt.Errorf("vtxo expires too soon (within %s)", gap)
+	}
+	return nil
+}

--- a/internal/core/application/utils_test.go
+++ b/internal/core/application/utils_test.go
@@ -476,3 +476,39 @@ func makeP2TRLeafTx(t *testing.T, outputs []testOutput) string {
 	require.NoError(t, err)
 	return b64
 }
+
+// TestCheckSettlementExpiryGap pins the direction of the settlement expiry gap:
+// the setting is documented as "the min expiry gap in seconds required to settle
+// a vtxo" (cmd/arkd/flags.go), i.e. a floor on remaining life. A vtxo with almost
+// no life left must be rejected, a healthy one accepted.
+func TestCheckSettlementExpiryGap(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	gap := 24 * time.Hour
+
+	t.Run("healthy vtxo with plenty of life is accepted", func(t *testing.T) {
+		expiresAt := now.Add(7 * 24 * time.Hour)
+		require.NoError(t, checkSettlementExpiryGap(expiresAt, now, gap))
+	})
+
+	t.Run("vtxo expiring inside the gap is rejected", func(t *testing.T) {
+		expiresAt := now.Add(1 * time.Hour)
+		err := checkSettlementExpiryGap(expiresAt, now, gap)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "expires too soon")
+	})
+
+	t.Run("vtxo exactly at the boundary is accepted", func(t *testing.T) {
+		expiresAt := now.Add(gap)
+		require.NoError(t, checkSettlementExpiryGap(expiresAt, now, gap))
+	})
+
+	t.Run("already expired vtxo is rejected", func(t *testing.T) {
+		expiresAt := now.Add(-1 * time.Hour)
+		require.Error(t, checkSettlementExpiryGap(expiresAt, now, gap))
+	})
+
+	t.Run("zero gap disables the check", func(t *testing.T) {
+		expiresAt := now.Add(-1 * time.Hour)
+		require.NoError(t, checkSettlementExpiryGap(expiresAt, now, 0))
+	})
+}

--- a/internal/core/ports/wallet.go
+++ b/internal/core/ports/wallet.go
@@ -12,7 +12,17 @@ import (
 var (
 	// ErrNonFinalBIP68 is returned when a transaction spending a CSV-locked output is not final.
 	ErrNonFinalBIP68 = errors.New("non-final BIP68 sequence")
+	// ErrNonFinalCLTV is returned when a transaction's nLockTime has not yet been
+	// reached according to the chain's median-time-past.
+	ErrNonFinalCLTV = errors.New("non-final nLockTime")
 )
+
+// IsNonFinal reports whether err means "too early, try again later" for either
+// timelock kind. Broadcast loops waiting on a timelock should retry on this
+// rather than treating it as a permanent failure.
+func IsNonFinal(err error) bool {
+	return errors.Is(err, ErrNonFinalBIP68) || errors.Is(err, ErrNonFinalCLTV)
+}
 
 type WalletService interface {
 	BlockchainScanner

--- a/internal/infrastructure/tx-builder/covenantless/builder.go
+++ b/internal/infrastructure/tx-builder/covenantless/builder.go
@@ -548,17 +548,10 @@ func (b *txBuilder) BuildCommitmentTx(
 		return "", nil, "", nil, err
 	}
 
-	sweepScript, err := (&script.CSVMultisigClosure{
-		MultisigClosure: script.MultisigClosure{
-			PubKeys: []*btcec.PublicKey{signerPubkey},
-		},
-		Locktime: vtxoTreeExpiry,
-	}).Script()
+	sweepTapscriptRoot, _, err := tree.BuildLegacySweepTapTreeRoot(signerPubkey, vtxoTreeExpiry)
 	if err != nil {
 		return "", nil, "", nil, err
 	}
-
-	sweepTapscriptRoot := txscript.NewBaseTapLeaf(sweepScript).TapHash()
 
 	if !intents.HaveOnlyOnchainOutput() {
 		batchOutputScript, batchOutputAmount, err = tree.BuildBatchOutput(
@@ -1213,20 +1206,10 @@ func (b *txBuilder) extractSweepLeaf(ptx *psbt.Packet, inputIndex int) (
 
 	vtxoTreeExpiry := vtxoTreeExpiryFields[0]
 
-	sweepClosure := &script.CSVMultisigClosure{
-		Locktime: vtxoTreeExpiry,
-		MultisigClosure: script.MultisigClosure{
-			PubKeys: []*btcec.PublicKey{sweeperPubkey},
-		},
-	}
-
-	sweepScript, err := sweepClosure.Script()
+	sweepRoot, sweepScript, err := tree.BuildLegacySweepTapTreeRoot(sweeperPubkey, vtxoTreeExpiry)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
-	sweepTapTree := txscript.AssembleTaprootScriptTree(txscript.NewBaseTapLeaf(sweepScript))
-	sweepRoot := sweepTapTree.RootNode.TapHash()
 
 	cosignerPubkeys, err := txutils.ParseCosignerKeysFromArkPsbt(ptx, inputIndex)
 	if err != nil {
@@ -1246,6 +1229,8 @@ func (b *txBuilder) extractSweepLeaf(ptx *psbt.Packet, inputIndex int) (
 	}
 	internalKey := aggregatedKey.PreTweakedKey
 
+	// single-leaf tree, so the proof carries no merkle path
+	sweepTapTree := txscript.AssembleTaprootScriptTree(txscript.NewBaseTapLeaf(sweepScript))
 	sweepLeafMerkleProof := sweepTapTree.LeafMerkleProofs[0]
 	sweepLeafControlBlock := sweepLeafMerkleProof.ToControlBlock(internalKey)
 	sweepLeafControlBlockBytes, err := sweepLeafControlBlock.ToBytes()

--- a/internal/infrastructure/tx-builder/covenantless/sweep.go
+++ b/internal/infrastructure/tx-builder/covenantless/sweep.go
@@ -25,7 +25,8 @@ import (
 // are non-final, which is also what CHECKLOCKTIMEVERIFY requires of its input.
 func sweepInputLocktime(tapscript []byte) (sequence uint32, lockTime uint32, err error) {
 	epoch := script.CLTVCSVMultisigClosure{}
-	if valid, decodeErr := epoch.Decode(tapscript); decodeErr == nil && valid {
+	valid, epochErr := epoch.Decode(tapscript)
+	if epochErr == nil && valid {
 		seq, err := arklib.BIP68Sequence(epoch.UnrollGrace)
 		if err != nil {
 			return 0, 0, err
@@ -33,12 +34,27 @@ func sweepInputLocktime(tapscript []byte) (sequence uint32, lockTime uint32, err
 		return seq, uint32(epoch.ExpiryDate), nil
 	}
 
+	// Fall through to the legacy decoder even when the hybrid one errored. A CSV
+	// leaf is under no obligation to be readable as a hybrid leaf, and refusing
+	// on that error would leave legacy batches unswept - the failure this whole
+	// path exists to avoid.
+	//
+	// Do not throw the error away either: if the leaf turns out not to be a legacy
+	// one, it is the only thing that says what went wrong, and "unsupported sweep
+	// tapscript" on its own gives an operator nothing to work with.
 	legacy := script.CSVMultisigClosure{}
-	valid, err := legacy.Decode(tapscript)
+	valid, err = legacy.Decode(tapscript)
 	if err != nil {
 		return 0, 0, err
 	}
 	if !valid {
+		if epochErr != nil {
+			return 0, 0, fmt.Errorf(
+				"unsupported sweep tapscript, cannot build sweep transaction "+
+					"(not a legacy leaf, and reading it as an epoch leaf failed: %w)",
+				epochErr,
+			)
+		}
 		return 0, 0, fmt.Errorf("unsupported sweep tapscript, cannot build sweep transaction")
 	}
 

--- a/internal/infrastructure/tx-builder/covenantless/sweep.go
+++ b/internal/infrastructure/tx-builder/covenantless/sweep.go
@@ -17,11 +17,48 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+// sweepInputLocktime derives the nSequence and the required nLockTime for a
+// sweep input from its tapscript leaf.
+//
+// A legacy CSV leaf needs only a BIP68 sequence. An epoch leaf needs that plus an
+// nLockTime at or after its expiry date. Both sequences are BIP68-encoded and so
+// are non-final, which is also what CHECKLOCKTIMEVERIFY requires of its input.
+func sweepInputLocktime(tapscript []byte) (sequence uint32, lockTime uint32, err error) {
+	epoch := script.CLTVCSVMultisigClosure{}
+	if valid, decodeErr := epoch.Decode(tapscript); decodeErr == nil && valid {
+		seq, err := arklib.BIP68Sequence(epoch.UnrollGrace)
+		if err != nil {
+			return 0, 0, err
+		}
+		return seq, uint32(epoch.ExpiryDate), nil
+	}
+
+	legacy := script.CSVMultisigClosure{}
+	valid, err := legacy.Decode(tapscript)
+	if err != nil {
+		return 0, 0, err
+	}
+	if !valid {
+		return 0, 0, fmt.Errorf("unsupported sweep tapscript, cannot build sweep transaction")
+	}
+
+	seq, err := arklib.BIP68Sequence(legacy.Locktime)
+	if err != nil {
+		return 0, 0, err
+	}
+	return seq, 0, nil
+}
+
 func sweepTransaction(
 	ctx context.Context, wallet ports.WalletService, inputs []ports.TxInput,
 ) (txid string, txhex string, err error) {
 	ins := make([]*wire.OutPoint, 0)
 	sequences := make([]uint32, 0)
+
+	// One transaction carries one nLockTime, so it must satisfy the latest expiry
+	// date among its inputs. Callers group inputs by maturity class: mixing a
+	// future-dated epoch input into a batch of ready ones would stall them all.
+	maxLockTime := uint32(0)
 
 	for _, input := range inputs {
 		hash, err := chainhash.NewHashFromStr(input.Txid)
@@ -42,26 +79,21 @@ func sweepTransaction(
 				return "", "", err
 			}
 
-			sweepClosure := script.CSVMultisigClosure{}
-			valid, err := sweepClosure.Decode(tapscriptBytes)
+			seq, lockTime, err := sweepInputLocktime(tapscriptBytes)
 			if err != nil {
 				return "", "", err
 			}
 
-			if !valid {
-				return "", "", fmt.Errorf("invalid csv script, cannot build sweep transaction")
-			}
-
-			sequence, err = arklib.BIP68Sequence(sweepClosure.Locktime)
-			if err != nil {
-				return "", "", err
+			sequence = seq
+			if lockTime > maxLockTime {
+				maxLockTime = lockTime
 			}
 		}
 
 		sequences = append(sequences, sequence)
 	}
 
-	ptx, err := psbt.New(ins, nil, 2, 0, sequences)
+	ptx, err := psbt.New(ins, nil, 2, maxLockTime, sequences)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/infrastructure/tx-builder/covenantless/sweep_internal_test.go
+++ b/internal/infrastructure/tx-builder/covenantless/sweep_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +72,47 @@ func TestSweepInputLocktime(t *testing.T) {
 	t.Run("garbage is rejected", func(t *testing.T) {
 		_, _, err := sweepInputLocktime([]byte{0x01, 0x02, 0x03})
 		require.Error(t, err)
+	})
+
+	// A leaf that is neither kind, but which got far enough into the epoch decoder
+	// to fail there, must report why. "unsupported sweep tapscript" on its own
+	// leaves an operator with nothing to work with.
+	t.Run("a failed epoch decode reaches the caller", func(t *testing.T) {
+		// CLTV-shaped, but the locktime is a 7-byte script number: past the 6-byte
+		// limit MakeScriptNum allows, so the epoch decoder errors rather than
+		// declining. The legacy decoder does not recognise it either.
+		raw, err := txscript.NewScriptBuilder().
+			AddData([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}).
+			AddOps([]byte{txscript.OP_CHECKLOCKTIMEVERIFY, txscript.OP_DROP}).
+			Script()
+		require.NoError(t, err)
+
+		_, _, err = sweepInputLocktime(raw)
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(), "reading it as an epoch leaf failed",
+			"the epoch decoder's error must not be swallowed",
+		)
+	})
+
+	// The counterpart: a legacy leaf must keep working even if the epoch decoder
+	// errors on it. Refusing on that error would leave legacy batches unswept.
+	t.Run("a legacy leaf survives an epoch decode error", func(t *testing.T) {
+		raw, err := (&script.CSVMultisigClosure{
+			MultisigClosure: keys, Locktime: legacyExpiry,
+		}).Script()
+		require.NoError(t, err)
+
+		// Confirm the premise: whatever the epoch decoder makes of this leaf, the
+		// legacy path still has to produce a sequence.
+		epoch := script.CLTVCSVMultisigClosure{}
+		valid, _ := epoch.Decode(raw)
+		require.False(t, valid, "a csv leaf must not decode as an epoch leaf")
+
+		seq, lock, err := sweepInputLocktime(raw)
+		require.NoError(t, err)
+		require.Zero(t, lock)
+		require.NotZero(t, seq)
 	})
 }
 

--- a/internal/infrastructure/tx-builder/covenantless/sweep_internal_test.go
+++ b/internal/infrastructure/tx-builder/covenantless/sweep_internal_test.go
@@ -1,0 +1,138 @@
+package txbuilder
+
+import (
+	"testing"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil/psbt"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+func testKeys(t *testing.T) script.MultisigClosure {
+	t.Helper()
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	return script.MultisigClosure{PubKeys: []*btcec.PublicKey{prv.PubKey()}}
+}
+
+// TestSweepInputLocktime pins how a sweep input's tapscript leaf maps to the
+// nSequence and nLockTime the spending transaction must carry.
+func TestSweepInputLocktime(t *testing.T) {
+	keys := testKeys(t)
+	grace := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 7168}
+	legacyExpiry := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672}
+	date := arklib.AbsoluteLocktime(1788134400)
+
+	t.Run("legacy csv leaf yields a sequence and no locktime", func(t *testing.T) {
+		raw, err := (&script.CSVMultisigClosure{
+			MultisigClosure: keys, Locktime: legacyExpiry,
+		}).Script()
+		require.NoError(t, err)
+
+		seq, lock, err := sweepInputLocktime(raw)
+		require.NoError(t, err)
+		require.Zero(t, lock, "a relative-only leaf must not force an nLockTime")
+
+		expected, err := arklib.BIP68Sequence(legacyExpiry)
+		require.NoError(t, err)
+		require.Equal(t, expected, seq)
+	})
+
+	t.Run("epoch leaf yields both", func(t *testing.T) {
+		raw, err := (&script.CLTVCSVMultisigClosure{
+			MultisigClosure: keys, ExpiryDate: date, UnrollGrace: grace,
+		}).Script()
+		require.NoError(t, err)
+
+		seq, lock, err := sweepInputLocktime(raw)
+		require.NoError(t, err)
+		require.Equal(t, uint32(date), lock)
+
+		expected, err := arklib.BIP68Sequence(grace)
+		require.NoError(t, err)
+		require.Equal(t, expected, seq)
+		require.Less(
+			t, seq, uint32(0xfffffffe),
+			"sequence must stay non-final or CHECKLOCKTIMEVERIFY rejects the spend",
+		)
+	})
+
+	t.Run("unknown leaf is rejected", func(t *testing.T) {
+		raw, err := (&script.MultisigClosure{PubKeys: keys.PubKeys}).Script()
+		require.NoError(t, err)
+		_, _, err = sweepInputLocktime(raw)
+		require.Error(t, err)
+	})
+
+	t.Run("garbage is rejected", func(t *testing.T) {
+		_, _, err := sweepInputLocktime([]byte{0x01, 0x02, 0x03})
+		require.Error(t, err)
+	})
+}
+
+// TestSweepTxShape assembles the transaction the way sweepTransaction does and
+// pins the three properties the script engine requires of it: version 2, an
+// nLockTime at or above every input's expiry date, and non-final sequences.
+func TestSweepTxShape(t *testing.T) {
+	keys := testKeys(t)
+	grace := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 7168}
+	legacyExpiry := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672}
+	earlier := arklib.AbsoluteLocktime(1788134400)
+	later := arklib.AbsoluteLocktime(1790000000)
+
+	leaf := func(t *testing.T, c script.Closure) []byte {
+		t.Helper()
+		raw, err := c.Script()
+		require.NoError(t, err)
+		return raw
+	}
+
+	build := func(t *testing.T, leaves [][]byte) *psbt.Packet {
+		t.Helper()
+		ins := make([]*wire.OutPoint, 0, len(leaves))
+		sequences := make([]uint32, 0, len(leaves))
+		maxLockTime := uint32(0)
+
+		for i, l := range leaves {
+			ins = append(ins, &wire.OutPoint{Hash: chainhash.Hash{byte(i)}, Index: uint32(i)})
+			seq, lock, err := sweepInputLocktime(l)
+			require.NoError(t, err)
+			sequences = append(sequences, seq)
+			if lock > maxLockTime {
+				maxLockTime = lock
+			}
+		}
+
+		ptx, err := psbt.New(ins, nil, 2, maxLockTime, sequences)
+		require.NoError(t, err)
+		return ptx
+	}
+
+	t.Run("legacy only leaves nLockTime at zero", func(t *testing.T) {
+		ptx := build(t, [][]byte{
+			leaf(t, &script.CSVMultisigClosure{MultisigClosure: keys, Locktime: legacyExpiry}),
+		})
+		require.Equal(t, uint32(0), ptx.UnsignedTx.LockTime)
+		require.Equal(t, int32(2), ptx.UnsignedTx.Version)
+	})
+
+	t.Run("epoch inputs take the highest expiry date", func(t *testing.T) {
+		ptx := build(t, [][]byte{
+			leaf(t, &script.CLTVCSVMultisigClosure{
+				MultisigClosure: keys, ExpiryDate: earlier, UnrollGrace: grace,
+			}),
+			leaf(t, &script.CLTVCSVMultisigClosure{
+				MultisigClosure: keys, ExpiryDate: later, UnrollGrace: grace,
+			}),
+		})
+		require.Equal(t, uint32(later), ptx.UnsignedTx.LockTime)
+
+		for i, in := range ptx.UnsignedTx.TxIn {
+			require.Less(t, in.Sequence, uint32(0xfffffffe), "input %d must be non-final", i)
+		}
+	})
+}

--- a/internal/infrastructure/wallet/wallet_client.go
+++ b/internal/infrastructure/wallet/wallet_client.go
@@ -391,14 +391,32 @@ func (w *walletDaemonClient) BroadcastTransaction(
 		ctx, &arkwalletv1.BroadcastTransactionRequest{Txs: txs},
 	)
 	if err != nil {
-		// handle non-final BIP68 error and return the appropriate error
-		if strings.Contains(
-			strings.ToLower(err.Error()), "non-bip68-final") {
-			return "", ports.ErrNonFinalBIP68
+		// map timelock rejections to typed errors the sweeper can retry on
+		if classified := classifyBroadcastError(err); classified != nil {
+			return "", classified
 		}
 		return "", err
 	}
 	return resp.GetTxid(), nil
+}
+
+// classifyBroadcastError maps a node's mempool rejection reason to a typed port
+// error, or nil when the failure is not a timelock problem. Bitcoin Core reports
+// "non-BIP68-final" for a premature relative timelock and "non-final" for a
+// premature nLockTime; the two are disjoint, but BIP68 is checked first so the
+// narrower reason can never be swallowed by the broader one.
+func classifyBroadcastError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "non-bip68-final") {
+		return ports.ErrNonFinalBIP68
+	}
+	if strings.Contains(msg, "non-final") {
+		return ports.ErrNonFinalCLTV
+	}
+	return nil
 }
 
 func (w *walletDaemonClient) EstimateFees(ctx context.Context, psbt string) (uint64, error) {

--- a/internal/infrastructure/wallet/wallet_client.go
+++ b/internal/infrastructure/wallet/wallet_client.go
@@ -410,13 +410,41 @@ func classifyBroadcastError(err error) error {
 		return nil
 	}
 	msg := strings.ToLower(err.Error())
-	if strings.Contains(msg, "non-bip68-final") {
+	if namesReason(msg, "non-bip68-final") {
 		return ports.ErrNonFinalBIP68
 	}
-	if strings.Contains(msg, "non-final") {
+	if namesReason(msg, "non-final") {
 		return ports.ErrNonFinalCLTV
 	}
 	return nil
+}
+
+// namesReason reports whether msg gives reason as a rejection reason rather than
+// as the start of a longer word.
+//
+// A plain substring test also fires on "non-finalized" and friends, and a
+// misclassification is not free here: IsNonFinal marks the failure retryable, so
+// the sweeper would spend its whole retry budget on an error that was never
+// going to clear. Only the trailing edge is checked - Core prefixes reasons in
+// more than one way, and demanding a leading boundary too would reject
+// legitimate forms like "bad-txns-non-final".
+func namesReason(msg, reason string) bool {
+	for i := 0; i+len(reason) <= len(msg); {
+		j := strings.Index(msg[i:], reason)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(reason)
+		if end == len(msg) || !isReasonByte(msg[end]) {
+			return true
+		}
+		i = end
+	}
+	return false
+}
+
+func isReasonByte(b byte) bool {
+	return b == '-' || b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
 }
 
 func (w *walletDaemonClient) EstimateFees(ctx context.Context, psbt string) (uint64, error) {

--- a/internal/infrastructure/wallet/wallet_client_test.go
+++ b/internal/infrastructure/wallet/wallet_client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	arkwalletv1 "github.com/arkade-os/arkd/api-spec/protobuf/gen/arkwallet/v1"
+	"github.com/arkade-os/arkd/internal/core/ports"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -241,4 +242,54 @@ func TestWalletClientUnwatchScriptsChunking(t *testing.T) {
 		require.ErrorIs(t, err, boom)
 		require.Len(t, fake.unwatchCalls, 1)
 	})
+}
+
+// TestClassifyBroadcastError pins that both timelock rejections are recognised.
+// The mapping is a substring match on the node's rejection reason: Core says
+// "non-BIP68-final" for a premature relative timelock and "non-final" for a
+// premature nLockTime. Only the first was handled, so a CLTV-too-early sweep
+// returned a bare error and the sweeper's retry loop skipped it.
+func TestClassifyBroadcastError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want error
+	}{
+		{"bip68", "rpc error: non-BIP68-final", ports.ErrNonFinalBIP68},
+		{"bip68 lowercase", "non-bip68-final", ports.ErrNonFinalBIP68},
+		{"cltv", "rpc error: non-final", ports.ErrNonFinalCLTV},
+		{"cltv mixed case", "Non-Final", ports.ErrNonFinalCLTV},
+		{"unrelated", "insufficient fee", nil},
+		{"nil", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var in error
+			if tt.in != "" {
+				in = errors.New(tt.in)
+			}
+			got := classifyBroadcastError(in)
+			if tt.want == nil {
+				require.Nil(t, got)
+				return
+			}
+			require.ErrorIs(t, got, tt.want)
+		})
+	}
+}
+
+// TestClassifyBroadcastErrorPrecedence pins that a BIP68 rejection is never
+// misread as a CLTV one. The two reason strings are disjoint today; this test
+// keeps a future edit from reordering them into ambiguity.
+func TestClassifyBroadcastErrorPrecedence(t *testing.T) {
+	got := classifyBroadcastError(errors.New("non-BIP68-final"))
+	require.ErrorIs(t, got, ports.ErrNonFinalBIP68)
+	require.NotErrorIs(t, got, ports.ErrNonFinalCLTV)
+}
+
+func TestIsNonFinal(t *testing.T) {
+	require.True(t, ports.IsNonFinal(ports.ErrNonFinalBIP68))
+	require.True(t, ports.IsNonFinal(ports.ErrNonFinalCLTV))
+	require.False(t, ports.IsNonFinal(errors.New("insufficient fee")))
+	require.False(t, ports.IsNonFinal(nil))
 }

--- a/internal/infrastructure/wallet/wallet_client_test.go
+++ b/internal/infrastructure/wallet/wallet_client_test.go
@@ -293,3 +293,33 @@ func TestIsNonFinal(t *testing.T) {
 	require.False(t, ports.IsNonFinal(errors.New("insufficient fee")))
 	require.False(t, ports.IsNonFinal(nil))
 }
+
+// TestClassifyBroadcastErrorWordBoundary pins that a longer word merely
+// containing a reason is not read as that reason. Misclassifying one marks the
+// failure retryable, and the sweeper then burns its whole retry budget on an
+// error that will never clear.
+func TestClassifyBroadcastErrorWordBoundary(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want error
+	}{
+		{"non-final", ports.ErrNonFinalCLTV},
+		{"bad-txns-non-final", ports.ErrNonFinalCLTV},
+		{"error: non-final, rejecting", ports.ErrNonFinalCLTV},
+		{"non-BIP68-final", ports.ErrNonFinalBIP68},
+		{"non-finalized channel state", nil},
+		{"transaction is non-finality-locked", nil},
+		{"rate limited", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			got := classifyBroadcastError(errors.New(tt.msg))
+			if tt.want == nil {
+				require.NoError(t, got)
+				return
+			}
+			require.ErrorIs(t, got, tt.want)
+		})
+	}
+}

--- a/pkg/ark-lib/script/closure.go
+++ b/pkg/ark-lib/script/closure.go
@@ -42,6 +42,9 @@ func DecodeClosure(script []byte) (Closure, error) {
 		closure Closure
 		name    string
 	}{
+		// most specific first: the hybrid starts with a CLTV prefix the narrower
+		// types reject anyway, but ordering keeps that from being load-bearing
+		{&CLTVCSVMultisigClosure{}, "CLTV+CSV Multisig"},
 		{&CSVMultisigClosure{}, "CSV Multisig"},
 		{&CLTVMultisigClosure{}, "CLTV Multisig"},
 		{&MultisigClosure{}, "Multisig"},

--- a/pkg/ark-lib/script/closure_epoch.go
+++ b/pkg/ark-lib/script/closure_epoch.go
@@ -1,0 +1,168 @@
+package script
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// CLTVCSVMultisigClosure is the operator's epoch sweep closure. It requires both
+// an absolute date (ExpiryDate, shared by every batch in the epoch) and a
+// relative delay since the spent output appeared (UnrollGrace).
+//
+// For an untouched batch node the relative delay is satisfied long before the
+// date, so the output matures at exactly ExpiryDate and the whole epoch can be
+// swept in one transaction. For a node created by a mid-flight unilateral unroll
+// at time u it matures at max(ExpiryDate, u+UnrollGrace), which hands the exiting
+// user UnrollGrace per tree level without needing a different script per level.
+//
+// This closure is only ever used in the sweep leaf. It must never appear in a
+// user's vtxo script, where ForfeitClosures/ExitClosures would not classify it.
+type CLTVCSVMultisigClosure struct {
+	MultisigClosure
+	ExpiryDate  arklib.AbsoluteLocktime
+	UnrollGrace arklib.RelativeLocktime
+}
+
+func (d *CLTVCSVMultisigClosure) Script() ([]byte, error) {
+	sequence, err := arklib.BIP68Sequence(d.UnrollGrace)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix, err := txscript.NewScriptBuilder().
+		AddInt64(int64(d.ExpiryDate)).
+		AddOps([]byte{txscript.OP_CHECKLOCKTIMEVERIFY, txscript.OP_DROP}).
+		AddInt64(int64(sequence)).
+		AddOps([]byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_DROP}).
+		Script()
+	if err != nil {
+		return nil, err
+	}
+
+	multisigScript, err := d.MultisigClosure.Script()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(prefix, multisigScript...), nil
+}
+
+func (d *CLTVCSVMultisigClosure) Decode(script []byte) (bool, error) {
+	if len(script) == 0 {
+		return false, fmt.Errorf("empty script")
+	}
+
+	tokenizer := txscript.MakeScriptTokenizer(0, script)
+
+	// Absolute locktime. Kept as int64 throughout: an nLockTime timestamp exceeds
+	// int32 in 2038, and CLTVMultisigClosure.Decode narrows there.
+	if !tokenizer.Next() {
+		return false, nil
+	}
+
+	var locktime int64
+	if txscript.IsSmallInt(tokenizer.Opcode()) {
+		locktime = int64(txscript.AsSmallInt(tokenizer.Opcode()))
+	} else {
+		num, err := txscript.MakeScriptNum(tokenizer.Data(), true, 6)
+		if err != nil {
+			return false, err
+		}
+		locktime = int64(num)
+		if locktime > 0 && locktime <= 16 {
+			return false, fmt.Errorf(
+				"expected minimal encoding OP_%d for locktime value %d", locktime, locktime,
+			)
+		}
+	}
+	if locktime < 0 || locktime > math.MaxUint32 {
+		return false, fmt.Errorf("locktime %d out of uint32 range", locktime)
+	}
+
+	for _, opCode := range []byte{txscript.OP_CHECKLOCKTIMEVERIFY, txscript.OP_DROP} {
+		if !tokenizer.Next() || tokenizer.Opcode() != opCode {
+			return false, nil
+		}
+	}
+
+	// Relative locktime.
+	if !tokenizer.Next() {
+		return false, nil
+	}
+
+	var sequence []byte
+	if txscript.IsSmallInt(tokenizer.Opcode()) {
+		if tokenizer.Opcode() == txscript.OP_0 {
+			// minimal encoding policy forces an empty byte slice for OP_0
+			sequence = []byte{}
+		} else {
+			sequence = []byte{tokenizer.Opcode() - (txscript.OP_1 - 1)}
+		}
+	} else {
+		sequence = tokenizer.Data()
+	}
+
+	for _, opCode := range []byte{txscript.OP_CHECKSEQUENCEVERIFY, txscript.OP_DROP} {
+		if !tokenizer.Next() || tokenizer.Opcode() != opCode {
+			return false, nil
+		}
+	}
+
+	grace, err := arklib.BIP68DecodeSequenceFromBytes(sequence)
+	if err != nil {
+		return false, err
+	}
+	if grace == nil {
+		return false, fmt.Errorf("failed to decode sequence: locktime is nil")
+	}
+
+	multisigClosure := &MultisigClosure{}
+	subScript := tokenizer.Script()[tokenizer.ByteIndex():]
+	valid, err := multisigClosure.Decode(subScript)
+	if err != nil {
+		return false, err
+	}
+	if !valid {
+		return false, nil
+	}
+
+	d.ExpiryDate = arklib.AbsoluteLocktime(locktime)
+	d.UnrollGrace = *grace
+	d.MultisigClosure = *multisigClosure
+
+	// Same rebuild-and-compare guard the other closures use: reject anything that
+	// parses but would not re-serialise identically.
+	rebuilt, err := d.Script()
+	if err != nil {
+		return false, err
+	}
+	if !bytes.Equal(rebuilt, script) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (f *CLTVCSVMultisigClosure) Witness(
+	controlBlock []byte, signatures map[string][]byte,
+) (wire.TxWitness, error) {
+	multisigWitness, err := f.MultisigClosure.Witness(controlBlock, signatures)
+	if err != nil {
+		return nil, err
+	}
+
+	script, err := f.Script()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate script: %w", err)
+	}
+
+	// replace the bare multisig script with the full hybrid script
+	multisigWitness[len(multisigWitness)-2] = script
+
+	return multisigWitness, nil
+}

--- a/pkg/ark-lib/script/closure_epoch.go
+++ b/pkg/ark-lib/script/closure_epoch.go
@@ -22,6 +22,12 @@ import (
 //
 // This closure is only ever used in the sweep leaf. It must never appear in a
 // user's vtxo script, where ForfeitClosures/ExitClosures would not classify it.
+//
+// Consumers of this library therefore do not need to handle it in any type
+// switch over a vtxo script's closures: DecodeClosure can return it, but only
+// for a sweep leaf, which a vtxo script never contains. Code that walks a full
+// tapscript tree rather than a vtxo script is the exception and does need a case
+// for it.
 type CLTVCSVMultisigClosure struct {
 	MultisigClosure
 	ExpiryDate  arklib.AbsoluteLocktime

--- a/pkg/ark-lib/script/closure_epoch_test.go
+++ b/pkg/ark-lib/script/closure_epoch_test.go
@@ -1,0 +1,249 @@
+package script_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// 1 Sep 2026 00:00:00 UTC. 7168 == 14 * 512, a BIP68-representable seconds value.
+const (
+	testEpochExpiry = arklib.AbsoluteLocktime(1788134400)
+	testGraceSecs   = uint32(7168)
+)
+
+func testGrace() arklib.RelativeLocktime {
+	return arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: testGraceSecs}
+}
+
+func testEpochClosure(pub *btcec.PublicKey) *script.CLTVCSVMultisigClosure {
+	return &script.CLTVCSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{pub}},
+		ExpiryDate:      testEpochExpiry,
+		UnrollGrace:     testGrace(),
+	}
+}
+
+func TestCLTVCSVMultisigClosureRoundTrip(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	original := testEpochClosure(prv.PubKey())
+	raw, err := original.Script()
+	require.NoError(t, err)
+
+	decoded := &script.CLTVCSVMultisigClosure{}
+	valid, err := decoded.Decode(raw)
+	require.NoError(t, err)
+	require.True(t, valid)
+	require.Equal(t, original.ExpiryDate, decoded.ExpiryDate)
+	require.Equal(t, original.UnrollGrace, decoded.UnrollGrace)
+	require.Len(t, decoded.PubKeys, 1)
+	require.Equal(
+		t, schnorr.SerializePubKey(original.PubKeys[0]), schnorr.SerializePubKey(decoded.PubKeys[0]),
+	)
+}
+
+// TestCLTVCSVMultisigClosureBeyond2038 pins that the absolute locktime is not
+// narrowed through int32. CLTVMultisigClosure.Decode does narrow, which breaks
+// for nLockTime timestamps past 2038; the hybrid must not inherit that.
+func TestCLTVCSVMultisigClosureBeyond2038(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	// 1 Jan 2040 00:00:00 UTC, above math.MaxInt32 (2147483647)
+	future := arklib.AbsoluteLocktime(2208988800)
+	original := &script.CLTVCSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{prv.PubKey()}},
+		ExpiryDate:      future,
+		UnrollGrace:     testGrace(),
+	}
+	raw, err := original.Script()
+	require.NoError(t, err)
+
+	decoded := &script.CLTVCSVMultisigClosure{}
+	valid, err := decoded.Decode(raw)
+	require.NoError(t, err)
+	require.True(t, valid)
+	require.Equal(t, future, decoded.ExpiryDate)
+}
+
+func TestCLTVCSVMultisigClosureDisambiguation(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	keys := script.MultisigClosure{PubKeys: []*btcec.PublicKey{prv.PubKey()}}
+
+	hybrid := testEpochClosure(prv.PubKey())
+	csvOnly := &script.CSVMultisigClosure{MultisigClosure: keys, Locktime: testGrace()}
+	cltvOnly := &script.CLTVMultisigClosure{MultisigClosure: keys, Locktime: testEpochExpiry}
+
+	t.Run("hybrid decodes as hybrid", func(t *testing.T) {
+		raw, err := hybrid.Script()
+		require.NoError(t, err)
+		got, err := script.DecodeClosure(raw)
+		require.NoError(t, err)
+		require.IsType(t, &script.CLTVCSVMultisigClosure{}, got)
+	})
+
+	t.Run("csv still decodes as csv", func(t *testing.T) {
+		raw, err := csvOnly.Script()
+		require.NoError(t, err)
+		got, err := script.DecodeClosure(raw)
+		require.NoError(t, err)
+		require.IsType(t, &script.CSVMultisigClosure{}, got)
+	})
+
+	t.Run("cltv still decodes as cltv", func(t *testing.T) {
+		raw, err := cltvOnly.Script()
+		require.NoError(t, err)
+		got, err := script.DecodeClosure(raw)
+		require.NoError(t, err)
+		require.IsType(t, &script.CLTVMultisigClosure{}, got)
+	})
+
+	t.Run("hybrid is not accepted by the narrower types", func(t *testing.T) {
+		raw, err := hybrid.Script()
+		require.NoError(t, err)
+
+		csv := &script.CSVMultisigClosure{}
+		valid, _ := csv.Decode(raw)
+		require.False(t, valid)
+
+		cltv := &script.CLTVMultisigClosure{}
+		valid, _ = cltv.Decode(raw)
+		require.False(t, valid)
+
+		plain := &script.MultisigClosure{}
+		valid, _ = plain.Decode(raw)
+		require.False(t, valid)
+	})
+
+	t.Run("narrower scripts are not accepted by the hybrid", func(t *testing.T) {
+		for name, c := range map[string]script.Closure{"csv": csvOnly, "cltv": cltvOnly} {
+			raw, err := c.Script()
+			require.NoError(t, err, name)
+
+			h := &script.CLTVCSVMultisigClosure{}
+			valid, _ := h.Decode(raw)
+			require.False(t, valid, name)
+		}
+	})
+}
+
+// spendHybrid locks a taproot output to the hybrid leaf and spends it, returning
+// the script engine's verdict.
+func spendHybrid(
+	t *testing.T, prv *btcec.PrivateKey, lockTime uint32, sequence uint32, version int32,
+) error {
+	t.Helper()
+
+	leafScript, err := testEpochClosure(prv.PubKey()).Script()
+	require.NoError(t, err)
+
+	tapLeaf := txscript.NewBaseTapLeaf(leafScript)
+	tapTree := txscript.AssembleTaprootScriptTree(tapLeaf)
+	root := tapTree.RootNode.TapHash()
+	internalKey := script.UnspendableKey()
+	pkScript, err := script.P2TRScript(txscript.ComputeTaprootOutputKey(internalKey, root[:]))
+	require.NoError(t, err)
+
+	const prevValue = int64(100_000)
+
+	tx := wire.NewMsgTx(version)
+	tx.LockTime = lockTime
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{0x01}, Index: 0},
+		Sequence:         sequence,
+	})
+	tx.AddTxOut(&wire.TxOut{Value: prevValue - 1000, PkScript: pkScript})
+
+	fetcher := txscript.NewCannedPrevOutputFetcher(pkScript, prevValue)
+	sig, err := txscript.RawTxInTapscriptSignature(
+		tx, txscript.NewTxSigHashes(tx, fetcher), 0, prevValue, pkScript,
+		tapLeaf, txscript.SigHashDefault, prv,
+	)
+	require.NoError(t, err)
+
+	ctrlBlock := tapTree.LeafMerkleProofs[0].ToControlBlock(internalKey)
+	ctrl, err := ctrlBlock.ToBytes()
+	require.NoError(t, err)
+	tx.TxIn[0].Witness = wire.TxWitness{sig, leafScript, ctrl}
+
+	vm, err := txscript.NewEngine(
+		pkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		txscript.NewTxSigHashes(tx, fetcher), prevValue, fetcher,
+	)
+	if err != nil {
+		return err
+	}
+	return vm.Execute()
+}
+
+// TestCLTVCSVMultisigClosureExecutes pins the exact transaction shape a sweep
+// spending this leaf must have: version 2, nLockTime at or after the expiry
+// date, and a non-final BIP68 sequence at or above the grace period.
+func TestCLTVCSVMultisigClosureExecutes(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	seq, err := arklib.BIP68Sequence(testGrace())
+	require.NoError(t, err)
+
+	t.Run("valid spend", func(t *testing.T) {
+		require.NoError(t, spendHybrid(t, prv, uint32(testEpochExpiry), seq, 2))
+	})
+	t.Run("nLockTime before expiry fails", func(t *testing.T) {
+		require.Error(t, spendHybrid(t, prv, uint32(testEpochExpiry)-1, seq, 2))
+	})
+	t.Run("final sequence fails CLTV", func(t *testing.T) {
+		require.Error(t, spendHybrid(t, prv, uint32(testEpochExpiry), wire.MaxTxInSequenceNum, 2))
+	})
+	t.Run("sequence below grace fails CSV", func(t *testing.T) {
+		small, err := arklib.BIP68Sequence(
+			arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 512},
+		)
+		require.NoError(t, err)
+		require.Error(t, spendHybrid(t, prv, uint32(testEpochExpiry), small, 2))
+	})
+	t.Run("tx version 1 fails CSV", func(t *testing.T) {
+		require.Error(t, spendHybrid(t, prv, uint32(testEpochExpiry), seq, 1))
+	})
+}
+
+// TestCLTVCSVMultisigClosureWitness guards the wallet's finalizer path: it calls
+// DecodeClosure then Closure.Witness to build the final witness, so a closure
+// whose Witness returns the bare multisig script would make the operator unable
+// to finalize its own sweep.
+func TestCLTVCSVMultisigClosureWitness(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	closure := testEpochClosure(prv.PubKey())
+	raw, err := closure.Script()
+	require.NoError(t, err)
+
+	ctrl := make([]byte, 33)
+	sigs := map[string][]byte{
+		hex.EncodeToString(schnorr.SerializePubKey(prv.PubKey())): make([]byte, 64),
+	}
+	witness, err := closure.Witness(ctrl, sigs)
+	require.NoError(t, err)
+	require.Len(t, witness, 3)
+	require.Equal(
+		t, raw, []byte(witness[len(witness)-2]),
+		"witness must carry the hybrid script, not the bare multisig script",
+	)
+	require.Equal(t, ctrl, []byte(witness[len(witness)-1]))
+
+	t.Run("missing signature is an error", func(t *testing.T) {
+		_, err := closure.Witness(ctrl, map[string][]byte{})
+		require.Error(t, err)
+	})
+}

--- a/pkg/ark-lib/tree/sweep_root.go
+++ b/pkg/ark-lib/tree/sweep_root.go
@@ -1,0 +1,50 @@
+package tree
+
+import (
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+// BuildLegacySweepTapTreeRoot returns the sweep tapscript root for a batch using
+// the relative-CSV expiry scheme, along with the leaf script itself.
+//
+// Every batch built before epoch expiry uses this, and it must keep producing
+// byte-identical output forever: it is what lets the operator sweep trees
+// created by older releases, and what lets a client re-derive and verify the
+// taproot output key of every node in a tree it is asked to sign.
+func BuildLegacySweepTapTreeRoot(
+	operator *btcec.PublicKey, expiry arklib.RelativeLocktime,
+) (chainhash.Hash, []byte, error) {
+	leafScript, err := (&script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{operator}},
+		Locktime:        expiry,
+	}).Script()
+	if err != nil {
+		return chainhash.Hash{}, nil, err
+	}
+
+	return txscript.NewBaseTapLeaf(leafScript).TapHash(), leafScript, nil
+}
+
+// BuildEpochSweepTapTreeRoot returns the sweep tapscript root for an epoch batch:
+// an absolute expiry date shared across the epoch, plus a relative grace period
+// that only bites for outputs created by a mid-flight unilateral unroll.
+func BuildEpochSweepTapTreeRoot(
+	operator *btcec.PublicKey,
+	expiryDate arklib.AbsoluteLocktime,
+	grace arklib.RelativeLocktime,
+) (chainhash.Hash, []byte, error) {
+	leafScript, err := (&script.CLTVCSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{operator}},
+		ExpiryDate:      expiryDate,
+		UnrollGrace:     grace,
+	}).Script()
+	if err != nil {
+		return chainhash.Hash{}, nil, err
+	}
+
+	return txscript.NewBaseTapLeaf(leafScript).TapHash(), leafScript, nil
+}

--- a/pkg/ark-lib/tree/sweep_root_test.go
+++ b/pkg/ark-lib/tree/sweep_root_test.go
@@ -1,0 +1,93 @@
+package tree_test
+
+import (
+	"testing"
+
+	arklib "github.com/arkade-os/arkd/pkg/ark-lib"
+	"github.com/arkade-os/arkd/pkg/ark-lib/script"
+	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildLegacySweepTapTreeRootMatchesHandRolled is the guard that makes
+// centralising the sweep root a safe refactor: the constructor must produce
+// output byte-identical to the code it replaces. A moved root means every tree
+// built against it is unspendable by the operator.
+func TestBuildLegacySweepTapTreeRootMatchesHandRolled(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	expiry := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672}
+
+	// exactly what BuildCommitmentTx did inline
+	want, err := (&script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{prv.PubKey()}},
+		Locktime:        expiry,
+	}).Script()
+	require.NoError(t, err)
+	wantRoot := txscript.NewBaseTapLeaf(want).TapHash()
+
+	gotRoot, gotScript, err := tree.BuildLegacySweepTapTreeRoot(prv.PubKey(), expiry)
+	require.NoError(t, err)
+	require.Equal(t, want, gotScript)
+	require.Equal(t, wantRoot, gotRoot, "must be byte-identical to the existing root")
+}
+
+// TestBuildLegacySweepTapTreeRootMatchesAssembledTree pins the other inline form
+// the codebase used: AssembleTaprootScriptTree(...).RootNode.TapHash(). For a
+// single leaf the two must agree, which is why one constructor can replace both.
+func TestBuildLegacySweepTapTreeRootMatchesAssembledTree(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	expiry := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672}
+
+	leafScript, err := (&script.CSVMultisigClosure{
+		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{prv.PubKey()}},
+		Locktime:        expiry,
+	}).Script()
+	require.NoError(t, err)
+
+	assembled := txscript.AssembleTaprootScriptTree(txscript.NewBaseTapLeaf(leafScript))
+	wantRoot := assembled.RootNode.TapHash()
+
+	gotRoot, _, err := tree.BuildLegacySweepTapTreeRoot(prv.PubKey(), expiry)
+	require.NoError(t, err)
+	require.Equal(t, wantRoot, gotRoot)
+}
+
+func TestBuildEpochSweepTapTreeRoot(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	date := arklib.AbsoluteLocktime(1788134400)
+	grace := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 7168}
+
+	root, leafScript, err := tree.BuildEpochSweepTapTreeRoot(prv.PubKey(), date, grace)
+	require.NoError(t, err)
+	require.NotEmpty(t, leafScript)
+
+	decoded := &script.CLTVCSVMultisigClosure{}
+	valid, err := decoded.Decode(leafScript)
+	require.NoError(t, err)
+	require.True(t, valid)
+	require.Equal(t, date, decoded.ExpiryDate)
+	require.Equal(t, grace, decoded.UnrollGrace)
+
+	legacyRoot, _, err := tree.BuildLegacySweepTapTreeRoot(
+		prv.PubKey(), arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672},
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, legacyRoot, root, "epoch and legacy roots must differ")
+}
+
+func TestSweepTapTreeRootIsDeterministic(t *testing.T) {
+	prv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	expiry := arklib.RelativeLocktime{Type: arklib.LocktimeTypeSecond, Value: 604672}
+
+	a, _, err := tree.BuildLegacySweepTapTreeRoot(prv.PubKey(), expiry)
+	require.NoError(t, err)
+	b, _, err := tree.BuildLegacySweepTapTreeRoot(prv.PubKey(), expiry)
+	require.NoError(t, err)
+	require.Equal(t, a, b)
+}

--- a/pkg/ark-lib/tree/validation.go
+++ b/pkg/ark-lib/tree/validation.go
@@ -13,7 +13,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/txscript"
 )
 
 var (
@@ -75,19 +74,10 @@ func ValidateVtxoTree(
 		return ErrNoLeaves
 	}
 
-	sweepClosure := &script.CSVMultisigClosure{
-		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{signerPubkey}},
-		Locktime:        vtxoTreeExpiry,
-	}
-
-	sweepScript, err := sweepClosure.Script()
+	tapTreeRoot, _, err := BuildLegacySweepTapTreeRoot(signerPubkey, vtxoTreeExpiry)
 	if err != nil {
 		return err
 	}
-
-	sweepLeaf := txscript.NewBaseTapLeaf(sweepScript)
-	tapTree := txscript.AssembleTaprootScriptTree(sweepLeaf)
-	tapTreeRoot := tapTree.RootNode.TapHash()
 
 	// Verify the batch output pays to the root cosigners
 	rootCosigners, err := txutils.ParseCosignerKeysFromArkPsbt(vtxoTree.Root, 0)

--- a/pkg/ark-lib/txutils/psbt_fields.go
+++ b/pkg/ark-lib/txutils/psbt_fields.go
@@ -30,9 +30,8 @@ var (
 	// input. Its presence marks the tree as an epoch batch; absence means the
 	// legacy relative-CSV scheme under ArkFieldTreeExpiry.
 	//
-	// Deliberately not named "batchexpiry": containsArkPsbtKey matches with
-	// bytes.Contains, so any name containing "expiry" would also be matched by
-	// VtxoTreeExpiryField, which would then BIP68-decode an absolute timestamp.
+	// Named for what it is - a date, not a duration - which also keeps it clear
+	// of ArkFieldTreeExpiry. Key matching is exact, so the two cannot collide.
 	ArkFieldBatchExpiry = []byte("epochdate")
 )
 

--- a/pkg/ark-lib/txutils/psbt_fields.go
+++ b/pkg/ark-lib/txutils/psbt_fields.go
@@ -26,6 +26,14 @@ var (
 	ArkFieldCosigner = []byte("cosigner")
 	// ArkFieldConditionWitness allows to set extra witness elements used to sign custom script inputs
 	ArkFieldConditionWitness = []byte("condition")
+	// ArkFieldBatchExpiry attaches the absolute epoch expiry date to a tree tx
+	// input. Its presence marks the tree as an epoch batch; absence means the
+	// legacy relative-CSV scheme under ArkFieldTreeExpiry.
+	//
+	// Deliberately not named "batchexpiry": containsArkPsbtKey matches with
+	// bytes.Contains, so any name containing "expiry" would also be matched by
+	// VtxoTreeExpiryField, which would then BIP68-decode an absolute timestamp.
+	ArkFieldBatchExpiry = []byte("epochdate")
 )
 
 // Singletons instances for each field type
@@ -33,6 +41,7 @@ var VtxoTaprootTreeField ArkPsbtFieldCoder[TapTree] = arkPsbtFieldCoderTaprootTr
 var VtxoTreeExpiryField ArkPsbtFieldCoder[arklib.RelativeLocktime] = arkPsbtFieldCoderTreeExpiry{}
 var CosignerPublicKeyField ArkPsbtFieldCoder[IndexedCosignerPublicKey] = arkPsbtFieldCoderCosignerPublicKey{}
 var ConditionWitnessField ArkPsbtFieldCoder[wire.TxWitness] = arkPsbtFieldCoderConditionWitness{}
+var BatchExpiryField ArkPsbtFieldCoder[arklib.AbsoluteLocktime] = arkPsbtFieldCoderBatchExpiry{}
 
 type ArkPsbtFieldCoder[T any] interface {
 	Encode(T) (*psbt.Unknown, error)
@@ -167,6 +176,41 @@ func (c arkPsbtFieldCoderTreeExpiry) Decode(unknown *psbt.Unknown) (*arklib.Rela
 	}
 
 	return arklib.BIP68DecodeSequenceFromBytes(unknown.Value)
+}
+
+// ArkPsbtFieldCoder implementation for the absolute epoch expiry date.
+// Encoded as a fixed 4-byte little-endian uint32 rather than the minimal
+// encoding used for sequences: this is a timestamp, not a script number, and a
+// fixed width removes any ambiguity in the round trip.
+type arkPsbtFieldCoderBatchExpiry struct{}
+
+func (c arkPsbtFieldCoderBatchExpiry) Encode(
+	expiry arklib.AbsoluteLocktime,
+) (*psbt.Unknown, error) {
+	var valueLE [4]byte
+	binary.LittleEndian.PutUint32(valueLE[:], uint32(expiry))
+
+	return &psbt.Unknown{
+		Key:   makeArkPsbtKey(ArkFieldBatchExpiry),
+		Value: valueLE[:],
+	}, nil
+}
+
+func (c arkPsbtFieldCoderBatchExpiry) Decode(
+	unknown *psbt.Unknown,
+) (*arklib.AbsoluteLocktime, error) {
+	if !matchesArkPsbtKey(unknown, ArkFieldBatchExpiry, 0) {
+		return nil, nil
+	}
+
+	if len(unknown.Value) != 4 {
+		return nil, fmt.Errorf(
+			"invalid batch expiry field length %d, expected 4", len(unknown.Value),
+		)
+	}
+
+	expiry := arklib.AbsoluteLocktime(binary.LittleEndian.Uint32(unknown.Value))
+	return &expiry, nil
 }
 
 // ArkPsbtFieldCoder implementation for cosigner public key

--- a/pkg/ark-lib/txutils/psbt_fields_test.go
+++ b/pkg/ark-lib/txutils/psbt_fields_test.go
@@ -157,3 +157,94 @@ func TestPsbtCustomUnknownFields(t *testing.T) {
 		}
 	})
 }
+
+// TestBatchExpiryField covers the absolute epoch expiry field. Its presence on a
+// tree tx marks the tree as an epoch batch; absence means the legacy relative-CSV
+// scheme under ArkFieldTreeExpiry.
+func TestBatchExpiryField(t *testing.T) {
+	newPacket := func(t *testing.T) *psbt.Packet {
+		t.Helper()
+		ptx, err := psbt.New(nil, nil, 2, 0, nil)
+		require.NoError(t, err)
+		ptx.UnsignedTx.TxIn = []*wire.TxIn{{PreviousOutPoint: wire.OutPoint{}}}
+		ptx.Inputs = []psbt.PInput{{}}
+		return ptx
+	}
+
+	t.Run("round trip", func(t *testing.T) {
+		ptx := newPacket(t)
+		want := common.AbsoluteLocktime(1788134400)
+		require.NoError(t, txutils.SetArkPsbtField(ptx, 0, txutils.BatchExpiryField, want))
+
+		got, err := txutils.GetArkPsbtFields(ptx, 0, txutils.BatchExpiryField)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		require.Equal(t, want, got[0])
+	})
+
+	t.Run("absent on a legacy packet", func(t *testing.T) {
+		ptx := newPacket(t)
+		require.NoError(t, txutils.SetArkPsbtField(
+			ptx, 0, txutils.VtxoTreeExpiryField,
+			common.RelativeLocktime{Type: common.LocktimeTypeSecond, Value: 604672},
+		))
+
+		got, err := txutils.GetArkPsbtFields(ptx, 0, txutils.BatchExpiryField)
+		require.NoError(t, err)
+		require.Empty(t, got, "legacy packets must not look like epoch packets")
+	})
+
+	// containsArkPsbtKey matches with bytes.Contains, so a key naming collision is
+	// silent: the tree-expiry decoder would match the epoch field and BIP68-decode
+	// an absolute timestamp. Pin that neither field sees the other.
+	t.Run("does not collide with the relative expiry field", func(t *testing.T) {
+		ptx := newPacket(t)
+		require.NoError(t, txutils.SetArkPsbtField(
+			ptx, 0, txutils.BatchExpiryField, common.AbsoluteLocktime(1788134400),
+		))
+
+		rel, err := txutils.GetArkPsbtFields(ptx, 0, txutils.VtxoTreeExpiryField)
+		require.NoError(t, err)
+		require.Empty(t, rel, "epoch field must not be read as a relative locktime")
+
+		other := newPacket(t)
+		require.NoError(t, txutils.SetArkPsbtField(
+			other, 0, txutils.VtxoTreeExpiryField,
+			common.RelativeLocktime{Type: common.LocktimeTypeSecond, Value: 7168},
+		))
+		abs, err := txutils.GetArkPsbtFields(other, 0, txutils.BatchExpiryField)
+		require.NoError(t, err)
+		require.Empty(t, abs, "relative field must not be read as an epoch date")
+	})
+
+	t.Run("both fields coexist on one input", func(t *testing.T) {
+		ptx := newPacket(t)
+		require.NoError(t, txutils.SetArkPsbtField(
+			ptx, 0, txutils.BatchExpiryField, common.AbsoluteLocktime(1788134400),
+		))
+		require.NoError(t, txutils.SetArkPsbtField(
+			ptx, 0, txutils.VtxoTreeExpiryField,
+			common.RelativeLocktime{Type: common.LocktimeTypeSecond, Value: 7168},
+		))
+
+		rel, err := txutils.GetArkPsbtFields(ptx, 0, txutils.VtxoTreeExpiryField)
+		require.NoError(t, err)
+		require.Len(t, rel, 1)
+		require.Equal(t, uint32(7168), rel[0].Value)
+
+		abs, err := txutils.GetArkPsbtFields(ptx, 0, txutils.BatchExpiryField)
+		require.NoError(t, err)
+		require.Len(t, abs, 1)
+		require.Equal(t, common.AbsoluteLocktime(1788134400), abs[0])
+	})
+
+	t.Run("rejects a malformed value", func(t *testing.T) {
+		ptx := newPacket(t)
+		ptx.Inputs[0].Unknowns = []*psbt.Unknown{{
+			Key:   append([]byte{222}, []byte("epochdate")...),
+			Value: []byte{0x01, 0x02},
+		}}
+		_, err := txutils.GetArkPsbtFields(ptx, 0, txutils.BatchExpiryField)
+		require.Error(t, err)
+	})
+}

--- a/pkg/client-lib/batch-session/handler/default_handler.go
+++ b/pkg/client-lib/batch-session/handler/default_handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/arkade-os/arkd/pkg/ark-lib/tree"
 	"github.com/arkade-os/arkd/pkg/ark-lib/txutils"
 	clientlib "github.com/arkade-os/arkd/pkg/client-lib"
-	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -163,14 +162,9 @@ func (h *defaultHandler) OnTreeSigningStarted(
 		return false, fmt.Errorf("not all signers found in cosigner list")
 	}
 
-	sweepClosure := script.CSVMultisigClosure{
-		MultisigClosure: script.MultisigClosure{PubKeys: []*btcec.PublicKey{
-			h.ServerParams.ForfeitPubKey,
-		}},
-		Locktime: h.batchExpiry,
-	}
-
-	script, err := sweepClosure.Script()
+	root, _, err := tree.BuildLegacySweepTapTreeRoot(
+		h.ServerParams.ForfeitPubKey, h.batchExpiry,
+	)
 	if err != nil {
 		return false, err
 	}
@@ -182,10 +176,6 @@ func (h *defaultHandler) OnTreeSigningStarted(
 
 	batchOutput := commitmentTx.UnsignedTx.TxOut[0]
 	batchOutputAmount := batchOutput.Value
-
-	sweepTapLeaf := txscript.NewBaseTapLeaf(script)
-	sweepTapTree := txscript.AssembleTaprootScriptTree(sweepTapLeaf)
-	root := sweepTapTree.RootNode.TapHash()
 
 	generateAndSendNonces := func(session tree.SignerSession) error {
 		if err := session.Init(root.CloneBytes(), batchOutputAmount, vtxoTree); err != nil {


### PR DESCRIPTION
Three defect fixes in the expiry/sweep path, plus the primitives a later PR needs
to make batches expire on shared epoch boundaries. **No observable behaviour
change**: arkd still produces exactly the batches it does today, and every item
here is worth having on its own terms.

### Fixes

**`SettlementMinExpiryGap` was inverted.** The flag reads *"the min expiry gap in
seconds required to settle a vtxo"* (`cmd/arkd/flags.go`) — a floor on remaining
life. The check rejected when `expiresAt` was *after* `now+gap`, so it turned
away healthy vtxos and admitted exactly the near-expiry ones the setting exists
to exclude. The sibling `checkUnrolledVtxoExpiry` already uses the protective
direction. Disabled by default, so no deployment changes behaviour.

**A failed sweep was never retried.** One mempool conflict or transient node
error left the batch outputs unswept until an operator restart — the window an
attacker racing the sweep needs. Now retried with a bounded backoff, on *both*
paths: `scheduleTask` also runs a task inline when its time has already passed,
and that is the branch a restart takes for every batch that expired while the
service was down, so it is the one that most needs retrying. `scheduledTasks` is
released before execution, deliberately: it is a dedup guard, and holding the id
would block every later schedule for that tree, including the retries.

**A premature `nLockTime` was treated as fatal.** `ErrNonFinalBIP68` comes from a
substring match on `non-bip68-final`; Core rejects a premature `nLockTime` with
`non-final`, which does not contain it. Added `ErrNonFinalCLTV` and
`ports.IsNonFinal` covering both, matched as whole rejection reasons rather than
bare substrings — a misclassification marks the failure retryable, so it would
spend the sweeper's entire retry budget on an error that will never clear.
Unreachable today — no batch output carries an absolute locktime — but a
prerequisite for ones that will.

### Primitives

- **`CLTVCSVMultisigClosure`** — `<E> CLTV DROP <seq> CSV DROP <pk> CHECKSIG`.
  Verified against the script engine under `StandardVerifyFlags`: the spend
  requires tx version 2, `nLockTime >= E`, and a non-final BIP68 sequence, with
  all four negative cases pinned. `Decode` keeps the locktime as `int64` rather
  than narrowing through `int32` as `CLTVMultisigClosure` does, which breaks past
  2038. Sweep-leaf-only, and its godoc says so — a consumer doing a type switch
  over a vtxo script's closures needs no case for it.
- **`BatchExpiryField`** — an absolute expiry alongside the relative one, keyed
  `epochdate` and matched exactly via `matchesArkPsbtKey`. Tests pin that neither
  field can be read as the other. (Written before `matchesArkPsbtKey` landed,
  when key matching was `bytes.Contains` and a name containing `expiry` really
  would have been swallowed by `VtxoTreeExpiryField`; the distinct name is now
  belt-and-braces, and reads better anyway — it is a date, not a duration.)
- **One sweep-root constructor.** The root was rebuilt by hand in five places
  across three modules, in two different spellings. Collapsed onto
  `BuildLegacySweepTapTreeRoot`, pinned byte-identical to both prior forms. The
  batch-output binding check added in #67 now sources its root from it.
- **`sweepTransaction` understands absolute locktimes** — decodes both leaf
  kinds and carries the highest expiry date into `nLockTime`. Legacy sweeps are
  unchanged: with only CSV leaves the locktime stays 0, exactly as before. A
  failed hybrid decode falls through to the legacy decoder (a CSV leaf is under
  no obligation to parse as a hybrid one, and refusing there would leave legacy
  batches unswept) but its error is carried into the failure message rather than
  discarded.

### Also

`docs/version-compat.md` claimed only the major version is compared. `isBehind`
compares major, then minor, then patch, and the interceptor tests pin that.
Corrected, along with the decision table's omissions.

### Test plan

- Unit tests for every fix, including both directions of the corrected expiry
  gap, a dedup-slot test that would have caught the wrong retry fix, and an
  already-due test that records 1 attempt without the fix and 4 with it.
- Script-engine execution of the new closure; `DecodeClosure` disambiguation
  against all five existing closure types.
- Sweep sizing measured, not estimated: **78.0 vB per input**, ~1,280 per
  standard-relay transaction.
- Full suite against real Postgres and Redis; `-race` clean; `golangci-lint`
  clean on an LF checkout; every commit in the series builds independently.

### Review

Both bots have reviewed. CodeRabbit's finding (already-due tasks skipped the
retry policy) and all three of `arkana-ai-bot`'s (swallowed decode error, loose
`non-final` match, closure godoc) are fixed; the replies on each thread say what
changed and, for the decode error, where the suggested fix would have regressed
legacy sweeps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for epoch-based sweep transactions with absolute expiry dates and relative grace periods.
  - Added batch-expiry information to transaction metadata.
  - Sweep transactions now correctly combine absolute and relative timelock requirements.

- **Bug Fixes**
  - Improved handling of premature relative and absolute timelocks during broadcasts.
  - Failed sweeps now retry automatically and can be rescheduled after execution.
  - Settlement expiry validation provides clearer rejection details.
  - Version checks compare complete version numbers and reject malformed required headers.

- **Documentation**
  - Updated version-compatibility guidance and enforcement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->