### PR TITLE
fix(api): normalize invalid OpenAPI query styles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ pprof:
 proto: proto-lint
 	@echo "Compiling stubs..."
 	@docker run --rm --volume "$(shell pwd):/workspace" --workdir /workspace buf generate
+	@go run ./scripts/normalize-openapi
 
 ## proto-lint: lint protos
 proto-lint: buf

--- a/api-spec/openapi/swagger/ark/v1/admin.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/admin.openapi.json
@@ -510,7 +510,6 @@
           {
             "name": "intentIds",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",

--- a/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/indexer.openapi.json
@@ -445,7 +445,6 @@
             "name": "filter.expressions",
             "in": "query",
             "description": "CEL expressions evaluated against each indexed tx envelope. The\nindexer combines them with OR.",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -457,7 +456,6 @@
           {
             "name": "filter.scripts.add",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -469,7 +467,6 @@
           {
             "name": "filter.scripts.remove",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -564,7 +561,6 @@
             "name": "filter.expressions",
             "in": "query",
             "description": "CEL expressions evaluated against each indexed tx envelope. The\nindexer combines them with OR.",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -576,7 +572,6 @@
           {
             "name": "filter.scripts.add",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -588,7 +583,6 @@
           {
             "name": "filter.scripts.remove",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -855,7 +849,6 @@
             "name": "scripts",
             "in": "query",
             "description": "Either specify a list of vtxo scripts.",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",
@@ -868,7 +861,6 @@
             "name": "outpoints",
             "in": "query",
             "description": "Or specify a list of vtxo outpoints. The 2 filters are mutually exclusive.",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",

--- a/api-spec/openapi/swagger/ark/v1/service.openapi.json
+++ b/api-spec/openapi/swagger/ark/v1/service.openapi.json
@@ -139,7 +139,6 @@
           {
             "name": "topics",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",

--- a/api-spec/openapi/swagger/arkwallet/v1/bitcoin_wallet.openapi.json
+++ b/api-spec/openapi/swagger/arkwallet/v1/bitcoin_wallet.openapi.json
@@ -115,7 +115,6 @@
           {
             "name": "connectorAddresses",
             "in": "query",
-            "style": "simple",
             "schema": {
               "minItems": 1,
               "type": "array",

--- a/scripts/normalize-openapi/main.go
+++ b/scripts/normalize-openapi/main.go
@@ -6,12 +6,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
+	"sort"
 )
 
 const specs = "api-spec/openapi/swagger/*/v1/*.openapi.json"
-
-var invalidQueryStyle = regexp.MustCompile(`(?m)(^[ \t]*"in": "query",\r?\n(?:^[ \t]*"description": [^\r\n]*,\r?\n)?)[ \t]*"style": "simple",\r?\n`)
 
 func main() {
 	paths, err := filepath.Glob(specs)
@@ -29,9 +27,9 @@ func main() {
 			log.Fatalf("%s: %v", path, err)
 		}
 
-		fixed, count := normalize(data)
-		if !json.Valid(fixed) {
-			log.Fatalf("%s: invalid JSON", path)
+		fixed, count, err := normalize(data)
+		if err != nil {
+			log.Fatalf("%s: %v", path, err)
 		}
 		if count > 0 {
 			if err := os.WriteFile(path, fixed, 0o644); err != nil {
@@ -44,7 +42,236 @@ func main() {
 	fmt.Printf("Removed %d invalid query parameter style(s).\n", total)
 }
 
-func normalize(data []byte) ([]byte, int) {
-	count := len(invalidQueryStyle.FindAll(data, -1))
-	return invalidQueryStyle.ReplaceAll(data, []byte("${1}")), count
+type span struct {
+	start int
+	end   int
+}
+
+type objectMember struct {
+	key         string
+	prefixStart int
+	valueStart  int
+	valueEnd    int
+	comma       int
+}
+
+type jsonScanner struct {
+	data     []byte
+	removals []span
+}
+
+// normalize parses the JSON structure and removes only style: simple members
+// belonging to query parameter objects. It applies byte-range edits to the
+// original document so generated key ordering and whitespace remain unchanged.
+func normalize(data []byte) ([]byte, int, error) {
+	if !json.Valid(data) {
+		return nil, 0, fmt.Errorf("invalid JSON")
+	}
+
+	scanner := jsonScanner{data: data}
+	end, err := scanner.parseValue(scanner.skipSpace(0))
+	if err != nil {
+		return nil, 0, err
+	}
+	if scanner.skipSpace(end) != len(data) {
+		return nil, 0, fmt.Errorf("unexpected data after JSON value")
+	}
+
+	sort.Slice(scanner.removals, func(i, j int) bool {
+		return scanner.removals[i].start > scanner.removals[j].start
+	})
+	fixed := append([]byte(nil), data...)
+	for _, removal := range scanner.removals {
+		fixed = append(fixed[:removal.start], fixed[removal.end:]...)
+	}
+
+	return fixed, len(scanner.removals), nil
+}
+
+func (s *jsonScanner) parseValue(start int) (int, error) {
+	start = s.skipSpace(start)
+	if start >= len(s.data) {
+		return 0, fmt.Errorf("unexpected end of JSON")
+	}
+
+	switch s.data[start] {
+	case '{':
+		return s.parseObject(start)
+	case '[':
+		return s.parseArray(start)
+	case '"':
+		return s.parseString(start)
+	default:
+		end := start
+		for end < len(s.data) && !isValueDelimiter(s.data[end]) {
+			end++
+		}
+		if end == start {
+			return 0, fmt.Errorf("unexpected byte %q at offset %d", s.data[start], start)
+		}
+		return end, nil
+	}
+}
+
+func (s *jsonScanner) parseObject(start int) (int, error) {
+	pos := start + 1
+	members := make([]objectMember, 0)
+
+	for {
+		prefixStart := pos
+		pos = s.skipSpace(pos)
+		if pos >= len(s.data) {
+			return 0, fmt.Errorf("unterminated object at offset %d", start)
+		}
+		if s.data[pos] == '}' {
+			s.recordInvalidQueryStyles(members)
+			return pos + 1, nil
+		}
+		if s.data[pos] != '"' {
+			return 0, fmt.Errorf("expected object key at offset %d", pos)
+		}
+
+		keyStart := pos
+		keyEnd, err := s.parseString(keyStart)
+		if err != nil {
+			return 0, err
+		}
+		var key string
+		if err := json.Unmarshal(s.data[keyStart:keyEnd], &key); err != nil {
+			return 0, fmt.Errorf("decode object key at offset %d: %w", keyStart, err)
+		}
+
+		pos = s.skipSpace(keyEnd)
+		if pos >= len(s.data) || s.data[pos] != ':' {
+			return 0, fmt.Errorf("expected colon after object key at offset %d", keyStart)
+		}
+		valueStart := s.skipSpace(pos + 1)
+		valueEnd, err := s.parseValue(valueStart)
+		if err != nil {
+			return 0, err
+		}
+
+		pos = s.skipSpace(valueEnd)
+		comma := -1
+		if pos < len(s.data) && s.data[pos] == ',' {
+			comma = pos
+			pos++
+		} else if pos >= len(s.data) || s.data[pos] != '}' {
+			return 0, fmt.Errorf("expected comma or object end at offset %d", pos)
+		}
+
+		members = append(members, objectMember{
+			key:         key,
+			prefixStart: prefixStart,
+			valueStart:  valueStart,
+			valueEnd:    valueEnd,
+			comma:       comma,
+		})
+	}
+}
+
+func (s *jsonScanner) parseArray(start int) (int, error) {
+	pos := start + 1
+	for {
+		pos = s.skipSpace(pos)
+		if pos >= len(s.data) {
+			return 0, fmt.Errorf("unterminated array at offset %d", start)
+		}
+		if s.data[pos] == ']' {
+			return pos + 1, nil
+		}
+
+		var err error
+		pos, err = s.parseValue(pos)
+		if err != nil {
+			return 0, err
+		}
+		pos = s.skipSpace(pos)
+		if pos < len(s.data) && s.data[pos] == ',' {
+			pos++
+			continue
+		}
+		if pos >= len(s.data) || s.data[pos] != ']' {
+			return 0, fmt.Errorf("expected comma or array end at offset %d", pos)
+		}
+	}
+}
+
+func (s *jsonScanner) parseString(start int) (int, error) {
+	for pos := start + 1; pos < len(s.data); pos++ {
+		switch s.data[pos] {
+		case '\\':
+			pos++
+			if pos >= len(s.data) {
+				return 0, fmt.Errorf("unterminated escape at offset %d", start)
+			}
+		case '"':
+			return pos + 1, nil
+		}
+	}
+	return 0, fmt.Errorf("unterminated string at offset %d", start)
+}
+
+func (s *jsonScanner) recordInvalidQueryStyles(members []objectMember) {
+	isQueryParameter := false
+	styleIndexes := make([]int, 0, 1)
+	for i, member := range members {
+		if member.key == "in" && s.stringValue(member) == "query" {
+			isQueryParameter = true
+		}
+		if member.key == "style" && s.stringValue(member) == "simple" {
+			styleIndexes = append(styleIndexes, i)
+		}
+	}
+	if !isQueryParameter {
+		return
+	}
+
+	for _, i := range styleIndexes {
+		if i+1 < len(members) {
+			s.removals = append(s.removals, span{
+				start: members[i].prefixStart,
+				end:   members[i+1].prefixStart,
+			})
+			continue
+		}
+		if i > 0 && members[i-1].comma >= 0 {
+			s.removals = append(s.removals, span{
+				start: members[i-1].comma,
+				end:   members[i].valueEnd,
+			})
+		}
+	}
+}
+
+func (s *jsonScanner) stringValue(member objectMember) string {
+	if member.valueStart >= member.valueEnd || s.data[member.valueStart] != '"' {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(s.data[member.valueStart:member.valueEnd], &value); err != nil {
+		return ""
+	}
+	return value
+}
+
+func (s *jsonScanner) skipSpace(pos int) int {
+	for pos < len(s.data) {
+		switch s.data[pos] {
+		case ' ', '\t', '\r', '\n':
+			pos++
+		default:
+			return pos
+		}
+	}
+	return pos
+}
+
+func isValueDelimiter(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n', ',', ']', '}':
+		return true
+	default:
+		return false
+	}
 }

--- a/scripts/normalize-openapi/main.go
+++ b/scripts/normalize-openapi/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+const specs = "api-spec/openapi/swagger/*/v1/*.openapi.json"
+
+var invalidQueryStyle = regexp.MustCompile(`(?m)(^[ \t]*"in": "query",\r?\n(?:^[ \t]*"description": [^\r\n]*,\r?\n)?)[ \t]*"style": "simple",\r?\n`)
+
+func main() {
+	paths, err := filepath.Glob(specs)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(paths) == 0 {
+		log.Fatalf("no specs match %s", specs)
+	}
+
+	total := 0
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			log.Fatalf("%s: %v", path, err)
+		}
+
+		fixed, count := normalize(data)
+		if !json.Valid(fixed) {
+			log.Fatalf("%s: invalid JSON", path)
+		}
+		if count > 0 {
+			if err := os.WriteFile(path, fixed, 0o644); err != nil {
+				log.Fatalf("%s: %v", path, err)
+			}
+		}
+		total += count
+	}
+
+	fmt.Printf("Removed %d invalid query parameter style(s).\n", total)
+}
+
+func normalize(data []byte) ([]byte, int) {
+	count := len(invalidQueryStyle.FindAll(data, -1))
+	return invalidQueryStyle.ReplaceAll(data, []byte("${1}")), count
+}

--- a/scripts/normalize-openapi/main_test.go
+++ b/scripts/normalize-openapi/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNormalize(t *testing.T) {
+	input := []byte("{\n" +
+		"  \"parameters\": [\n" +
+		"    {\n" +
+		"      \"in\": \"query\",\n" +
+		"      \"style\": \"simple\",\n" +
+		"      \"schema\": {}\n" +
+		"    },\n" +
+		"    {\n" +
+		"      \"in\": \"query\",\n" +
+		"      \"description\": \"topics\",\n" +
+		"      \"style\": \"simple\",\n" +
+		"      \"schema\": {}\n" +
+		"    },\n" +
+		"    {\n" +
+		"      \"in\": \"path\",\n" +
+		"      \"style\": \"simple\",\n" +
+		"      \"schema\": {}\n" +
+		"    }\n" +
+		"  ]\n" +
+		"}\n")
+	want := []byte("{\n" +
+		"  \"parameters\": [\n" +
+		"    {\n" +
+		"      \"in\": \"query\",\n" +
+		"      \"schema\": {}\n" +
+		"    },\n" +
+		"    {\n" +
+		"      \"in\": \"query\",\n" +
+		"      \"description\": \"topics\",\n" +
+		"      \"schema\": {}\n" +
+		"    },\n" +
+		"    {\n" +
+		"      \"in\": \"path\",\n" +
+		"      \"style\": \"simple\",\n" +
+		"      \"schema\": {}\n" +
+		"    }\n" +
+		"  ]\n" +
+		"}\n")
+
+	got, count := normalize(input)
+	if count != 2 || !bytes.Equal(got, want) {
+		t.Fatalf("normalize() removed %d styles; got:\n%s", count, got)
+	}
+	again, count := normalize(got)
+	if count != 0 || !bytes.Equal(again, got) {
+		t.Fatal("normalize() is not idempotent")
+	}
+}

--- a/scripts/normalize-openapi/main_test.go
+++ b/scripts/normalize-openapi/main_test.go
@@ -45,12 +45,71 @@ func TestNormalize(t *testing.T) {
 		"  ]\n" +
 		"}\n")
 
-	got, count := normalize(input)
+	got, count, err := normalize(input)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if count != 2 || !bytes.Equal(got, want) {
 		t.Fatalf("normalize() removed %d styles; got:\n%s", count, got)
 	}
-	again, count := normalize(got)
+	again, count, err := normalize(got)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if count != 0 || !bytes.Equal(again, got) {
 		t.Fatal("normalize() is not idempotent")
+	}
+}
+
+func TestNormalizeHandlesReorderedAndInterveningFields(t *testing.T) {
+	input := []byte("{\r\n" +
+		"  \"parameters\": [\r\n" +
+		"    {\r\n" +
+		"      \"style\": \"simple\",\r\n" +
+		"      \"name\": \"cursor\",\r\n" +
+		"      \"schema\": {\"type\": \"string\"},\r\n" +
+		"      \"description\": \"pagination cursor\",\r\n" +
+		"      \"in\": \"query\"\r\n" +
+		"    },\r\n" +
+		"    {\r\n" +
+		"      \"in\": \"query\",\r\n" +
+		"      \"name\": \"limit\",\r\n" +
+		"      \"schema\": {},\r\n" +
+		"      \"style\": \"simple\"\r\n" +
+		"    },\r\n" +
+		"    {\"style\": \"simple\", \"in\": \"header\", \"name\": \"x-token\"}\r\n" +
+		"  ],\r\n" +
+		"  \"example\": \"\\\"in\\\": \\\"query\\\", \\\"style\\\": \\\"simple\\\"\"\r\n" +
+		"}\r\n")
+	want := []byte("{\r\n" +
+		"  \"parameters\": [\r\n" +
+		"    {\r\n" +
+		"      \"name\": \"cursor\",\r\n" +
+		"      \"schema\": {\"type\": \"string\"},\r\n" +
+		"      \"description\": \"pagination cursor\",\r\n" +
+		"      \"in\": \"query\"\r\n" +
+		"    },\r\n" +
+		"    {\r\n" +
+		"      \"in\": \"query\",\r\n" +
+		"      \"name\": \"limit\",\r\n" +
+		"      \"schema\": {}\r\n" +
+		"    },\r\n" +
+		"    {\"style\": \"simple\", \"in\": \"header\", \"name\": \"x-token\"}\r\n" +
+		"  ],\r\n" +
+		"  \"example\": \"\\\"in\\\": \\\"query\\\", \\\"style\\\": \\\"simple\\\"\"\r\n" +
+		"}\r\n")
+
+	got, count, err := normalize(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 || !bytes.Equal(got, want) {
+		t.Fatalf("normalize() removed %d styles; got:\n%s", count, got)
+	}
+}
+
+func TestNormalizeRejectsInvalidJSON(t *testing.T) {
+	if _, _, err := normalize([]byte(`{"in":"query",`)); err == nil {
+		t.Fatal("normalize() accepted invalid JSON")
 	}
 }


### PR DESCRIPTION
Closes #1169.

Run a narrow normalization step after `buf generate` so repeated query parameters no longer retain the invalid `style: simple` value. The normalizer preserves valid path parameter styles, validates every processed document as JSON, and is idempotent.

This also regenerates the committed specs and removes all 11 current invalid occurrences, including the additional admin and wallet parameters now present on `master`.

Tests:
- `go test -count=1 ./scripts/normalize-openapi`
- `go vet ./scripts/normalize-openapi`
- second normalizer run reports 0 changes
- semantic scan reports 0 remaining query parameters with `style: simple`

I could not run the complete `make proto` target locally because Docker is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenAPI query-parameter serialization metadata for array parameters across administrative, indexing, service, and wallet APIs.
  * Improved compatibility with clients that rely on standard OpenAPI form-style query serialization.

* **Chores**
  * Added automatic normalization and validation of OpenAPI specifications during proto generation.
  * Improved handling of varied specification layouts and invalid input during normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->