### PR TITLE
indexer: batch txid db lookups transparently to avoid SQL parameter limits

### DIFF
--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -960,11 +960,29 @@ func (i *indexerService) ensureVtxosCached(
 func (i *indexerService) getVirtualTxs(
 	ctx context.Context, txids []string, page *Page, authToken string,
 ) (*VirtualTxsResp, error) {
-	txs, err := i.repoManager.Rounds().GetTxsWithTxids(ctx, txids)
-	if err != nil {
-		return nil, err
+	const maxQueryChunkSize = 250
+	var allTxs []string
+	seen := make(map[string]bool)
+
+	for start := 0; start < len(txids); start += maxQueryChunkSize {
+		end := start + maxQueryChunkSize
+		if end > len(txids) {
+			end = len(txids)
+		}
+		chunk := txids[start:end]
+		chunkTxs, err := i.repoManager.Rounds().GetTxsWithTxids(ctx, chunk)
+		if err != nil {
+			return nil, err
+		}
+		for _, tx := range chunkTxs {
+			if !seen[tx] {
+				seen[tx] = true
+				allTxs = append(allTxs, tx)
+			}
+		}
 	}
-	virtualTxs, resp := paginate(txs, page, maxPageSizeVirtualTxs)
+
+	virtualTxs, resp := paginate(allTxs, page, maxPageSizeVirtualTxs)
 	return &VirtualTxsResp{
 		Txs:       virtualTxs,
 		Page:      resp,

--- a/internal/core/application/indexer.go
+++ b/internal/core/application/indexer.go
@@ -960,6 +960,9 @@ func (i *indexerService) ensureVtxosCached(
 func (i *indexerService) getVirtualTxs(
 	ctx context.Context, txids []string, page *Page, authToken string,
 ) (*VirtualTxsResp, error) {
+	// maxQueryChunkSize bounds the number of txids queried in a single SQL query.
+	// Each txid expands into 3 IN-clause bound parameters in the underlying SQLite query.
+	// A chunk size of 250 translates to 750 parameters per query, well below SQLite's SQLITE_MAX_VARIABLE_NUMBER ceiling.
 	const maxQueryChunkSize = 250
 	var allTxs []string
 	seen := make(map[string]bool)

--- a/internal/core/application/indexer_test.go
+++ b/internal/core/application/indexer_test.go
@@ -1769,8 +1769,8 @@ func TestGetVirtualTxs_Batching(t *testing.T) {
 		require.Contains(t, resp.Txs, fmt.Sprintf("tx_%s", txids[500]))
 		require.Contains(t, resp.Txs, "dup_tx")
 
-		// 6. Pagination happens AFTER aggregation (total count reflects all aggregated unique txs)
-		require.Equal(t, int32(4), resp.Page.Total)
+		// 6. Pagination happens AFTER aggregation (total page count = 1 for 4 items with PageSize 10, all 4 items returned)
+		require.Equal(t, int32(1), resp.Page.Total)
 	})
 
 	t.Run("propagates error from intermediate chunk", func(t *testing.T) {

--- a/internal/core/application/indexer_test.go
+++ b/internal/core/application/indexer_test.go
@@ -1716,3 +1716,95 @@ func matchIDs(expected ...string) interface{} {
 		return true
 	})
 }
+
+func TestGetVirtualTxs_Batching(t *testing.T) {
+	t.Run("chunks lookups, aggregates results, handles duplicates and missing txs", func(t *testing.T) {
+		repoManager := &mockedRepoManager{}
+		roundRepo := &mockedRoundRepo{}
+		repoManager.On("Rounds").Return(roundRepo)
+
+		// 501 txids -> expected chunks: 250 + 250 + 1
+		txids := make([]string, 501)
+		for i := range txids {
+			txids[i] = fmt.Sprintf("%064d", i+1)
+		}
+
+		var callChunks [][]string
+		roundRepo.On("GetTxsWithTxids", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				chunk := args.Get(1).([]string)
+				copied := make([]string, len(chunk))
+				copy(copied, chunk)
+				callChunks = append(callChunks, copied)
+			}).
+			Return(func(ctx context.Context, chunk []string) []string {
+				res := []string{fmt.Sprintf("tx_%s", chunk[0])}
+				if len(chunk) > 1 {
+					res = append(res, "dup_tx")
+				}
+				return res
+			}, nil)
+
+		svc := &indexerService{
+			repoManager: repoManager,
+			txExposure:  exposurePublic,
+		}
+
+		resp, err := svc.GetVirtualTxs(context.Background(), "", txids, &Page{PageNum: 1, PageSize: 10})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// 1. >250 txids are split into 3 calls (250 + 250 + 1)
+		require.Len(t, callChunks, 3)
+
+		// 2. Every chunk is <= 250
+		require.Len(t, callChunks[0], 250)
+		require.Len(t, callChunks[1], 250)
+		require.Len(t, callChunks[2], 1)
+
+		// 3, 4, 5. Results are combined, missing txids handled, duplicates deduplicated
+		require.Len(t, resp.Txs, 4)
+		require.Contains(t, resp.Txs, fmt.Sprintf("tx_%s", txids[0]))
+		require.Contains(t, resp.Txs, fmt.Sprintf("tx_%s", txids[250]))
+		require.Contains(t, resp.Txs, fmt.Sprintf("tx_%s", txids[500]))
+		require.Contains(t, resp.Txs, "dup_tx")
+
+		// 6. Pagination happens AFTER aggregation (total count reflects all aggregated unique txs)
+		require.Equal(t, int32(4), resp.Page.Total)
+	})
+
+	t.Run("propagates error from intermediate chunk", func(t *testing.T) {
+		repoManager := &mockedRepoManager{}
+		roundRepo := &mockedRoundRepo{}
+		repoManager.On("Rounds").Return(roundRepo)
+
+		txids := make([]string, 501)
+		for i := range txids {
+			txids[i] = fmt.Sprintf("%064d", i+1)
+		}
+
+		callCount := 0
+		roundRepo.On("GetTxsWithTxids", mock.Anything, mock.Anything).
+			Return(func(ctx context.Context, chunk []string) []string {
+				callCount++
+				if callCount == 2 {
+					return nil
+				}
+				return []string{"tx_ok"}
+			}, func(ctx context.Context, chunk []string) error {
+				if callCount == 2 {
+					return fmt.Errorf("db error on chunk 2")
+				}
+				return nil
+			})
+
+		svc := &indexerService{
+			repoManager: repoManager,
+			txExposure:  exposurePublic,
+		}
+
+		_, err := svc.GetVirtualTxs(context.Background(), "", txids, nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "db error on chunk 2")
+	})
+}

--- a/internal/core/application/indexer_test.go
+++ b/internal/core/application/indexer_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/arkade-os/arkd/internal/core/domain"
@@ -1783,19 +1784,14 @@ func TestGetVirtualTxs_Batching(t *testing.T) {
 			txids[i] = fmt.Sprintf("%064d", i+1)
 		}
 
-		callCount := 0
+		var callCount atomic.Int32
 		roundRepo.On("GetTxsWithTxids", mock.Anything, mock.Anything).
-			Return(func(ctx context.Context, chunk []string) []string {
-				callCount++
-				if callCount == 2 {
-					return nil
+			Return(func(ctx context.Context, chunk []string) ([]string, error) {
+				count := callCount.Add(1)
+				if count == 2 {
+					return nil, fmt.Errorf("db error on chunk 2")
 				}
-				return []string{"tx_ok"}
-			}, func(ctx context.Context, chunk []string) error {
-				if callCount == 2 {
-					return fmt.Errorf("db error on chunk 2")
-				}
-				return nil
+				return []string{"tx_ok"}, nil
 			})
 
 		svc := &indexerService{

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -18,16 +18,29 @@ type mockedRoundRepo struct {
 
 func (m *mockedRoundRepo) GetTxsWithTxids(ctx context.Context, txids []string) ([]string, error) {
 	args := m.Called(ctx, txids)
+	var res []string
+	var err error
+
 	if v := args.Get(0); v != nil {
 		if fn, ok := v.(func(context.Context, []string) ([]string, error)); ok {
 			return fn(ctx, txids)
 		}
 		if fn, ok := v.(func(context.Context, []string) []string); ok {
-			return fn(ctx, txids), args.Error(1)
+			res = fn(ctx, txids)
+		} else {
+			res = v.([]string)
 		}
-		return v.([]string), args.Error(1)
 	}
-	return nil, args.Error(1)
+
+	if v := args.Get(1); v != nil {
+		if fn, ok := v.(func(context.Context, []string) error); ok {
+			err = fn(ctx, txids)
+		} else {
+			err = args.Error(1)
+		}
+	}
+
+	return res, err
 }
 
 func (m *mockedRoundRepo) GetRoundVtxoTree(ctx context.Context, txid string) (arktree.FlatTxTree, error) {

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -19,6 +19,12 @@ type mockedRoundRepo struct {
 func (m *mockedRoundRepo) GetTxsWithTxids(ctx context.Context, txids []string) ([]string, error) {
 	args := m.Called(ctx, txids)
 	if v := args.Get(0); v != nil {
+		if fn, ok := v.(func(context.Context, []string) ([]string, error)); ok {
+			return fn(ctx, txids)
+		}
+		if fn, ok := v.(func(context.Context, []string) []string); ok {
+			return fn(ctx, txids), args.Error(1)
+		}
 		return v.([]string), args.Error(1)
 	}
 	return nil, args.Error(1)

--- a/internal/core/application/mocks_test.go
+++ b/internal/core/application/mocks_test.go
@@ -18,13 +18,14 @@ type mockedRoundRepo struct {
 
 func (m *mockedRoundRepo) GetTxsWithTxids(ctx context.Context, txids []string) ([]string, error) {
 	args := m.Called(ctx, txids)
+	if fn, ok := args.Get(0).(func(context.Context, []string) ([]string, error)); ok {
+		return fn(ctx, txids)
+	}
+
 	var res []string
 	var err error
 
 	if v := args.Get(0); v != nil {
-		if fn, ok := v.(func(context.Context, []string) ([]string, error)); ok {
-			return fn(ctx, txids)
-		}
 		if fn, ok := v.(func(context.Context, []string) []string); ok {
 			res = fn(ctx, txids)
 		} else {

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -922,9 +922,14 @@ func parsePage(page *arkv1.IndexerPageRequest) (*application.Page, error) {
 	}, nil
 }
 
+const maxTxidsPerRequest = 10_000
+
 func parseTxids(txids []string) ([]string, error) {
 	if len(txids) == 0 {
 		return nil, fmt.Errorf("missing txids")
+	}
+	if len(txids) > maxTxidsPerRequest {
+		return nil, fmt.Errorf("txids list exceeds maximum limit of %d", maxTxidsPerRequest)
 	}
 	for _, txid := range txids {
 		if _, err := parseTxid(txid); err != nil {

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -922,14 +922,9 @@ func parsePage(page *arkv1.IndexerPageRequest) (*application.Page, error) {
 	}, nil
 }
 
-const maxTxidsBatchSize = 100
-
 func parseTxids(txids []string) ([]string, error) {
 	if len(txids) == 0 {
 		return nil, fmt.Errorf("missing txids")
-	}
-	if len(txids) > maxTxidsBatchSize {
-		return nil, fmt.Errorf("exceeded max txid batch size of %d", maxTxidsBatchSize)
 	}
 	for _, txid := range txids {
 		if _, err := parseTxid(txid); err != nil {

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -922,9 +922,14 @@ func parsePage(page *arkv1.IndexerPageRequest) (*application.Page, error) {
 	}, nil
 }
 
+const maxTxidsBatchSize = 100
+
 func parseTxids(txids []string) ([]string, error) {
 	if len(txids) == 0 {
 		return nil, fmt.Errorf("missing txids")
+	}
+	if len(txids) > maxTxidsBatchSize {
+		return nil, fmt.Errorf("exceeded max txid batch size of %d", maxTxidsBatchSize)
 	}
 	for _, txid := range txids {
 		if _, err := parseTxid(txid); err != nil {

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -925,6 +925,9 @@ func parsePage(page *arkv1.IndexerPageRequest) (*application.Page, error) {
 	}, nil
 }
 
+// maxTxidsPerRequest caps the gRPC request size; the application layer
+// transparently chunks these lookups further (see getVirtualTxs in
+// internal/core/application/indexer.go) to stay under SQLite's parameter limit.
 const maxTxidsPerRequest = 10_000
 
 func parseTxids(txids []string) ([]string, error) {

--- a/internal/interface/grpc/handlers/indexer.go
+++ b/internal/interface/grpc/handlers/indexer.go
@@ -406,6 +406,9 @@ func (e *indexerService) GetVirtualTxs(
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	if page == nil {
+		page = &application.Page{PageSize: maxPageRequestSize, PageNum: 1}
+	}
 
 	var resp *application.VirtualTxsResp
 	if request.GetIntent() != nil {

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -91,6 +91,19 @@ func TestParsePage(t *testing.T) {
 	}
 }
 
+func TestGetVirtualTxsDefaultsPage(t *testing.T) {
+	mockSvc := &mockAppIndexer{}
+	svc := newTestIndexerService(t)
+	svc.indexerSvc = mockSvc
+
+	_, err := svc.GetVirtualTxs(context.Background(), &arkv1.GetVirtualTxsRequest{
+		Txids: []string{testChainTxid},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, &application.Page{PageSize: maxPageRequestSize, PageNum: 1}, mockSvc.gotVirtualTxsPage)
+}
+
 func TestGetVtxoChain(t *testing.T) {
 	// Cursor pagination is continued via the auth_token, not by re-submitting the intent proof,
 	// so combining an intent with a page_token must be rejected before the request reaches the
@@ -2095,9 +2108,10 @@ func (m *gatedSubscriptionServer) RecvMsg(any) error            { return nil }
 // other method would panic via the embedded nil interface (none are called).
 type mockAppIndexer struct {
 	application.IndexerService
-	gotPageToken string
-	resp         *application.VtxoChainResp
-	err          error
+	gotPageToken      string
+	gotVirtualTxsPage *application.Page
+	resp              *application.VtxoChainResp
+	err               error
 }
 
 func (m *mockAppIndexer) GetVtxoChain(
@@ -2105,4 +2119,11 @@ func (m *mockAppIndexer) GetVtxoChain(
 ) (*application.VtxoChainResp, error) {
 	m.gotPageToken = pageToken
 	return m.resp, m.err
+}
+
+func (m *mockAppIndexer) GetVirtualTxs(
+	_ context.Context, _ string, _ []string, page *application.Page,
+) (*application.VirtualTxsResp, error) {
+	m.gotVirtualTxsPage = page
+	return &application.VirtualTxsResp{}, m.err
 }

--- a/internal/interface/grpc/handlers/indexer_test.go
+++ b/internal/interface/grpc/handlers/indexer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arkade-os/arkd/internal/core/domain"
 	"github.com/arkade-os/arkd/pkg/ark-lib/extension"
 	arkdErrors "github.com/arkade-os/arkd/pkg/errors"
+	"github.com/arkade-os/arkd/pkg/ark-lib/intent"
 	"github.com/btcsuite/btcd/psbt/v2"
 	"github.com/btcsuite/btcd/wire/v2"
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,31 @@ func TestGetVirtualTxsDefaultsPage(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, &application.Page{PageSize: maxPageRequestSize, PageNum: 1}, mockSvc.gotVirtualTxsPage)
+}
+
+func TestGetVirtualTxsByIntentDefaultsPage(t *testing.T) {
+	mockSvc := &mockAppIndexer{}
+	svc := newTestIndexerService(t)
+	svc.indexerSvc = mockSvc
+
+	message, err := intent.GetDataMessage{
+		BaseMessage: intent.BaseMessage{Type: intent.IntentMessageTypeGetData},
+	}.Encode()
+	require.NoError(t, err)
+
+	fixtures := loadParserFixtures(t)
+
+	_, err = svc.GetVirtualTxs(context.Background(), &arkv1.GetVirtualTxsRequest{
+		Auth: &arkv1.GetVirtualTxsRequest_Intent{
+			Intent: &arkv1.IndexerIntent{
+				Proof:   fixtures.ValidProof,
+				Message: message,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, &application.Page{PageSize: maxPageRequestSize, PageNum: 1}, mockSvc.gotIntentPage)
 }
 
 func TestGetVtxoChain(t *testing.T) {
@@ -2110,6 +2136,7 @@ type mockAppIndexer struct {
 	application.IndexerService
 	gotPageToken      string
 	gotVirtualTxsPage *application.Page
+	gotIntentPage     *application.Page
 	resp              *application.VtxoChainResp
 	err               error
 }
@@ -2125,5 +2152,12 @@ func (m *mockAppIndexer) GetVirtualTxs(
 	_ context.Context, _ string, _ []string, page *application.Page,
 ) (*application.VirtualTxsResp, error) {
 	m.gotVirtualTxsPage = page
+	return &application.VirtualTxsResp{}, m.err
+}
+
+func (m *mockAppIndexer) GetVirtualTxsByIntent(
+	_ context.Context, _ application.Intent, page *application.Page,
+) (*application.VirtualTxsResp, error) {
+	m.gotIntentPage = page
 	return &application.VirtualTxsResp{}, m.err
 }

--- a/internal/interface/grpc/handlers/parser_test.go
+++ b/internal/interface/grpc/handlers/parser_test.go
@@ -337,6 +337,8 @@ func TestParseDeleteIntent(t *testing.T) {
 				_, _, err := parseDeleteIntent(intentProof)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.ExpectedError)
+			})
+		}
 	})
 }
 

--- a/internal/interface/grpc/handlers/parser_test.go
+++ b/internal/interface/grpc/handlers/parser_test.go
@@ -337,7 +337,35 @@ func TestParseDeleteIntent(t *testing.T) {
 				_, _, err := parseDeleteIntent(intentProof)
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.ExpectedError)
-			})
+	})
+}
+
+func TestParseTxidsLimit(t *testing.T) {
+	validTxid := "0000000000000000000000000000000000000000000000000000000000000001"
+
+	t.Run("empty txids", func(t *testing.T) {
+		_, err := parseTxids(nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing txids")
+	})
+
+	t.Run("within batch limit", func(t *testing.T) {
+		txids := make([]string, maxTxidsBatchSize)
+		for i := range txids {
+			txids[i] = validTxid
 		}
+		res, err := parseTxids(txids)
+		require.NoError(t, err)
+		require.Len(t, res, maxTxidsBatchSize)
+	})
+
+	t.Run("exceeds batch limit", func(t *testing.T) {
+		txids := make([]string, maxTxidsBatchSize+1)
+		for i := range txids {
+			txids[i] = validTxid
+		}
+		_, err := parseTxids(txids)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "exceeded max txid batch size")
 	})
 }

--- a/internal/interface/grpc/handlers/parser_test.go
+++ b/internal/interface/grpc/handlers/parser_test.go
@@ -342,7 +342,7 @@ func TestParseDeleteIntent(t *testing.T) {
 	})
 }
 
-func TestParseTxidsLimit(t *testing.T) {
+func TestParseTxids(t *testing.T) {
 	validTxid := "0000000000000000000000000000000000000000000000000000000000000001"
 
 	t.Run("empty txids", func(t *testing.T) {
@@ -351,23 +351,13 @@ func TestParseTxidsLimit(t *testing.T) {
 		require.Contains(t, err.Error(), "missing txids")
 	})
 
-	t.Run("within batch limit", func(t *testing.T) {
-		txids := make([]string, maxTxidsBatchSize)
+	t.Run("large txid batch parsed cleanly", func(t *testing.T) {
+		txids := make([]string, 500)
 		for i := range txids {
 			txids[i] = validTxid
 		}
 		res, err := parseTxids(txids)
 		require.NoError(t, err)
-		require.Len(t, res, maxTxidsBatchSize)
-	})
-
-	t.Run("exceeds batch limit", func(t *testing.T) {
-		txids := make([]string, maxTxidsBatchSize+1)
-		for i := range txids {
-			txids[i] = validTxid
-		}
-		_, err := parseTxids(txids)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "exceeded max txid batch size")
+		require.Len(t, res, 500)
 	})
 }


### PR DESCRIPTION
Fixes #1115.

This PR implements transparent internal chunking for GetVirtualTxs lookups in the indexer service layer.

### Changes
- Chunk txids into internal batches of 250 items when querying the database repository. This prevents bound parameter limit errors in SQLite (too many SQL variables) and high query planner overhead in PostgreSQL when requesting large sets of txids.
- Deduplicates result transaction records before pagination.
- Preserves the public API contract so callers can query large txid sets transparently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction ID requests now support up to 10,000 IDs.
  * Large transaction lookups are processed in smaller batches to avoid database limits.
  * Results are combined, duplicates removed, and pagination applied consistently across batches.
  * Requests without pagination default to the maximum page size and first page.

* **Bug Fixes**
  * Missing transaction IDs are handled consistently.
  * Errors encountered while processing a batch are correctly reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->