### PR TITLE
Redact secrets from the config logged at startup

### DIFF
--- a/cmd/arkd-wallet/main.go
+++ b/cmd/arkd-wallet/main.go
@@ -27,7 +27,7 @@ func main() {
 		log.Fatalf("failed to create service: %s", err)
 	}
 
-	log.Infof("arkd wallet config: %+v", cfg)
+	log.Infof("arkd wallet config: %s", cfg)
 
 	log.Info("starting service...")
 	if err := svc.Start(); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,12 +206,19 @@ func redactConnectionString(rawURL string) string {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return redactedMask
 	}
-	redactQueryCredentials(parsed)
+	if err := redactQueryCredentials(parsed); err != nil {
+		return redactedMask
+	}
 	return parsed.Redacted()
 }
 
-func redactQueryCredentials(parsed *url.URL) {
-	query := parsed.Query()
+// Fails closed: url.URL.Query would silently drop a malformed password pair,
+// leaving it in RawQuery for Redacted() to emit.
+func redactQueryCredentials(parsed *url.URL) error {
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return err
+	}
 	redacted := false
 	for key := range query {
 		for _, credential := range credentialQueryParams {
@@ -225,6 +232,7 @@ func redactQueryCredentials(parsed *url.URL) {
 	if redacted {
 		parsed.RawQuery = query.Encode()
 	}
+	return nil
 }
 
 var (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -166,19 +167,42 @@ type Config struct {
 	settings  *domain.Settings
 }
 
+const redactedMask = "••••••"
+
 func (c *Config) String() string {
 	clone := *c
-	if clone.UnlockerPassword != "" {
-		clone.UnlockerPassword = "••••••"
-	}
-	if clone.IndexerSigningKey != "" {
-		clone.IndexerSigningKey = "••••••"
-	}
+	clone.UnlockerPassword = maskSecret(clone.UnlockerPassword)
+	clone.IndexerSigningKey = maskSecret(clone.IndexerSigningKey)
+	clone.DbUrl = redactConnectionString(clone.DbUrl)
+	clone.EventDbUrl = redactConnectionString(clone.EventDbUrl)
+	clone.RedisUrl = redactConnectionString(clone.RedisUrl)
+
 	json, err := json.MarshalIndent(clone, "", "  ")
 	if err != nil {
 		return fmt.Sprintf("error while marshalling config JSON: %s", err)
 	}
 	return string(json)
+}
+
+func maskSecret(secret string) string {
+	if secret == "" {
+		return ""
+	}
+	return redactedMask
+}
+
+// Non-URL values are masked whole because lib/pq also accepts keyword DSNs
+// ("host=pg user=ark password=hunter2"), which url.Parse accepts without
+// recognising any credential, so Redacted() would pass the password through.
+func redactConnectionString(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return redactedMask
+	}
+	return parsed.Redacted()
 }
 
 var (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,9 +191,13 @@ func maskSecret(secret string) string {
 	return redactedMask
 }
 
-// Non-URL values are masked whole because lib/pq also accepts keyword DSNs
-// ("host=pg user=ark password=hunter2"), which url.Parse accepts without
-// recognising any credential, so Redacted() would pass the password through.
+// matches url.URL.Redacted()
+const urlPasswordMask = "xxxxx"
+
+// lib/pq honours these in URL form; Redacted() masks only the userinfo.
+var credentialQueryParams = []string{"password", "sslpassword"}
+
+// Non-URLs are masked whole: keyword DSNs hide credentials from url.Parse.
 func redactConnectionString(rawURL string) string {
 	if rawURL == "" {
 		return ""
@@ -202,7 +206,25 @@ func redactConnectionString(rawURL string) string {
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return redactedMask
 	}
+	redactQueryCredentials(parsed)
 	return parsed.Redacted()
+}
+
+func redactQueryCredentials(parsed *url.URL) {
+	query := parsed.Query()
+	redacted := false
+	for key := range query {
+		for _, credential := range credentialQueryParams {
+			if strings.EqualFold(key, credential) {
+				query.Set(key, urlPasswordMask)
+				redacted = true
+			}
+		}
+	}
+	// Encode reorders params, so only rewrite when masked.
+	if redacted {
+		parsed.RawQuery = query.Encode()
+	}
 }
 
 var (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -272,6 +272,30 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 			mustContain:    "postgres://ark:xxxxx@pg:5432/arkd-events",
 		},
 		{
+			name: "password query parameter is redacted",
+			mutate: func(c *Config) {
+				c.DbUrl = "postgresql://ark@pg:5432/arkd?password=hunter2&sslmode=disable"
+			},
+			mustNotContain: "hunter2",
+			mustContain:    "password=xxxxx",
+		},
+		{
+			name: "sslpassword query parameter is redacted",
+			mutate: func(c *Config) {
+				c.EventDbUrl = "postgresql://ark@pg:5432/arkd-events?sslpassword=keypass"
+			},
+			mustNotContain: "keypass",
+			mustContain:    "sslpassword=xxxxx",
+		},
+		{
+			// not re-encoded, so param order survives
+			name: "query parameters are otherwise left untouched",
+			mutate: func(c *Config) {
+				c.DbUrl = "postgresql://ark@pg:5432/arkd?sslmode=disable&connect_timeout=5"
+			},
+			mustContain: "arkd?sslmode=disable",
+		},
+		{
 			name:           "redis url password is redacted",
 			mutate:         func(c *Config) { c.RedisUrl = "redis://default:hunter2@redis:6379/0" },
 			mustNotContain: "hunter2",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -230,28 +230,62 @@ func TestConfigValidateEarlyChecks(t *testing.T) {
 
 func TestConfigStringRedactsSecrets(t *testing.T) {
 	tests := []struct {
-		name     string
-		mutate   func(c *Config)
-		value    string
-		redacted bool
+		name           string
+		mutate         func(c *Config)
+		mustNotContain string
+		mustContain    string
 	}{
 		{
-			"unlocker password is redacted",
-			func(c *Config) { c.UnlockerPassword = "super-secret-password" },
-			"super-secret-password",
-			true,
+			name:           "unlocker password is redacted",
+			mutate:         func(c *Config) { c.UnlockerPassword = "super-secret-password" },
+			mustNotContain: "super-secret-password",
+			mustContain:    redactedMask,
 		},
 		{
-			"indexer signing key is redacted",
-			func(c *Config) { c.IndexerSigningKey = "deadbeefsigningkey" },
-			"deadbeefsigningkey",
-			true,
+			name:           "indexer signing key is redacted",
+			mutate:         func(c *Config) { c.IndexerSigningKey = "deadbeefsigningkey" },
+			mustNotContain: "deadbeefsigningkey",
+			mustContain:    redactedMask,
 		},
 		{
-			"non-sensitive field is preserved",
-			func(c *Config) { c.WalletAddr = "localhost:6060" },
-			"localhost:6060",
-			false,
+			name: "postgres url keeps host and database but drops the password",
+			mutate: func(c *Config) {
+				c.DbUrl = "postgres://ark:hunter2@pg:5432/arkd?sslmode=disable"
+			},
+			mustNotContain: "hunter2",
+			mustContain:    "postgres://ark:xxxxx@pg:5432/arkd?sslmode=disable",
+		},
+		{
+			name: "postgres keyword dsn is masked whole",
+			mutate: func(c *Config) {
+				c.DbUrl = "host=pg port=5432 user=ark password=hunter2 dbname=arkd"
+			},
+			mustNotContain: "hunter2",
+			mustContain:    redactedMask,
+		},
+		{
+			name: "event db url password is redacted",
+			mutate: func(c *Config) {
+				c.EventDbUrl = "postgres://ark:hunter2@pg:5432/arkd-events"
+			},
+			mustNotContain: "hunter2",
+			mustContain:    "postgres://ark:xxxxx@pg:5432/arkd-events",
+		},
+		{
+			name:           "redis url password is redacted",
+			mutate:         func(c *Config) { c.RedisUrl = "redis://default:hunter2@redis:6379/0" },
+			mustNotContain: "hunter2",
+			mustContain:    "redis://default:xxxxx@redis:6379/0",
+		},
+		{
+			name:        "credential-free url is left intact",
+			mutate:      func(c *Config) { c.RedisUrl = "redis://redis:6379/0" },
+			mustContain: "redis://redis:6379/0",
+		},
+		{
+			name:        "non-sensitive field is preserved",
+			mutate:      func(c *Config) { c.WalletAddr = "localhost:6060" },
+			mustContain: "localhost:6060",
 		},
 	}
 
@@ -261,12 +295,10 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 			tt.mutate(&c)
 
 			out := c.String()
-			if tt.redacted {
-				require.NotContains(t, out, tt.value)
-				require.Contains(t, out, "••••••")
-			} else {
-				require.Contains(t, out, tt.value)
+			if tt.mustNotContain != "" {
+				require.NotContains(t, out, tt.mustNotContain)
 			}
+			require.Contains(t, out, tt.mustContain)
 		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -228,6 +229,11 @@ func TestConfigValidateEarlyChecks(t *testing.T) {
 	})
 }
 
+// maskedField matches a field whose entire logged value is the mask.
+func maskedField(name string) string {
+	return fmt.Sprintf("%q: %q", name, redactedMask)
+}
+
 func TestConfigStringRedactsSecrets(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -261,7 +267,7 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 				c.DbUrl = "host=pg port=5432 user=ark password=hunter2 dbname=arkd"
 			},
 			mustNotContain: "hunter2",
-			mustContain:    redactedMask,
+			mustContain:    maskedField("DbUrl"),
 		},
 		{
 			name: "event db url password is redacted",
@@ -293,7 +299,7 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 				c.DbUrl = "postgresql://ark@pg:5432/arkd?password=secret%ZZ"
 			},
 			mustNotContain: "secret",
-			mustContain:    redactedMask,
+			mustContain:    maskedField("DbUrl"),
 		},
 		{
 			// over-masking: nothing secret here, but a DSN is not parseable
@@ -301,7 +307,8 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 			mutate: func(c *Config) {
 				c.DbUrl = "host=pg port=5432 user=ark dbname=arkd"
 			},
-			mustContain: redactedMask,
+			mustNotContain: "host=pg",
+			mustContain:    maskedField("DbUrl"),
 		},
 		{
 			// not re-encoded, so param order survives

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -288,6 +288,22 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 			mustContain:    "sslpassword=xxxxx",
 		},
 		{
+			name: "unparseable query is masked whole",
+			mutate: func(c *Config) {
+				c.DbUrl = "postgresql://ark@pg:5432/arkd?password=secret%ZZ"
+			},
+			mustNotContain: "secret",
+			mustContain:    redactedMask,
+		},
+		{
+			// over-masking: nothing secret here, but a DSN is not parseable
+			name: "keyword dsn without a password is still masked whole",
+			mutate: func(c *Config) {
+				c.DbUrl = "host=pg port=5432 user=ark dbname=arkd"
+			},
+			mustContain: redactedMask,
+		},
+		{
 			// not re-encoded, so param order survives
 			name: "query parameters are otherwise left untouched",
 			mutate: func(c *Config) {

--- a/pkg/arkd-wallet/config/config.go
+++ b/pkg/arkd-wallet/config/config.go
@@ -97,18 +97,29 @@ type Config struct {
 	OtelPushInterval      int64
 	PyroscopeServerURL    string
 
-	WalletSvc  application.WalletService
-	ScannerSvc application.BlockchainScanner
+	WalletSvc  application.WalletService     `json:"-"`
+	ScannerSvc application.BlockchainScanner `json:"-"`
 }
+
+const redactedMask = "••••••"
 
 func (c *Config) String() string {
 	clone := *c
+	clone.SignerKey = maskSecret(clone.SignerKey)
+	clone.DeprecatedSignerKeys = maskSecret(clone.DeprecatedSignerKeys)
 
 	json, err := json.MarshalIndent(clone, "", "  ")
 	if err != nil {
 		return fmt.Sprintf("error while marshalling config JSON: %s", err)
 	}
 	return string(json)
+}
+
+func maskSecret(secret string) string {
+	if secret == "" {
+		return ""
+	}
+	return redactedMask
 }
 
 func (c *Config) initServices() error {

--- a/pkg/arkd-wallet/config/config_test.go
+++ b/pkg/arkd-wallet/config/config_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// validConfig returns a config shaped like one produced by LoadConfig, minus the
-// services that initServices attaches.
 func validConfig() Config {
 	return Config{
 		Port:         6060,
@@ -65,8 +63,7 @@ func TestConfigStringRedactsSecrets(t *testing.T) {
 	}
 }
 
-// The services are not configuration, and marshalling them would leak the moment
-// one of them gained an exported field.
+// services would leak once any gains an exported field
 func TestConfigStringOmitsServices(t *testing.T) {
 	c := validConfig()
 

--- a/pkg/arkd-wallet/config/config_test.go
+++ b/pkg/arkd-wallet/config/config_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validConfig returns a config shaped like one produced by LoadConfig, minus the
+// services that initServices attaches.
+func validConfig() Config {
+	return Config{
+		Port:         6060,
+		DbDir:        "/tmp/arkd-wallet/db",
+		LogLevel:     4,
+		NbxplorerURL: "http://localhost:32838",
+	}
+}
+
+func TestConfigStringRedactsSecrets(t *testing.T) {
+	const signerKey = "1111111111111111111111111111111111111111111111111111111111111111"
+	const deprecatedKey = "2222222222222222222222222222222222222222222222222222222222222222"
+
+	tests := []struct {
+		name           string
+		mutate         func(c *Config)
+		mustNotContain string
+		mustContain    string
+	}{
+		{
+			name:           "signer key is redacted",
+			mutate:         func(c *Config) { c.SignerKey = signerKey },
+			mustNotContain: signerKey,
+			mustContain:    redactedMask,
+		},
+		{
+			name:           "deprecated signer keys are redacted",
+			mutate:         func(c *Config) { c.DeprecatedSignerKeys = deprecatedKey + ":1767926037" },
+			mustNotContain: deprecatedKey,
+			mustContain:    redactedMask,
+		},
+		{
+			name:        "unset signer key stays empty rather than looking configured",
+			mutate:      func(c *Config) { c.SignerKey = "" },
+			mustContain: `"SignerKey": ""`,
+		},
+		{
+			name:        "non-sensitive field is preserved",
+			mutate:      func(c *Config) { c.NbxplorerURL = "http://nbxplorer:32838" },
+			mustContain: "http://nbxplorer:32838",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validConfig()
+			tt.mutate(&c)
+
+			out := c.String()
+			if tt.mustNotContain != "" {
+				require.NotContains(t, out, tt.mustNotContain)
+			}
+			require.Contains(t, out, tt.mustContain)
+		})
+	}
+}
+
+// The services are not configuration, and marshalling them would leak the moment
+// one of them gained an exported field.
+func TestConfigStringOmitsServices(t *testing.T) {
+	c := validConfig()
+
+	out := c.String()
+
+	require.NotContains(t, out, "WalletSvc")
+	require.NotContains(t, out, "ScannerSvc")
+}


### PR DESCRIPTION
Aims to fix #1020

#### tldr

- Redact sensitive values from the config logged by `arkd` and `arkd-wallet`. And this includes signer keys, database URLs, and Redis URLs.
- Also removed service structs from the wallet config output since they are not config values.

Also tested the regtest Docker setup and confirmed the services still start correctly and secrets no longer appear in the logs. Not a vibe coded PR so an AI review is appreciated just in case :)