### PR TITLE
ci(trivy): never serve the runtime stage from cache

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -29,6 +29,13 @@ jobs:
           tags: arkd:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Never serve the runtime stage from cache. It runs apk upgrade, so a
+          # cached layer pins whatever package versions were current when the
+          # entry was written and the scan then reports CVEs against an image
+          # staler than the one we ship: the release builds are uncached and do
+          # pick the fixes up. The builder stage stays cached, which is where
+          # the time goes.
+          no-cache-filters: runtime
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'm
 RUN cd pkg/ark-cli && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.Version=${VERSION}'" -o ../../bin/ark main.go
 
 # Second image, running the arkd executable
-FROM alpine:3.24
+FROM alpine:3.24 AS runtime
 
 RUN apk update && apk upgrade
 

--- a/arkdwallet.Dockerfile
+++ b/arkdwallet.Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-X 'main.Version=${VERSION}'" -o /app/bin/arkd-wallet ./cmd/arkd-wallet/main.go
 
 # Second stage: minimal runtime image
-FROM alpine:3.24
+FROM alpine:3.24 AS runtime
 
 RUN apk update && apk upgrade
 


### PR DESCRIPTION
Build and Scan is currently failing on every open PR with `CVE-2026-14456` (HIGH) against `libcrypto3`/`libssl3` `3.5.7-r0` in the alpine base.

## The package is not stale in what we ship

The runtime stage runs `apk upgrade`, and alpine 3.24 already carries the fixed `3.5.8-r0`:

```
$ docker run --rm alpine:3.24 sh -c "apk update && apk upgrade && apk list --installed | grep libcrypto3"
libcrypto3-3.5.8-r0
```

The release builds (`release.yaml`, `ecr-release.yaml`) build **without** `cache-from`/`cache-to`, so they pick that up. Only the scan build caches, via `type=gha`, and a cached `apk upgrade` layer pins whatever versions were current when the cache entry was written. So the scan has been reporting CVEs against an image staler than the one we release — the scan is less accurate than its subject, and it fails closed on a finding that does not reflect the artifact.

## Fix

Name the final stage `runtime` and pass `no-cache-filters: runtime` to the scan build. The security-update layer always re-runs; the `golang` builder stage, where the build time actually goes, stays cached.

## Verification

Built exactly as CI now will, and scanned:

```
$ docker build --no-cache-filter runtime -t check -f Dockerfile .
$ docker run --rm --entrypoint sh check -c "apk list --installed | grep -E \"^(libcrypto3|libssl3)-\""
libcrypto3-3.5.8-r0
libssl3-3.5.8-r0

$ trivy image --severity HIGH,CRITICAL check
check (alpine 3.24.1)   alpine     0
app/ark                 gobinary   0
app/arkd                gobinary   0
```

## Consequences

**The scan gets less likely to fail, not more.** `trivy.yaml` runs with `ignore-unfixed: true`, so it only fails when a fix actually exists. The runtime stage now always applies available fixes before the scan runs, which removes the only class of alpine finding the scan could report. The failure this PR addresses is exactly that class.

**Scan builds rebuild the runtime stage every run.** That is `apk upgrade` plus a `COPY`. The `golang` builder stage stays cached, so the cost is small in practice. This PR's own scan took 1m49s, against 2m51s and 3m19s for the failing cached runs on other PRs.

**Scan images are no longer identical between runs of the same commit.** Packages now come from the live alpine repository rather than a frozen layer. That is inherent to `apk upgrade` and already true of the release builds, so this aligns the scan with them rather than introducing something new.

**Naming the final stage is inert.** No workflow builds with `--target`, and naming the last stage does not change the default build target.

**One gap this does not close.** `release.yaml` and `ecr-release.yaml` produce correct images today only because neither sets `cache-from`/`cache-to`. Nothing enforces that. If caching is added to either, shipped images would go stale while this scan, now uncached, stays green. That is quieter than the current failure and worth deciding on deliberately. See the open question below.

## Open question for reviewers

The same `AS runtime` name is added to both `Dockerfile` and `arkdwallet.Dockerfile` for symmetry, but only `trivy.yaml` passes the filter. Should `release.yaml` and `ecr-release.yaml` pin `no-cache-filters: runtime` explicitly too, so the guarantee is stated rather than resting on them having no caching today? Happy to add it here or leave it for a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image vulnerability scanning by ensuring the runtime image is rebuilt rather than reused from cache.
  * Retained build caching to support efficient image creation while incorporating updated runtime packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
